### PR TITLE
Test infra: adopt python-dbusmock as an independent-peer harness

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -50,7 +50,9 @@ jobs:
       - name: Install Test Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus
+          # python3-dbusmock powers the independent-peer harness (DbusmockSmokeTest); if it is
+          # ever unavailable the smoke test skips cleanly rather than failing the build.
+          sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus python3-dbusmock
 
       - name: Run Full Test Suite on x64
         run: |

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
@@ -1,0 +1,75 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+/**
+ * Cross-platform (JVM + native) test harness that drives our sdbus-kotlin proxies against
+ * [python-dbusmock](https://github.com/martinpitt/python-dbusmock) — an *independent*
+ * Python/GDBus implementation of the D-Bus service side. Running our client against it
+ * validates our marshalling/wire protocol against a foreign stack, catching symmetric
+ * serializer bugs that our own-server-vs-our-proxy round-trips structurally cannot.
+ *
+ * ## How dbusmock is invoked
+ *
+ * dbusmock runs as `python3 -m dbusmock <NAME> <PATH> <INTERFACE>`, claiming a bus name and
+ * exposing a *generic* mock object. The object's behaviour is scripted at runtime over the
+ * `org.freedesktop.DBus.Mock` control interface (`AddMethod`, `AddProperty`, …). The harness
+ * launches it on the *current* bus (the private session bus created by `dbus-run-session`),
+ * so [com.monkopedia.sdbus.createBusConnection] connects our client to the very same bus.
+ *
+ * ## Installing python-dbusmock
+ *
+ * - Debian/Ubuntu CI: `apt-get install -y python3-dbusmock`
+ * - Arch: `pacman -S python-dbusmock` (or via pip into a venv)
+ * - pip: `python3 -m venv --system-site-packages venv && venv/bin/pip install python-dbusmock`
+ *   (dbusmock needs `dbus-python` + `PyGObject`, which is why a `--system-site-packages` venv
+ *   or distro package is the smoothest path).
+ *
+ * If a custom interpreter is needed (e.g. a venv), point the `DBUSMOCK_PYTHON` environment
+ * variable at it; otherwise `python3` on `PATH` is used.
+ *
+ * ## Graceful skip
+ *
+ * If python3 / python3-dbusmock is not present, or no D-Bus session bus is reachable,
+ * [launchDbusmock] returns `null` and the smoke test SKIPs cleanly (asserts nothing) rather
+ * than failing — so CI without dbusmock still passes.
+ */
+internal expect fun dbusmockGetenv(name: String): String?
+
+/**
+ * A running python-dbusmock process. [stop] terminates it and reaps the child.
+ */
+internal expect class DbusmockHandle {
+    fun stop()
+}
+
+/**
+ * Launches `python3 -m dbusmock` on the current (session) bus, claiming [busName] and exposing
+ * a generic mock object at [objectPath] with main interface [interfaceName].
+ *
+ * @return a [DbusmockHandle] if the process started, or `null` if dbusmock / python is not
+ *   available (the caller should then SKIP).
+ */
+internal expect fun launchDbusmock(
+    busName: String,
+    objectPath: String,
+    interfaceName: String
+): DbusmockHandle?

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSmokeTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSmokeTest.kt
@@ -1,0 +1,162 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.getProperty
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Smoke test for the python-dbusmock independent-peer harness ([DbusmockHarness]).
+ *
+ * This proves the end-to-end loop on whichever backend the test compiles for (JVM dbus-java
+ * via `jvmTest`, native sd-bus via `linuxX64Test`): our client scripts a generic dbusmock
+ * object, then calls a method and reads a property on it and asserts the results round-trip
+ * through the foreign (Python/GDBus) serializer.
+ *
+ * Deeper coverage (signals, property writes, richer payloads, real templates such as BlueZ /
+ * Secret Service) lands in the follow-up tickets that this harness unblocks.
+ *
+ * Skips cleanly when python3 / python3-dbusmock is not installed. See [DbusmockHarness] for
+ * installation instructions.
+ */
+class DbusmockSmokeTest {
+    @Test
+    fun callsMethodAndReadsPropertyOnDbusmockPeer() = runBlocking {
+        val suffix = Random.nextInt(100_000, 999_999)
+        val busName = "com.monkopedia.sdbus.dbusmock.Smoke$suffix"
+        val objectPath = "/com/monkopedia/sdbus/dbusmock/Smoke$suffix"
+        val interfaceName = "com.monkopedia.sdbus.dbusmock.Smoke$suffix"
+
+        val handle = launchDbusmock(busName, objectPath, interfaceName)
+        if (handle == null) {
+            // python3 / python3-dbusmock not available, or no session bus — skip cleanly.
+            println(
+                "[DbusmockSmokeTest] SKIP: python-dbusmock unavailable. " +
+                    "Install via 'apt install python3-dbusmock' / 'pip install python-dbusmock' " +
+                    "(see DbusmockHarness KDoc)."
+            )
+            return@runBlocking
+        }
+
+        val connection = createBusConnection()
+        connection.enterEventLoopAsync()
+        val mockControl = createProxy(connection, ServiceName(busName), ObjectPath(objectPath))
+        val proxy = createProxy(connection, ServiceName(busName), ObjectPath(objectPath))
+
+        try {
+            // dbusmock takes a moment to claim its bus name; retry the first control call until
+            // the name is owned (or we time out).
+            retry(timeoutMillis = 15_000) {
+                addMethod(
+                    mockControl,
+                    interfaceName,
+                    name = "Increment",
+                    inSig = "i",
+                    outSig = "i",
+                    code = "ret = args[0] + 1"
+                )
+            }
+            addProperty(
+                mockControl,
+                interfaceName,
+                name = "Greeting",
+                value = Variant("hello-from-dbusmock")
+            )
+
+            // Method call: our client -> dbusmock (foreign serializer) -> back.
+            val incremented = proxy.callMethod<Int>(
+                InterfaceName(interfaceName),
+                MethodName("Increment")
+            ) {
+                call(41)
+            }
+            assertEquals(42, incremented, "Increment(41) via dbusmock should return 42")
+
+            // Property read through the standard org.freedesktop.DBus.Properties.Get path.
+            val greeting = proxy.getProperty<String>(
+                InterfaceName(interfaceName),
+                PropertyName("Greeting")
+            )
+            assertEquals("hello-from-dbusmock", greeting, "Greeting property via dbusmock mismatch")
+        } finally {
+            proxy.release()
+            mockControl.release()
+            connection.leaveEventLoop()
+            connection.release()
+            handle.stop()
+        }
+    }
+
+    private fun addMethod(
+        mockControl: com.monkopedia.sdbus.Proxy,
+        interfaceName: String,
+        name: String,
+        inSig: String,
+        outSig: String,
+        code: String
+    ) {
+        mockControl.callMethod<Unit>(MOCK_INTERFACE, MethodName("AddMethod")) {
+            call(interfaceName, name, inSig, outSig, code)
+        }
+    }
+
+    private fun addProperty(
+        mockControl: com.monkopedia.sdbus.Proxy,
+        interfaceName: String,
+        name: String,
+        value: Variant
+    ) {
+        mockControl.callMethod<Unit>(MOCK_INTERFACE, MethodName("AddProperty")) {
+            call(interfaceName, name, value)
+        }
+    }
+
+    private inline fun retry(timeoutMillis: Long, block: () -> Unit) {
+        val start = kotlin.time.TimeSource.Monotonic.markNow()
+        var last: Throwable? = null
+        while (start.elapsedNow().inWholeMilliseconds < timeoutMillis) {
+            val result = runCatching(block)
+            if (result.isSuccess) return
+            last = result.exceptionOrNull()
+            busyWait(100)
+        }
+        throw AssertionError("Timed out waiting for dbusmock to become ready", last)
+    }
+
+    private companion object {
+        private val MOCK_INTERFACE = InterfaceName("org.freedesktop.DBus.Mock")
+    }
+}
+
+/** Platform busy-wait used to space out readiness retries without a coroutine delay. */
+internal expect fun busyWait(millis: Long)

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.jvm.kt
@@ -1,0 +1,72 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import java.util.concurrent.TimeUnit
+
+internal actual fun dbusmockGetenv(name: String): String? = System.getenv(name)
+
+internal actual class DbusmockHandle(private val process: Process) {
+    actual fun stop() {
+        process.destroy()
+        if (!process.waitFor(5, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+        }
+    }
+}
+
+internal actual fun launchDbusmock(
+    busName: String,
+    objectPath: String,
+    interfaceName: String
+): DbusmockHandle? {
+    // No session bus -> nothing to launch dbusmock on; skip.
+    if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) return null
+
+    val python = dbusmockGetenv("DBUSMOCK_PYTHON") ?: "python3"
+    return try {
+        val process = ProcessBuilder(
+            python,
+            "-m",
+            "dbusmock",
+            "--session",
+            busName,
+            objectPath,
+            interfaceName
+        ).redirectErrorStream(true)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
+        // python3 exists but dbusmock module is missing -> process exits ~immediately non-zero.
+        if (process.waitFor(500, TimeUnit.MILLISECONDS)) {
+            // Exited already: dbusmock not installed / failed to start. Skip.
+            return null
+        }
+        DbusmockHandle(process)
+    } catch (_: Exception) {
+        // python3 not on PATH, etc. Skip.
+        null
+    }
+}
+
+internal actual fun busyWait(millis: Long) {
+    Thread.sleep(millis)
+}

--- a/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
@@ -1,0 +1,106 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.monkopedia.sdbus.integration
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.cstr
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.toKString
+import platform.posix.SIGTERM
+import platform.posix.WNOHANG
+import platform.posix._exit
+import platform.posix.execvp
+import platform.posix.fork
+import platform.posix.getenv
+import platform.posix.kill
+import platform.posix.usleep
+import platform.posix.waitpid
+
+internal actual fun dbusmockGetenv(name: String): String? = getenv(name)?.toKString()
+
+internal actual class DbusmockHandle(private val pid: Int) {
+    actual fun stop() {
+        kill(pid, SIGTERM)
+        // Reap the child so it does not linger as a zombie. Give it a short grace period.
+        memScoped {
+            val status = alloc<IntVar>()
+            repeat(50) {
+                if (waitpid(pid, status.ptr, WNOHANG) != 0) return
+                usleep(10_000u)
+            }
+        }
+    }
+}
+
+internal actual fun launchDbusmock(
+    busName: String,
+    objectPath: String,
+    interfaceName: String
+): DbusmockHandle? {
+    // No session bus -> nothing to launch dbusmock on; skip.
+    if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) return null
+
+    val python = dbusmockGetenv("DBUSMOCK_PYTHON") ?: "python3"
+    val args = listOf(
+        python,
+        "-m",
+        "dbusmock",
+        "--session",
+        busName,
+        objectPath,
+        interfaceName
+    )
+
+    val pid = fork()
+    if (pid < 0) return null
+    if (pid == 0) {
+        // Child: exec python3 -m dbusmock. On any failure, exit non-zero.
+        memScoped {
+            val cArgs = args.map { it.cstr.getPointer(this) } + listOf(null)
+            execvp(python, allocArrayOf(cArgs))
+            // execvp only returns on failure (e.g. python3 not on PATH).
+            _exit(127)
+        }
+    }
+
+    // Parent: detect an immediate failure (e.g. dbusmock module missing -> python exits fast).
+    memScoped {
+        val status = alloc<IntVar>()
+        repeat(50) {
+            if (waitpid(pid, status.ptr, WNOHANG) == pid) {
+                // Child already exited: dbusmock not installed / failed to start. Skip.
+                return null
+            }
+            usleep(10_000u)
+        }
+    }
+    return DbusmockHandle(pid)
+}
+
+internal actual fun busyWait(millis: Long) {
+    usleep((millis * 1_000L).toUInt())
+}


### PR DESCRIPTION
## What

Adopts [python-dbusmock](https://github.com/martinpitt/python-dbusmock) as an independent-peer test harness, the keystone that unblocks the dbusmock-driven coverage tickets (#33-36). Scope is intentionally kept to the **harness + one smoke test**; deep coverage is the follow-ups.

dbusmock's service side is an independent Python/GDBus implementation. Driving our generated proxies against it validates our marshalling/wire protocol against a foreign stack, catching the symmetric-serializer bugs that our own-server-vs-our-proxy round-trips structurally cannot.

## How it works

- **`DbusmockHarness`** (commonTest `expect` + jvm/native `actual`s): launches `python3 -m dbusmock --session <name> <path> <iface>` on the *current* private bus (the one `dbus-run-session` already provides), so `createBusConnection()` points our client at the same bus.
  - JVM actual: `ProcessBuilder`.
  - Native (linuxX64) actual: `fork` / `execvp` / `waitpid` / `kill` via `platform.posix`.
  - Returns `null` -> clean **SKIP** if `python3` / `python3-dbusmock` is missing or no session bus is reachable.
- **`DbusmockSmokeTest`** (commonTest, so it runs on **both** backends via `jvmTest` and `linuxX64Test`): scripts a generic mock through the `org.freedesktop.DBus.Mock` control interface (`AddMethod` returning `args[0] + 1`, `AddProperty` set to a string), then via our proxy calls `Increment(41)` (asserts `42`) and reads the `Greeting` property (asserts the string). Both go through dbusmock's foreign serializer.

## Graceful skip

If python3 / python3-dbusmock isn't installed, the test prints a SKIP line with install instructions and passes (no hard-fail) — CI without dbusmock still goes green.

## CI / install

- `full-tests-x64` job now `apt-get install`s `python3-dbusmock` (it runs `:cross_test:{jvmTest,linuxX64Test}` via `allTests`).
- Install instructions for Debian/Ubuntu (`apt install python3-dbusmock`), Arch (`pacman -S python-dbusmock`), and pip (`pip install python-dbusmock` into a `--system-site-packages` venv), plus the `DBUSMOCK_PYTHON` interpreter override, are documented in the `DbusmockHarness` KDoc.

## Verification

Run locally with dbusmock installed in a venv, inside `dbus-run-session`:

- **Real loop, dbusmock present**: both JVM and native pass with assertions executed (native `system-out` shows dbusmock's `Increment 41` / `Get Greeting` log lines against the unique per-run interface).
- **Skip path, dbusmock absent**: both backends pass cleanly with the SKIP message.

Fixes #32