### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There is a gradle plugin which can generate sources as part of the the build whe
 ```
 plugins {
     ...
-    id("com.monkopedia.sdbus.plugin") version "0.4.3"
+    id("com.monkopedia.sdbus.plugin") version "0.4.4"
 }
 
 sdbus {
@@ -50,7 +50,7 @@ a common kotlin module, its implementations are currently only for linuxX64 and 
 ```
 val nativeMain by getting {
     dependencies {
-       implementation("com.monkopedia:sdbus-kotlin:0.4.3")
+       implementation("com.monkopedia:sdbus-kotlin:0.4.4")
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.4.3
+version=0.4.4
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/samples/bluez-scan/build.gradle.kts
+++ b/samples/bluez-scan/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization)
                 implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
-                implementation("com.monkopedia:sdbus-kotlin:0.4.3")
+                implementation("com.monkopedia:sdbus-kotlin:0.4.4")
             }
         }
         val nativeTest by getting {


### PR DESCRIPTION
Release-prep version bump to **0.4.4** for the JVM-backend fixes merged in #11
(empty-collection arg signature, `ay`→`UByte` deserialization, `jvmTarget=17`
pin), hardware-validated against real BlueZ via blue-falcon-sdbus.

- `gradle.properties` 0.4.3 → 0.4.4
- `README.md` install snippets (plugin id + library coordinate)
- `samples/bluez-scan` sdbus-kotlin dependency

No code changes. The GitHub release / Maven Central publish is a separate step after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)