### PR TITLE
Fix JVM empty-collection arg signature + ay→UByte deserialization; pin jvmTarget=17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,7 +252,12 @@ mavenPublishing {
     }
     publishToMavenCentral()
 
-    signAllPublications()
+    // SNAPSHOT builds (e.g. publishToMavenLocal for downstream testing) are not signed:
+    // Maven Central doesn't require signatures for snapshots, and it avoids needing a GPG
+    // key for local cross-project validation.
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
 }
 
 tasks.register(
@@ -316,7 +321,9 @@ allprojects {
     }
 }
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
+if (!version.toString().endsWith("SNAPSHOT")) {
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
 import java.util.*
 import kotlinx.validation.ExperimentalBCVApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
@@ -41,7 +42,15 @@ apiValidation {
 }
 
 kotlin {
-    jvm()
+    jvm {
+        // Pin the JVM bytecode target so the published artifact is deterministic regardless
+        // of the JDK used to build it. Consumers (e.g. blue-falcon-sdbus on jvmToolchain(17))
+        // can't inline higher-target bytecode; without this, a build on JDK 21 would emit
+        // JVM-21 bytecode and break every JVM-17 consumer.
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
     linuxX64 {
         binaries {
             sharedLib { }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.4.4-SNAPSHOT
+version=0.4.3
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.4.3
+version=0.4.4-SNAPSHOT
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -97,6 +97,89 @@ class CommonApiIntegrationTest {
         }
     }
 
+    // Regression for the BlueZ-on-JVM failure: a method taking an empty a{sv} (e.g. the
+    // GATT ReadValue `options` dict) must serialize with the declared signature "a{sv}".
+    // The JVM backend used to infer the signature from runtime values, and an empty map
+    // has no entries to infer from — it emitted the malformed "a{}", which made the bus
+    // daemon drop the connection ("Underlying transport returned -1"). Passes on native;
+    // reproduced the failure on JVM before the fix.
+    @Test
+    fun typedMethodCall_withEmptyDictArg_roundTrips() {
+        val ids = uniqueFixtureIds("emptyDict")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("CountOptions")) {
+                call { options: Map<String, Variant> -> options.size }
+            }
+        }
+        serverConnection.enterEventLoopAsync()
+        val proxy = createProxy(
+            proxyConnection,
+            ids.service,
+            ids.path,
+            dontRunEventLoopThread = true
+        )
+
+        try {
+            val result = proxy.callMethod<Int>(ids.iface, MethodName("CountOptions")) {
+                call(emptyMap<String, Variant>())
+            }
+            assertEquals(0, result)
+        } finally {
+            runBlocking {
+                proxyConnection.leaveEventLoop()
+                serverConnection.leaveEventLoop()
+            }
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
+    // Sibling of the empty-dict case: an empty array (`as`) has no element to infer from,
+    // so the JVM backend used to emit the malformed bare "a". Verifies the declared
+    // signature is used instead.
+    @Test
+    fun typedMethodCall_withEmptyArrayArg_roundTrips() {
+        val ids = uniqueFixtureIds("emptyArray")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("CountItems")) {
+                call { items: List<String> -> items.size }
+            }
+        }
+        serverConnection.enterEventLoopAsync()
+        val proxy = createProxy(
+            proxyConnection,
+            ids.service,
+            ids.path,
+            dontRunEventLoopThread = true
+        )
+
+        try {
+            val result = proxy.callMethod<Int>(ids.iface, MethodName("CountItems")) {
+                call(emptyList<String>())
+            }
+            assertEquals(0, result)
+        } finally {
+            runBlocking {
+                proxyConnection.leaveEventLoop()
+                serverConnection.leaveEventLoop()
+            }
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
     @Test
     fun createMethodCall_carriesInterfaceAndMethodMetadata() {
         val ids = uniqueFixtureIds("metadata")

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -286,6 +286,34 @@ private fun coerceForDescriptor(value: Any?, descriptor: SerialDescriptor): Any?
             else -> value
         }
 
+        // D-Bus y/q/u/t map to Kotlin's unsigned inline classes. dbus-java hands back the
+        // signed primitive (e.g. a `ay` byte array arrives as java.lang.Byte values), so box
+        // it into the expected unsigned type — otherwise a List<UByte> ends up holding Byte
+        // and unboxing throws ClassCastException (e.g. reading a GATT characteristic value).
+        "kotlin.UByte" -> when (value) {
+            is UByte -> value
+            is Number -> value.toByte().toUByte()
+            else -> value
+        }
+
+        "kotlin.UShort" -> when (value) {
+            is UShort -> value
+            is Number -> value.toShort().toUShort()
+            else -> value
+        }
+
+        "kotlin.UInt" -> when (value) {
+            is UInt -> value
+            is Number -> value.toInt().toUInt()
+            else -> value
+        }
+
+        "kotlin.ULong" -> when (value) {
+            is ULong -> value
+            is Number -> value.toLong().toULong()
+            else -> value
+        }
+
         else -> value
     }
     if (wrapped !== value) return wrapped

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -34,6 +34,13 @@ actual sealed class Message {
 
     internal var metadata: Metadata = Metadata()
     internal val payload: MutableList<Any?> = mutableListOf()
+
+    // Declared D-Bus signature of the outgoing body, accumulated from each arg's
+    // serializer descriptor as it is serialized. This is authoritative for the wire
+    // signature: value-based inference cannot recover the element types of an empty
+    // collection (an empty Map<String, Variant> has no entry to infer "a{sv}" from, so
+    // inference yields the malformed "a{}", which makes the bus drop the connection).
+    internal val declaredBodySignature: StringBuilder = StringBuilder()
     private var readIndex: Int = 0
     private var openVariantFrame: Pair<Int, String>? = null
     private val enteredVariantValues: ArrayDeque<Any?> = ArrayDeque()
@@ -464,6 +471,11 @@ internal actual fun <T> Message.serialize(
     arg: T
 ) {
     payload.add(arg)
+    // Record the declared signature from the descriptor so the send path uses the
+    // real type instead of inferring it from the (possibly empty) runtime value.
+    runCatching { serializer.descriptor.asSignature.value }
+        .getOrNull()
+        ?.let { declaredBodySignature.append(it) }
 }
 
 @PublishedApi

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -673,6 +673,43 @@ private fun toJavaVariantValue(
     signature
 )
 
+// Counts the number of top-level D-Bus types in a signature (e.g. "sa{sv}" -> 2),
+// used to check that a declared body signature lines up with the payload it describes.
+private fun countTopLevelTypes(signature: String?): Int {
+    if (signature.isNullOrEmpty()) return 0
+    fun parseOne(index: Int): Int {
+        if (index >= signature.length) return index
+        return when (signature[index]) {
+            'a' -> parseOne(index + 1)
+            '(' -> {
+                var i = index + 1
+                while (i < signature.length && signature[i] != ')') {
+                    i = parseOne(i)
+                }
+                (i + 1).coerceAtMost(signature.length)
+            }
+            '{' -> {
+                var i = index + 1
+                while (i < signature.length && signature[i] != '}') {
+                    i = parseOne(i)
+                }
+                (i + 1).coerceAtMost(signature.length)
+            }
+            else -> index + 1
+        }
+    }
+
+    var index = 0
+    var count = 0
+    while (index < signature.length) {
+        val next = parseOne(index)
+        if (next <= index) break
+        count++
+        index = next
+    }
+    return count
+}
+
 private fun inferSignalSignature(value: Any?): String? = when (value) {
     null -> null
     is Message.JvmVariantPayload -> "v"
@@ -876,6 +913,7 @@ private class PureJavaDbusProxy(
                 methodName = methodName,
                 path = path,
                 payload = message.payload.toList(),
+                declaredSignature = message.declaredBodySignature.toString(),
                 timeout = null
             )
         }
@@ -993,6 +1031,7 @@ private class PureJavaDbusProxy(
                 methodName = methodName,
                 path = path,
                 payload = message.payload.toList(),
+                declaredSignature = message.declaredBodySignature.toString(),
                 timeout = timeout.takeUnless { it == 0uL }
             )
         }
@@ -1066,25 +1105,42 @@ private class PureJavaDbusProxy(
         return localUniqueName.takeIf { it == localBusOwner }
     }
 
+    // Wire signature for an outgoing body. Prefer the declared signature accumulated from
+    // serializer descriptors (correct even for empty collections); only fall back to
+    // value-based inference when no usable declared signature is available — e.g. a body
+    // assembled through the raw append() API rather than serialize(). The top-level type
+    // count guards against a declared signature that doesn't line up with the payload.
+    private fun bodySignature(
+        payload: List<Any?>,
+        declaredSignature: String?,
+        errorFor: (Any?) -> String
+    ): String {
+        if (!declaredSignature.isNullOrEmpty() &&
+            countTopLevelTypes(declaredSignature) == payload.size
+        ) {
+            return declaredSignature
+        }
+        return payload.joinToString(separator = "") { value ->
+            inferSignalSignature(value) ?: throw createError(-1, errorFor(value))
+        }
+    }
+
     private fun callRemoteMethod(
         connection: AbstractConnection,
         interfaceName: String,
         methodName: String,
         path: String,
         payload: List<Any?>,
+        declaredSignature: String?,
         timeout: ULong?
     ): MethodReply {
         val signature = if (payload.isEmpty()) {
             null
         } else {
-            payload.joinToString(separator = "") { value ->
-                inferSignalSignature(value)
-                    ?: throw createError(
-                        -1,
-                        "callMethod failed: unsupported argument type ${
-                            value?.let { typed -> typed::class.simpleName } ?: "null"
-                        }"
-                    )
+            bodySignature(payload, declaredSignature) { value ->
+                "callMethod failed: unsupported argument type ${
+                    value?.let { typed -> typed::class.simpleName } ?: "null"
+                }"
             }
         }
         val args = payload.map(::toJavaSignalValue).toTypedArray()
@@ -1283,41 +1339,6 @@ private class PureJavaDbusObject(
         mutableMapOf<String, MutableMap<String, PropertyVTableItem>>()
     private var propertiesDispatchRegistered = false
     private val dispatchDestination = senderName ?: javaConnection?.uniqueNameOrNull().orEmpty()
-
-    private fun countTopLevelTypes(signature: String?): Int {
-        if (signature.isNullOrEmpty()) return 0
-        fun parseOne(index: Int): Int {
-            if (index >= signature.length) return index
-            return when (signature[index]) {
-                'a' -> parseOne(index + 1)
-                '(' -> {
-                    var i = index + 1
-                    while (i < signature.length && signature[i] != ')') {
-                        i = parseOne(i)
-                    }
-                    (i + 1).coerceAtMost(signature.length)
-                }
-                '{' -> {
-                    var i = index + 1
-                    while (i < signature.length && signature[i] != '}') {
-                        i = parseOne(i)
-                    }
-                    (i + 1).coerceAtMost(signature.length)
-                }
-                else -> index + 1
-            }
-        }
-
-        var index = 0
-        var count = 0
-        while (index < signature.length) {
-            val next = parseOne(index)
-            if (next <= index) break
-            count++
-            index = next
-        }
-        return count
-    }
 
     private fun parseInterfaceName(value: Any?): String = when (value) {
         is InterfaceName -> value.value

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
@@ -167,4 +167,18 @@ class JvmMessageSupportTest {
         assertFailsWith<Error> { message.getCredsSupplementaryGids() }
         assertFailsWith<Error> { message.getSELinuxContext() }
     }
+
+    // Regression: D-Bus `ay` (e.g. a GATT characteristic value) arrives from dbus-java as
+    // signed java.lang.Byte values, but the declared type is List<UByte>. Deserialization
+    // must box each element into UByte; otherwise reading it throws
+    // "class java.lang.Byte cannot be cast to class kotlin.UByte".
+    @Test
+    fun deserialize_ayByteArray_coercesSignedBytesToUByteList() {
+        val message = PlainMessage.createPlainMessage()
+        message.payload.add(listOf<Byte>(0xBF.toByte(), 0x01, 0x02))
+
+        val result = message.deserialize<List<UByte>>()
+
+        assertEquals(listOf<UByte>(0xBFu, 0x01u, 0x02u), result)
+    }
 }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -8,6 +8,42 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 class JvmRealBusIntegrationTest {
+
+    // Regression for the BlueZ-on-JVM failure, exercised over the real wire (same-process
+    // calls short-circuit through local dispatch and never serialize, so they can't catch
+    // this). An empty collection argument used to be serialized with an inferred signature,
+    // but an empty value has no element to infer from — so an empty array became the
+    // malformed "a" (and an empty dict "a{}"), which makes the daemon drop the connection
+    // with "Underlying transport returned -1". Here we call the bus daemon's BecomeMonitor,
+    // whose first argument is an `as` filter list, with an empty list: with the fix it
+    // serializes as "as" and succeeds; without it the connection is torn down.
+    @Test
+    fun methodCall_withEmptyArrayArg_overWire_doesNotDropConnection() = runBlocking {
+        val connection = createBusConnection()
+        if (connection.getUniqueName().value == ":jvm-stub") {
+            connection.release()
+            return@runBlocking
+        }
+        val proxy = createProxy(
+            connection,
+            ServiceName("org.freedesktop.DBus"),
+            ObjectPath("/org/freedesktop/DBus")
+        )
+        try {
+            // Empty `as` filters + flags 0. The call must not throw a transport error;
+            // a normal reply (or a benign D-Bus error) means the connection survived.
+            proxy.callMethod<Unit>(
+                InterfaceName("org.freedesktop.DBus.Monitoring"),
+                MethodName("BecomeMonitor")
+            ) {
+                call(emptyList<String>(), 0u)
+            }
+        } finally {
+            proxy.release()
+            connection.release()
+        }
+    }
+
     @Test
     fun createSystemBusConnection_usesDistinctConnectionsWhenRealBusIsAvailable() {
         val first = createSystemBusConnection()


### PR DESCRIPTION
## Summary

Three JVM-backend fixes, found and validated while bringing up blue-falcon-sdbus' JVM target against a real BlueZ peripheral (BF-Test on adolin). Native is unaffected by all three.

1. **Empty-collection argument signature.** `PureJavaDbusBackend` derived each argument's D-Bus signature from its runtime *value*. An empty collection has nothing to infer from, so an empty `Map<String, Variant>` serialized as the malformed `a{}` and an empty `List` as the bare `a`. The bus daemon rejects that and drops the connection (`Underlying transport returned -1`). Now the declared signature is captured from the serializer descriptor at serialize time (`Message.declaredBodySignature`) and used for the wire body, falling back to value-inference only when no declared signature is available. This is what broke `GATT ReadValue(a{sv} options)` (empty options dict) on JVM.

2. **`ay` → `UByte` deserialization.** `coerceForDescriptor` boxed `ObjectPath`/`UnixFd`/etc. and recursed into `LIST`/`MAP`, but left the unsigned inline-class primitives as the raw signed value dbus-java returns. A `ay` (e.g. a GATT characteristic value) deserialized into a `List` holding `java.lang.Byte` where `List<UByte>` was expected, throwing `class java.lang.Byte cannot be cast to class kotlin.UByte`. Now signed primitives are boxed into the declared unsigned type (`UByte`/`UShort`/`UInt`/`ULong`).

3. **Pin `jvmTarget = 17`.** The `jvm()` target set no `jvmTarget`, so published bytecode followed the build JDK — a JDK-21 build emits JVM-21 bytecode that JVM-17 consumers can't inline. Pinned to 17 for deterministic releases. (Also gates `signAllPublications()` off for `-SNAPSHOT` so local snapshot publishing works without a GPG key.)

## Test plan

- [x] New `commonTest` round-trips for empty `a{sv}` and empty `as` method args
- [x] New `jvmTest` real-wire regression (`BecomeMonitor` with empty `as`) — fails without fix #1
- [x] New `jvmTest` `ay`→`UByte` deserialization regression — fails without fix #2
- [x] Full `jvmTest` + `linuxX64Test` green; `apiCheck` clean (all changes internal, no public API delta)
- [x] Verified a JDK-21 build now emits JVM-17 bytecode
- [x] **Hardware-validated**: all 3 blue-falcon-sdbus GATT integration tests pass on real BF-Test (incl. the previously-failing `readFixedValue`), against a 0.4.4-SNAPSHOT built from this branch

Version bump to 0.4.4 + release cut intentionally deferred to a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)