### PR TITLE
Fix #28: JVM PropertiesChanged emits current value in changed_properties

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -1068,12 +1068,17 @@ class CommonApiIntegrationTest {
         }
 
         try {
+            state = true
             obj.emitPropertiesChangedSignal(ids.iface, listOf(stateProperty))
 
             val (changedProperties, invalidatedProperties) = withTimeout(2_000) { seen.await() }
-            val propertySeen = changedProperties.containsKey(stateProperty) ||
-                invalidatedProperties.contains(stateProperty)
-            assertTrue(propertySeen)
+            // Matching native, the emitted signal carries the current value in
+            // changed_properties (read from the registered getter), not invalidated_properties.
+            // This is what makes a consumer's PropertyGetter.changes() fire, not just
+            // changesOrNull().
+            assertTrue(changedProperties.containsKey(stateProperty))
+            assertFalse(invalidatedProperties.contains(stateProperty))
+            assertTrue(changedProperties.getValue(stateProperty).get<Boolean>())
         } finally {
             signalRegistration.release()
             registration.release()

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -1483,13 +1483,47 @@ private class PureJavaDbusObject(
         }.toMap()
     }
 
+    private fun readPropertyValue(property: PropertyVTableItem): Variant {
+        val getter = property.getter ?: error("no getter")
+        val reply = PropertyGetReply()
+        val value = JvmCurrentMessageContext.withMessage(reply) {
+            getter(reply)
+            reply.payload.firstOrNull()
+        }
+        return propertyToVariant(value)
+    }
+
+    // Mirrors native's sd_bus_emit_properties_changed_strv: each named property whose vtable
+    // getter can be read goes into changed_properties with its current value; names without a
+    // readable getter (write-only / value unavailable) fall back to invalidated_properties.
+    private fun resolveChangedProperties(
+        interfaceName: String,
+        propNames: List<PropertyName>
+    ): Pair<Map<PropertyName, Variant>, List<PropertyName>> {
+        val properties = propertiesByInterface[interfaceName].orEmpty()
+        val changed = mutableMapOf<PropertyName, Variant>()
+        val invalidated = mutableListOf<PropertyName>()
+        propNames.forEach { propName ->
+            val property = properties[propName.value]
+            val value = property
+                ?.takeIf { it.getter != null }
+                ?.let { runCatching { readPropertyValue(it) }.getOrNull() }
+            if (value != null) {
+                changed[propName] = value
+            } else {
+                invalidated += propName
+            }
+        }
+        return changed to invalidated
+    }
+
     override fun emitPropertiesChangedSignal(
         interfaceName: InterfaceName,
         propNames: List<PropertyName>
     ) {
         val sender = senderName ?: javaConnection?.uniqueNameOrNull()
-        val changedProperties = emptyMap<PropertyName, Variant>()
-        val invalidatedProperties = propNames
+        val (changedProperties, invalidatedProperties) =
+            resolveChangedProperties(interfaceName.value, propNames)
         val payload = listOf(interfaceName, changedProperties, invalidatedProperties)
         val realConnection = javaConnection
         if (realConnection == null) {
@@ -1502,6 +1536,11 @@ private class PureJavaDbusObject(
             )
             return
         }
+        val javaChangedProperties: Map<String, org.freedesktop.dbus.types.Variant<Any?>> =
+            changedProperties.entries.associate { (name, variant) ->
+                val javaPayload = extractVariantPayload(variant)
+                name.value to toJavaVariantValue(javaPayload.signature, javaPayload.value)
+            }
         val rawSignal = runCatching {
             realConnection.messageFactory.createSignal(
                 sender ?: realConnection.uniqueNameOrNull(),
@@ -1510,7 +1549,7 @@ private class PureJavaDbusObject(
                 propertiesChangedMemberName,
                 propertiesChangedSignature,
                 interfaceName.value,
-                emptyMap<String, org.freedesktop.dbus.types.Variant<Any?>>(),
+                javaChangedProperties,
                 invalidatedProperties.map { it.value }
             )
         }.getOrElse {


### PR DESCRIPTION
## What

Makes the JVM `PureJavaDbusBackend`'s `emitPropertiesChangedSignal(interfaceName, propNames)` match native behavior (Option A, per the owner's decision on #28).

Previously the JVM backend sent an **empty** `changed_properties` dict and placed every named property in `invalidated_properties`. Native's `sd_bus_emit_properties_changed_strv` instead reads each property's getter and carries the current value in `changed_properties`. The divergence meant a consumer's `PropertyGetter.changes()` never fired on the JVM backend — only `changesOrNull()` did.

## How

- Added `resolveChangedProperties(...)` which, for each named property, reads its registered vtable getter and puts the current value into `changed_properties`. Names with no readable getter (write-only / value unavailable) fall back to `invalidated_properties`, mirroring native.
- Both the local (no-connection) signal-bus path and the real dbus-java connection path now emit the populated `changed_properties` map. The real-connection path converts each `Variant` to a dbus-java `Variant` via the existing `extractVariantPayload` / `toJavaVariantValue` helpers.

This is a behavior-only change — the method signature is unchanged, so there is **no apiDump impact** (`apiCheck` passes with no `apiDump` update).

## Tests

Strengthened the cross-backend `propertiesChangedSignal_roundTripsForDeclaredProperty` test to assert the emitted signal carries the value in `changed_properties` (not `invalidated_properties`), which is what exercises `PropertyGetter.changes()` on both backends.

## Verification

- `./gradlew ktlintCheck apiCheck` — pass
- `:jvmTest` (full root suite, incl. the strengthened test) under `dbus-run-session` — pass

Fixes #28