### PR TITLE
Fix #9: Wire generator tasks as dependencies of Jar tasks

### DIFF
--- a/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusPlugin.kt
+++ b/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusPlugin.kt
@@ -4,6 +4,7 @@ import com.monkopedia.sdbus.capitalized
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
 
 class SdbusPlugin : Plugin<Project> {
@@ -18,6 +19,9 @@ class SdbusPlugin : Plugin<Project> {
                 }
             }
             target.tasks.withType(AbstractKotlinCompileTool::class.java).configureEach { task ->
+                task.dependsOn(rootTask)
+            }
+            target.tasks.withType(Jar::class.java).configureEach { task ->
                 task.dependsOn(rootTask)
             }
             ext.sources.asFileTree.filter { it.isFile && it.extension == "xml" }.forEach { file ->

--- a/plugin/src/test/kotlin/com/monkopedia/sdbus/plugin/SdbusPluginTest.kt
+++ b/plugin/src/test/kotlin/com/monkopedia/sdbus/plugin/SdbusPluginTest.kt
@@ -61,6 +61,20 @@ class SdbusPluginTest {
     }
 
     @Test
+    fun wiresGeneratorAsDependencyOfSourcesJar() = withProject(
+        generateProxies = false,
+        generateAdapters = false,
+        applyMavenPublish = true
+    ) { dir ->
+        val result = runTask(dir, "sourcesJar", "--dry-run")
+        assertTrue(
+            result.output.contains("generateSdbusWrappers"),
+            "Expected sourcesJar to depend on generateSdbusWrappers; output was:\n" +
+                result.output
+        )
+    }
+
+    @Test
     fun appliesOutputPackageOverride() = withProject(
         generateProxies = false,
         generateAdapters = false,
@@ -84,6 +98,7 @@ class SdbusPluginTest {
         outputPackage: String? = null,
         compileTargetJvm: Boolean = false,
         includeCompileFixture: Boolean = false,
+        applyMavenPublish: Boolean = false,
         block: (File) -> Unit
     ) {
         val root = Files.createTempDirectory("kdbus-plugin-test").toFile()
@@ -106,6 +121,7 @@ class SdbusPluginTest {
                     plugins {
                       id("org.jetbrains.kotlin.multiplatform") version "2.2.10"
                       id("com.monkopedia.sdbus.plugin")
+                      ${if (applyMavenPublish) "id(\"maven-publish\")" else ""}
                     }
 
                     repositories {


### PR DESCRIPTION
## Summary

- Wires `Jar` tasks (including `sourcesJar` and target-specific `*SourcesJar`) to depend on the `generateSdbusWrappers` root task, fixing the Gradle 9 missing-dependency error when maven-publish produces source jars.
- Adds a test verifying `sourcesJar --dry-run` includes `generateSdbusWrappers` in its task graph.

Fixes #9

## Test plan

- [x] `plugin:test` passes (6 tests including the new `wiresGeneratorAsDependencyOfSourcesJar`)
- [ ] CI: full test suite on x64
- [ ] CI: ARM build + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)