### PR TITLE
Auto-release Maven Central publications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,7 +259,7 @@ mavenPublishing {
             url.set("https://github.com/Monkopedia/sdbus-kotlin/")
         }
     }
-    publishToMavenCentral()
+    publishToMavenCentral(automaticRelease = true)
 
     // SNAPSHOT builds (e.g. publishToMavenLocal for downstream testing) are not signed:
     // Maven Central doesn't require signatures for snapshots, and it avoids needing a GPG

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -112,7 +112,7 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral()
+    publishToMavenCentral(automaticRelease = true)
 
     signAllPublications()
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -79,7 +79,7 @@ mavenPublishing {
             url.set("https://github.com/Monkopedia/sdbus-kotlin/")
         }
     }
-    publishToMavenCentral()
+    publishToMavenCentral(automaticRelease = true)
 
     signAllPublications()
 }


### PR DESCRIPTION
Enables automatic release of Maven Central deployments so a release no longer requires a manual "Publish" click in the Sonatype Central Portal (0.4.3 and 0.4.4 both needed that manual step).

- `publishToMavenCentral()` → `publishToMavenCentral(automaticRelease = true)` in the root, `codegen`, and `plugin` modules.
- The deployment is uploaded with `AUTOMATIC` publishing type, so the existing `gradle publish` step in `publish.yaml` auto-releases after validation — no workflow change needed.

vanniktech maven-publish is already on the latest stable (0.36.0), so no plugin bump was required.

No code changes; build configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)