### PR TITLE
Post-2.4.0 warning + hygiene cleanup (#17, #19, #20, #21)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
         // JVM-21 bytecode and break every JVM-17 consumer.
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
+            freeCompilerArgs.add("-Xexpect-actual-classes")
         }
     }
     linuxX64 {

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -14,7 +14,6 @@ group = "com.monkopedia"
 
 repositories {
     mavenCentral()
-    maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
 }
 
 dependencies {
@@ -22,7 +21,7 @@ dependencies {
     api(libs.clikt)
     api(libs.kotlinpoet)
     testImplementation(project(":"))
-    testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.3.0")
+    testImplementation(libs.kotlin.compiler.embeddable)
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
@@ -55,7 +54,7 @@ tasks.test {
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
-        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+        freeCompilerArgs.add("-jvm-default=enable")
     }
 }
 java {
@@ -101,15 +100,6 @@ mavenPublishing {
                 "scm:git:ssh://github.com/Monkopedia/sdbus-kotlin.git"
             )
             url.set("https://github.com/Monkopedia/sdbus-kotlin/")
-        }
-    }
-    repositories {
-        maven(url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-            name = "OSSRH"
-            credentials {
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
-            }
         }
     }
     publishToMavenCentral(automaticRelease = true)

--- a/codegen/src/main/kotlin/Xml2Kotlin.kt
+++ b/codegen/src/main/kotlin/Xml2Kotlin.kt
@@ -80,6 +80,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import java.io.File
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
+import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
 import nl.adaptivity.xmlutil.QName
 import nl.adaptivity.xmlutil.XmlReader
 import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
@@ -107,6 +108,7 @@ class Xml2Kotlin : CliktCommand() {
         help = "Override Kotlin package for generated files"
     )
 
+    @OptIn(ExperimentalXmlUtilApi::class)
     override fun run() {
         val packageOverride = outputPackage?.trim()?.takeUnless { it.isEmpty() }
         val xml = XML {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlin-atomicfu" }
 xmlutil = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "pdvrieze-xmlutil" }
 kotlinpoet = { module = "com.squareup:kotlinpoet-jvm", version.ref = "kotlinpoet" }
+kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt"}
 dbus-java-core = { module = "com.github.hypfvieh:dbus-java-core", version.ref = "dbus-java" }
 dbus-java-transport-junixsocket = { module = "com.github.hypfvieh:dbus-java-transport-junixsocket", version.ref = "dbus-java" }


### PR DESCRIPTION
Batches the four mechanical, user-approved code-health cleanups surfaced by the Kotlin 2.4.0 migration. No library runtime/behavior change; build-config + codegen only.

Closes #17 — add `-Xexpect-actual-classes` to the `jvm` target (native targets already had it) → ~20 expect/actual Beta warnings gone on the JVM compile.
Closes #19 — remove the dead OSSRH publishing block (`MAVEN_USERNAME`/`MAVEN_PASSWORD` the workflow never sets; real publish is vanniktech `publishToMavenCentral`) + the unused `oss.sonatype` snapshot dependency repo from `codegen`; migrate deprecated `-Xjvm-default=all-compatibility` → stabilized `-jvm-default=enable`.
Closes #20 — `@OptIn(ExperimentalXmlUtilApi::class)` on `Xml2Kotlin.run()` (the experimental xmlutil policy override is load-bearing) → 7 warnings gone.
Closes #21 — catalog-reference `kotlin-compiler-embeddable` (was hardcoded `2.3.0` vs the 2.4.0 toolchain) via a new `libs` entry pinned to the `kotlin` version ref.

## Verification
- [x] `codegen:compileKotlin` warning-free; JVM compile Beta-warning count: 0
- [x] `codegen:test` green (compilation test now uses embeddable 2.4.0)
- [x] `ktlintCheck` + `apiCheck` green (no API/ABI delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)