### PR TITLE
Update README badges + add CLAUDE.md maintenance note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+Guidance for agents working on sdbus-kotlin.
+
+## What this is
+
+A Kotlin Multiplatform D-Bus client (a port of sdbus-c++), targeting **jvm + linuxX64 + linuxArm64**. The native targets wrap `sd-bus` via cinterop; the JVM target is backed by dbus-java. It also ships a code generator (`:codegen`, XML → Kotlin BlueZ proxies/adaptors) and a Gradle plugin (`:plugin`, id `com.monkopedia.sdbus.plugin`).
+
+Modules: root (the library), `:codegen`, `:plugin`, `:cross_test`, `:stress_test`, `samples/bluez-scan`.
+
+## Building & verifying
+
+- **JDK 17+ required** (Gradle 9). The system default is often Java 8 and will fail — use `JAVA_HOME=/usr/lib/jvm/java-17-openjdk` (or java-21). The JVM bytecode target is pinned to 17 so published artifacts are deterministic regardless of build JDK.
+- Compile: `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64`
+- Static gates (run in CI's `static-checks` job): `./gradlew ktlintCheck apiCheck`. `apiCheck` is binary-compatibility-validator; if you intentionally change the public API, regenerate with `./gradlew apiDump` and commit the `api/*.api` diff.
+- Unit/integration tests (`jvmTest`, `linuxX64Test`) need a **D-Bus session bus** — run under `dbus-run-session -- ./gradlew …`.
+- The `samples/bluez-scan` and blue-falcon-sdbus integration suites need a **real BlueZ adapter + BLE peripheral** (hardware); they can't run in CI.
+
+## Releasing
+
+1. Bump the version in `gradle.properties`, the README install snippets, and `samples/bluez-scan/build.gradle.kts`.
+2. Create a GitHub release `vX.Y.Z` → the `publish.yaml` workflow publishes to Maven Central via vanniktech with `automaticRelease = true` (no manual Sonatype Portal step). All 5 coordinates (root, `-jvm`, `-linuxx64`, `-linuxarm64`, `-codegen`) deploy as one atomic deployment.
+3. SNAPSHOT versions skip signing (for local `publishToMavenLocal` cross-repo testing); real releases are signed.
+
+## Maintenance — keep these current when things change
+
+- **README badges:** when the Kotlin version or build setup changes, update the badge block at the top of `README.md`.
+  - The **Maven Central version** badge updates automatically (shields.io reads Central).
+  - The **Kotlin version** badge is hardcoded — bump it manually when the Kotlin version changes.
+  - The **Build** badge tracks `.github/workflows/arm-build-test.yaml`; keep the workflow path correct if CI is renamed.
+  - Maven Central has no public *download* count, so there is no downloads badge (only the namespace owner can see download stats in the Central Portal).
+- Generated BlueZ proxy fixtures and the BCV `api/*.api` dumps are checked in — regenerate (`apiDump`) and commit them when the public surface changes.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # sdbus-kotlin
 
+[![Build](https://github.com/Monkopedia/sdbus-kotlin/actions/workflows/arm-build-test.yaml/badge.svg)](https://github.com/Monkopedia/sdbus-kotlin/actions/workflows/arm-build-test.yaml)
 [![GitHub license](https://img.shields.io/badge/license-LGPL%203-blue.svg?style=flat)](https://www.gnu.org/licenses/lgpl-3.0.txt)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.4.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Maven Central](https://img.shields.io/maven-central/v/com.monkopedia/sdbus-kotlin)](https://search.maven.org/artifact/com.monkopedia/sdbus-kotlin)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://monkopedia.github.io/sdbus-kotlin/)
 


### PR DESCRIPTION
Docs only.

- **README badges:** bump the hardcoded **Kotlin** badge `2.3.0 → 2.4.0` (was stale after the 2.4.0 migration) and add a **CI build-status** badge for the `ARM Build and Test` workflow. (The Maven Central *version* badge already exists and is automatic; a *downloads* badge isn't possible — Maven Central exposes no public download count.)
- **New `CLAUDE.md`:** repo overview, build/verify commands (JDK 17+, the ktlintCheck/apiCheck gates, the dbus-run-session/hardware test requirements), the release flow (version-bump locations + auto-release), and a **Maintenance** section noting the Kotlin + build badges are manual and should be kept current when things change — per the owner's request.

No code or build-logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)