### PR TITLE
Upgrade to Kotlin 2.4.0 (0.4.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There is a gradle plugin which can generate sources as part of the the build whe
 ```
 plugins {
     ...
-    id("com.monkopedia.sdbus.plugin") version "0.4.4"
+    id("com.monkopedia.sdbus.plugin") version "0.4.5"
 }
 
 sdbus {
@@ -50,7 +50,7 @@ a common kotlin module, its implementations are currently only for linuxX64 and 
 ```
 val nativeMain by getting {
     dependencies {
-       implementation("com.monkopedia:sdbus-kotlin:0.4.4")
+       implementation("com.monkopedia:sdbus-kotlin:0.4.5")
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.4.4
+version=0.4.5
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 kotlin-coroutines = "1.10.2"
 kotlin-serialization = "1.11.0"
 kotlin-datetime = "0.7.1"

--- a/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusPlugin.kt
+++ b/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusPlugin.kt
@@ -3,8 +3,8 @@ package com.monkopedia.sdbus.plugin
 import com.monkopedia.sdbus.capitalized
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.gradle.jvm.tasks.Jar
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
 
 class SdbusPlugin : Plugin<Project> {

--- a/samples/bluez-scan/build.gradle.kts
+++ b/samples/bluez-scan/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization)
                 implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
-                implementation("com.monkopedia:sdbus-kotlin:0.4.4")
+                implementation("com.monkopedia:sdbus-kotlin:0.4.5")
             }
         }
         val nativeTest by getting {


### PR DESCRIPTION
Fleet-wide Kotlin **2.4.0** upgrade. sdbus-kotlin is the root of the sdbus→blue-falcon-sdbus chain (blue-falcon applies `com.monkopedia.sdbus.plugin`, so it needs a 2.4.0-built plugin to compile on 2.4.0).

## Changes
- **Kotlin 2.3.20 → 2.4.0** (`gradle/libs.versions.toml`). The codegen plugin + `:codegen` compiled clean against 2.4.0's compiler/plugin API — **no API adaptation needed**.
- **version 0.4.4 → 0.4.5** (Kotlin bump only = patch) + README/sample coordinate bumps.
- Fix a pre-existing ktlint import-order violation in `SdbusPlugin.kt` (introduced in #10; surfaced now because CI runs tests but not `ktlintCheck`).

## Verification
- [x] Compiles: `compileKotlinJvm` + `compileKotlinLinuxX64` + `compileKotlinLinuxArm64`
- [x] Tests green: `jvmTest`, `linuxX64Test`, `:plugin:test`, `:codegen:test`
- [x] `apiCheck` clean — no public API delta
- [x] No codegen behavior change from 2.4.0 (clean bump)

## Note (out of scope)
`ktlintCheck` also surfaces other **pre-existing** violations unrelated to this bump (stress_test whitespace; the `*Generated.kt` fixture-naming rule that's why ktlint is pinned at 14.0.1). Left untouched here — worth a separate cleanup, and CI should probably run `ktlintCheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)