### PR TITLE
Fix codegen failure when parameters are named like Kotlin keywords

### DIFF
--- a/codegen/src/main/kotlin/ProxyGenerator.kt
+++ b/codegen/src/main/kotlin/ProxyGenerator.kt
@@ -36,6 +36,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.UNIT
+import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.withIndent
 
 class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOverride) {
@@ -88,12 +89,15 @@ class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOve
                         if (outputs.size > 1) {
                             add("isGroupedReturn = true\n")
                         }
-                        add(
-                            "call(${
-                                params.joinToString(", ") {
-                                    (it.value.name ?: "arg${it.index}").decapitalCamelCase
-                                }
-                            })\n"
+
+                        val paramCode = params.map {
+                            val name = it.value.name ?: "arg${it.index}"
+                            name.decapitalCamelCase
+                        }.map { CodeBlock.of("%N", it) }
+
+                        addStatement(
+                            "call(%L)",
+                            paramCode.joinToCode()
                         )
                     }
                     add("}\n")

--- a/codegen/src/test/resources/BluezGattCharacteristic1Test/proxy.0.kt
+++ b/codegen/src/test/resources/BluezGattCharacteristic1Test/proxy.0.kt
@@ -73,7 +73,7 @@ public class GattCharacteristic1Proxy(
   }
 
   override suspend fun writeValue(`value`: List<UByte>, options: Map<String, Variant>): Unit = proxy.callMethodAsync(GattCharacteristic1.Companion.INTERFACE_NAME, MethodName("WriteValue")) {
-    call(value, options)
+    call(`value`, options)
   }
 
   override suspend fun acquireWrite(options: Map<String, Variant>): AcquireType = proxy.callMethodAsync(GattCharacteristic1.Companion.INTERFACE_NAME, MethodName("AcquireWrite")) {

--- a/codegen/src/test/resources/BluezGattDescriptor1Test/proxy.0.kt
+++ b/codegen/src/test/resources/BluezGattDescriptor1Test/proxy.0.kt
@@ -45,6 +45,6 @@ public class GattDescriptor1Proxy(
   }
 
   override suspend fun writeValue(`value`: List<UByte>, options: Map<String, Variant>): Unit = proxy.callMethodAsync(GattDescriptor1.Companion.INTERFACE_NAME, MethodName("WriteValue")) {
-    call(value, options)
+    call(`value`, options)
   }
 }


### PR DESCRIPTION
Fixes #4 by using KotlinPoet code interpolation instead of a manual one.