### PR TITLE
1.0 ABI: unify public timeout contract on Duration (#37)

### DIFF
--- a/api/sdbus-kotlin.api
+++ b/api/sdbus-kotlin.api
@@ -252,7 +252,7 @@ public final class com/monkopedia/sdbus/MethodCall : com/monkopedia/sdbus/Messag
 	public final fun createErrorReply (Lcom/monkopedia/sdbus/Error;)Lcom/monkopedia/sdbus/MethodReply;
 	public final fun createReply ()Lcom/monkopedia/sdbus/MethodReply;
 	public final fun getDontExpectReply ()Z
-	public final fun send-VKZWuLQ (J)Lcom/monkopedia/sdbus/MethodReply;
+	public final fun send-LRDsOJo (J)Lcom/monkopedia/sdbus/MethodReply;
 	public final fun setDontExpectReply (Z)V
 }
 
@@ -468,9 +468,9 @@ public final class com/monkopedia/sdbus/PropertyVTableItemKt {
 
 public abstract interface class com/monkopedia/sdbus/Proxy : com/monkopedia/sdbus/Resource {
 	public abstract fun callMethod (Lcom/monkopedia/sdbus/MethodCall;)Lcom/monkopedia/sdbus/MethodReply;
-	public abstract fun callMethod-2TYgG_w (Lcom/monkopedia/sdbus/MethodCall;J)Lcom/monkopedia/sdbus/MethodReply;
+	public abstract fun callMethod-HG0u8IE (Lcom/monkopedia/sdbus/MethodCall;J)Lcom/monkopedia/sdbus/MethodReply;
 	public abstract fun callMethodAsync (Lcom/monkopedia/sdbus/MethodCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun callMethodAsync-z13BHRw (Lcom/monkopedia/sdbus/MethodCall;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun callMethodAsync-8Mi8wO0 (Lcom/monkopedia/sdbus/MethodCall;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createMethodCall-QGofiho (Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/sdbus/MethodCall;
 	public abstract fun getConnection ()Lcom/monkopedia/sdbus/Connection;
 	public abstract fun getCurrentlyProcessedMessage ()Lcom/monkopedia/sdbus/Message;
@@ -483,8 +483,6 @@ public abstract interface class com/monkopedia/sdbus/ProxyHolder {
 }
 
 public final class com/monkopedia/sdbus/ProxyKt {
-	public static final fun callMethod-SxA4cEA (Lcom/monkopedia/sdbus/Proxy;Lcom/monkopedia/sdbus/MethodCall;J)Lcom/monkopedia/sdbus/MethodReply;
-	public static final fun callMethodAsync-exY8QGI (Lcom/monkopedia/sdbus/Proxy;Lcom/monkopedia/sdbus/MethodCall;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getAllProperties (Lcom/monkopedia/sdbus/Proxy;)Lcom/monkopedia/sdbus/AllPropertiesGetter;
 	public static final fun getAllPropertiesAsync (Lcom/monkopedia/sdbus/Proxy;)Lcom/monkopedia/sdbus/AsyncAllPropertiesGetter;
 	public static final fun getPropertyAsync-NRJcMk0 (Lcom/monkopedia/sdbus/Proxy;Ljava/lang/String;)Lcom/monkopedia/sdbus/AsyncPropertyGetter;

--- a/api/sdbus-kotlin.klib.api
+++ b/api/sdbus-kotlin.klib.api
@@ -78,11 +78,11 @@ abstract interface com.monkopedia.sdbus/Proxy : com.monkopedia.sdbus/Resource { 
         abstract fun <get-objectPath>(): com.monkopedia.sdbus/ObjectPath // com.monkopedia.sdbus/Proxy.objectPath.<get-objectPath>|<get-objectPath>(){}[0]
 
     abstract fun callMethod(com.monkopedia.sdbus/MethodCall): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/Proxy.callMethod|callMethod(com.monkopedia.sdbus.MethodCall){}[0]
-    abstract fun callMethod(com.monkopedia.sdbus/MethodCall, kotlin/ULong): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/Proxy.callMethod|callMethod(com.monkopedia.sdbus.MethodCall;kotlin.ULong){}[0]
+    abstract fun callMethod(com.monkopedia.sdbus/MethodCall, kotlin.time/Duration): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/Proxy.callMethod|callMethod(com.monkopedia.sdbus.MethodCall;kotlin.time.Duration){}[0]
     abstract fun createMethodCall(com.monkopedia.sdbus/InterfaceName, com.monkopedia.sdbus/MemberName): com.monkopedia.sdbus/MethodCall // com.monkopedia.sdbus/Proxy.createMethodCall|createMethodCall(com.monkopedia.sdbus.InterfaceName;com.monkopedia.sdbus.MemberName){}[0]
     abstract fun registerSignalHandler(com.monkopedia.sdbus/InterfaceName, com.monkopedia.sdbus/MemberName, kotlin/Function1<com.monkopedia.sdbus/Signal, kotlin/Unit>): com.monkopedia.sdbus/Resource // com.monkopedia.sdbus/Proxy.registerSignalHandler|registerSignalHandler(com.monkopedia.sdbus.InterfaceName;com.monkopedia.sdbus.MemberName;kotlin.Function1<com.monkopedia.sdbus.Signal,kotlin.Unit>){}[0]
     abstract suspend fun callMethodAsync(com.monkopedia.sdbus/MethodCall): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/Proxy.callMethodAsync|callMethodAsync(com.monkopedia.sdbus.MethodCall){}[0]
-    abstract suspend fun callMethodAsync(com.monkopedia.sdbus/MethodCall, kotlin/ULong): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/Proxy.callMethodAsync|callMethodAsync(com.monkopedia.sdbus.MethodCall;kotlin.ULong){}[0]
+    abstract suspend fun callMethodAsync(com.monkopedia.sdbus/MethodCall, kotlin.time/Duration): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/Proxy.callMethodAsync|callMethodAsync(com.monkopedia.sdbus.MethodCall;kotlin.time.Duration){}[0]
 }
 
 abstract interface com.monkopedia.sdbus/ProxyHolder { // com.monkopedia.sdbus/ProxyHolder|null[0]
@@ -253,7 +253,7 @@ final class com.monkopedia.sdbus/MethodCall : com.monkopedia.sdbus/Message { // 
 
     final fun createErrorReply(com.monkopedia.sdbus/Error): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.createErrorReply|createErrorReply(com.monkopedia.sdbus.Error){}[0]
     final fun createReply(): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.createReply|createReply(){}[0]
-    final fun send(kotlin/ULong): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.send|send(kotlin.ULong){}[0]
+    final fun send(kotlin.time/Duration): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.send|send(kotlin.time.Duration){}[0]
 }
 
 final class com.monkopedia.sdbus/MethodInvoker : com.monkopedia.sdbus/TypedArgumentsBuilderContext { // com.monkopedia.sdbus/MethodInvoker|null[0]
@@ -785,7 +785,6 @@ final val com.monkopedia.sdbus/DBUS_PROPERTIES_INTERFACE_NAME // com.monkopedia.
 final fun (com.monkopedia.sdbus/Connection).com.monkopedia.sdbus/withService(com.monkopedia.sdbus/BusName): com.monkopedia.sdbus/ServiceConnection // com.monkopedia.sdbus/withService|withService@com.monkopedia.sdbus.Connection(com.monkopedia.sdbus.BusName){}[0]
 final fun (com.monkopedia.sdbus/Message).com.monkopedia.sdbus/serialize(com.monkopedia.sdbus/TypedArguments) // com.monkopedia.sdbus/serialize|serialize@com.monkopedia.sdbus.Message(com.monkopedia.sdbus.TypedArguments){}[0]
 final fun (com.monkopedia.sdbus/Object).com.monkopedia.sdbus/emit(com.monkopedia.sdbus/SignalEmitter) // com.monkopedia.sdbus/emit|emit@com.monkopedia.sdbus.Object(com.monkopedia.sdbus.SignalEmitter){}[0]
-final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/callMethod(com.monkopedia.sdbus/MethodCall, kotlin.time/Duration): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/callMethod|callMethod@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.MethodCall;kotlin.time.Duration){}[0]
 final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/getAllProperties(): com.monkopedia.sdbus/AllPropertiesGetter // com.monkopedia.sdbus/getAllProperties|getAllProperties@com.monkopedia.sdbus.Proxy(){}[0]
 final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/getAllPropertiesAsync(): com.monkopedia.sdbus/AsyncAllPropertiesGetter // com.monkopedia.sdbus/getAllPropertiesAsync|getAllPropertiesAsync@com.monkopedia.sdbus.Proxy(){}[0]
 final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/getPropertyAsync(com.monkopedia.sdbus/MemberName): com.monkopedia.sdbus/AsyncPropertyGetter // com.monkopedia.sdbus/getPropertyAsync|getPropertyAsync@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.MemberName){}[0]
@@ -834,5 +833,4 @@ final inline fun <#A: reified kotlin/Any?> (com.monkopedia.sdbus/Variant).com.mo
 final inline fun <#A: reified kotlin/Any?> com.monkopedia.sdbus/signatureOf(): com.monkopedia.sdbus/SdbusSig // com.monkopedia.sdbus/signatureOf|signatureOf(){0§<kotlin.Any?>}[0]
 final inline fun com.monkopedia.sdbus/buildArgs(kotlin/Function1<com.monkopedia.sdbus/TypedArgumentsBuilderContext, com.monkopedia.sdbus/TypedArguments>): com.monkopedia.sdbus/TypedArguments // com.monkopedia.sdbus/buildArgs|buildArgs(kotlin.Function1<com.monkopedia.sdbus.TypedArgumentsBuilderContext,com.monkopedia.sdbus.TypedArguments>){}[0]
 final suspend fun <#A: kotlin/Any> (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/callMethodAsyncImpl(com.monkopedia.sdbus/MethodCall, com.monkopedia.sdbus/MethodInvoker, kotlinx.serialization/KSerializer<#A>, kotlinx.serialization.modules/SerializersModule): #A // com.monkopedia.sdbus/callMethodAsyncImpl|callMethodAsyncImpl@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.MethodCall;com.monkopedia.sdbus.MethodInvoker;kotlinx.serialization.KSerializer<0:0>;kotlinx.serialization.modules.SerializersModule){0§<kotlin.Any>}[0]
-final suspend inline fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/callMethodAsync(com.monkopedia.sdbus/MethodCall, kotlin.time/Duration): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/callMethodAsync|callMethodAsync@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.MethodCall;kotlin.time.Duration){}[0]
 final suspend inline fun <#A: reified kotlin/Any> (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/callMethodAsync(com.monkopedia.sdbus/InterfaceName, com.monkopedia.sdbus/MemberName, kotlin/Function1<com.monkopedia.sdbus/MethodInvoker, kotlin/Unit>): #A // com.monkopedia.sdbus/callMethodAsync|callMethodAsync@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.InterfaceName;com.monkopedia.sdbus.MemberName;kotlin.Function1<com.monkopedia.sdbus.MethodInvoker,kotlin.Unit>){0§<kotlin.Any>}[0]

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/MethodCall.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/MethodCall.kt
@@ -23,6 +23,8 @@
 
 package com.monkopedia.sdbus
 
+import kotlin.time.Duration
+
 /**
  * A [Message] representing a D-Bus method call.
  *
@@ -35,11 +37,11 @@ expect class MethodCall : Message {
     /**
      * Sends this call and waits for the reply.
      *
-     * @param timeout Call timeout in microseconds; `0` uses the connection default
+     * @param timeout Call timeout; [Duration.ZERO] uses the connection default
      * @return The reply message
      * @throws [com.monkopedia.sdbus.Error] in case of failure
      */
-    fun send(timeout: ULong): MethodReply
+    fun send(timeout: Duration): MethodReply
 
     /** Creates an empty success reply for this call. */
     fun createReply(): MethodReply

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
@@ -117,7 +117,7 @@ interface Proxy : Resource {
      * Calls method on the remote D-Bus object
      *
      * @param message Message representing a method call
-     * @param timeout Method call timeout (in microseconds)
+     * @param timeout Method call timeout
      * @return A method reply message
      *
      * The call does not block if the method call has dont-expect-reply flag set. In that case,
@@ -136,13 +136,13 @@ interface Proxy : Resource {
      * its own bus connection. So-called light-weight proxies (ones created with `dont_run_event_loop_thread`
      * tag are designed for exactly that purpose.
      *
-     * If timeout is zero, the default D-Bus method call timeout is used. See IConnection::getMethodCallTimeout().
+     * If timeout is [Duration.ZERO], the default D-Bus method call timeout is used. See IConnection::getMethodCallTimeout().
      *
      * Note: To avoid messing with messages, use API on a higher level of abstraction defined below.
      *
      * @throws [com.monkopedia.sdbus.Error] in case of failure (also in case the remote function returned an error)
      */
-    fun callMethod(message: MethodCall, timeout: ULong): MethodReply
+    fun callMethod(message: MethodCall, timeout: Duration): MethodReply
 
     /**
      * Calls method on the D-Bus object asynchronously
@@ -179,13 +179,13 @@ interface Proxy : Resource {
      * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.Error]
      * in case the remote method threw an exception, or the call timed out).
      *
-     * If timeout is zero, the default D-Bus method call timeout is used. See IConnection::getMethodCallTimeout().
+     * If timeout is [Duration.ZERO], the default D-Bus method call timeout is used. See IConnection::getMethodCallTimeout().
      *
      * Note: To avoid messing with messages, use higher-level API defined below.
      *
      * @throws [com.monkopedia.sdbus.Error] in case of failure
      */
-    suspend fun callMethodAsync(message: MethodCall, timeout: ULong): MethodReply
+    suspend fun callMethodAsync(message: MethodCall, timeout: Duration): MethodReply
 
     /**
      * Registers a handler for the desired signal emitted by the D-Bus object
@@ -263,9 +263,6 @@ internal interface CallbackAsyncProxy {
 
 // Out-of-line member definitions
 
-fun Proxy.callMethod(message: MethodCall, timeout: Duration): MethodReply =
-    callMethod(message, timeout.inWholeMicroseconds.toULong())
-
 internal fun Proxy.callMethodAsync(
     message: MethodCall,
     asyncReplyCallback: AsyncReplyHandler
@@ -284,9 +281,6 @@ internal fun Proxy.callMethodAsync(
     timeout: Duration
 ): PendingAsyncCall =
     callMethodAsync(message, asyncReplyCallback, timeout.inWholeMicroseconds.toULong())
-
-suspend inline fun Proxy.callMethodAsync(message: MethodCall, timeout: Duration): MethodReply =
-    callMethodAsync(message, timeout.inWholeMicroseconds.toULong())
 
 /**
  * Gets value of a property of the D-Bus object asynchronously

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -337,7 +338,7 @@ class CommonApiIntegrationTest {
             call.append(20)
             call.append(22)
 
-            val reply = call.send(2_000_000u)
+            val reply = call.send(2.seconds)
             assertEquals(42, reply.readIntReply())
         } finally {
             registration.release()

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -4,6 +4,7 @@ import com.monkopedia.sdbus.internal.jvmdbus.JvmStaticDispatch
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -353,7 +354,9 @@ actual class MethodCall internal constructor() : Message() {
     internal var sentReply: MethodReply? = null
     private val replySent = CountDownLatch(1)
 
-    actual fun send(timeout: ULong): MethodReply {
+    actual fun send(timeout: Duration): MethodReply = send(timeout.inWholeMicroseconds.toULong())
+
+    internal fun send(timeout: ULong): MethodReply {
         val interfaceName = metadata.interfaceName
             ?: throw createError(-1, "MethodCall.send failed: missing interface name")
         val methodName = metadata.memberName

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Proxy.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Proxy.jvm.kt
@@ -2,6 +2,7 @@ package com.monkopedia.sdbus
 
 import com.monkopedia.sdbus.internal.jvmdbus.JvmDbusBackendProvider
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
 
 internal class JvmProxy(
     override val connection: Connection,
@@ -19,8 +20,8 @@ internal class JvmProxy(
 
     override fun callMethod(message: MethodCall): MethodReply = backend.callMethod(message)
 
-    override fun callMethod(message: MethodCall, timeout: ULong): MethodReply =
-        backend.callMethod(message, timeout)
+    override fun callMethod(message: MethodCall, timeout: Duration): MethodReply =
+        backend.callMethod(message, timeout.inWholeMicroseconds.toULong())
 
     override fun callMethodAsync(
         message: MethodCall,
@@ -36,8 +37,8 @@ internal class JvmProxy(
     override suspend fun callMethodAsync(message: MethodCall): MethodReply =
         backend.callMethodAsync(message)
 
-    override suspend fun callMethodAsync(message: MethodCall, timeout: ULong): MethodReply =
-        backend.callMethodAsync(message, timeout)
+    override suspend fun callMethodAsync(message: MethodCall, timeout: Duration): MethodReply =
+        backend.callMethodAsync(message, timeout.inWholeMicroseconds.toULong())
 
     override fun registerSignalHandler(
         interfaceName: InterfaceName,

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
@@ -8,6 +8,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 class JvmMessageSupportTest {
     @Test
@@ -33,7 +35,7 @@ class JvmMessageSupportTest {
             call.append(20)
             call.append(22)
 
-            val reply = call.send(0u)
+            val reply = call.send(Duration.ZERO)
 
             reply.rewind(false)
             assertEquals(42, reply.readInt())
@@ -72,7 +74,7 @@ class JvmMessageSupportTest {
             call.append(22)
 
             val thrown = assertFailsWith<Error> {
-                call.send(1_000u)
+                call.send(1.milliseconds)
             }
             assertTrue(thrown.errorMessage.contains("timed out"))
         } finally {

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmProxyObjectMockkTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmProxyObjectMockkTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.microseconds
 import kotlinx.coroutines.test.runTest
 
 class JvmProxyObjectMockkTest {
@@ -48,9 +49,9 @@ class JvmProxyObjectMockkTest {
         assertEquals(currentMessage, proxy.currentlyProcessedMessage)
         assertEquals(call, proxy.createMethodCall(InterfaceName("com.example"), MethodName("Ping")))
         assertEquals(reply, proxy.callMethod(call))
-        assertEquals(reply, proxy.callMethod(call, 42u))
+        assertEquals(reply, proxy.callMethod(call, 42.microseconds))
         assertEquals(reply, proxy.callMethodAsync(call))
-        assertEquals(reply, proxy.callMethodAsync(call, 42u))
+        assertEquals(reply, proxy.callMethodAsync(call, 42.microseconds))
         assertEquals(
             resource,
             proxy.registerSignalHandler(

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/MethodCall.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/MethodCall.native.kt
@@ -29,6 +29,7 @@ import cnames.structs.sd_bus_slot
 import com.monkopedia.sdbus.internal.ISdBus
 import com.monkopedia.sdbus.internal.Reference
 import kotlin.native.internal.NativePtr
+import kotlin.time.Duration
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -58,7 +59,9 @@ actual class MethodCall internal constructor(
 
     constructor (o: MethodCall) : this(o.msg, o.sdbus)
 
-    actual fun send(timeout: ULong): MethodReply =
+    actual fun send(timeout: Duration): MethodReply = send(timeout.inWholeMicroseconds.toULong())
+
+    internal fun send(timeout: ULong): MethodReply =
         if (dontExpectReply) sendWithNoReply() else sendWithReply(timeout)
 
     internal fun send(

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ProxyImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ProxyImpl.kt
@@ -43,6 +43,7 @@ import com.monkopedia.sdbus.sdbusRequire
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.WeakReference
 import kotlin.native.ref.createCleaner
+import kotlin.time.Duration
 import kotlinx.atomicfu.atomic
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CPointer
@@ -99,7 +100,10 @@ internal class ProxyImpl(
 
     override fun callMethod(message: MethodCall): MethodReply = callMethod(message, 0u)
 
-    override fun callMethod(message: MethodCall, timeout: ULong): MethodReply {
+    override fun callMethod(message: MethodCall, timeout: Duration): MethodReply =
+        callMethod(message, timeout.inWholeMicroseconds.toULong())
+
+    private fun callMethod(message: MethodCall, timeout: ULong): MethodReply {
         sdbusRequire(!message.isValid, "Invalid method call message provided", EINVAL)
 
         return connection.callMethod(message, timeout)
@@ -144,7 +148,10 @@ internal class ProxyImpl(
     override suspend fun callMethodAsync(message: MethodCall): MethodReply =
         callMethodAsync(message, 0u)
 
-    override suspend fun callMethodAsync(message: MethodCall, timeout: ULong): MethodReply {
+    override suspend fun callMethodAsync(message: MethodCall, timeout: Duration): MethodReply =
+        callMethodAsync(message, timeout.inWholeMicroseconds.toULong())
+
+    private suspend fun callMethodAsync(message: MethodCall, timeout: ULong): MethodReply {
         val deferred = CompletableDeferred<MethodReply>()
 
         callMethodAsync(message, deferred.asAsyncReplyHandler, timeout)


### PR DESCRIPTION
Implements the owner decision commented on #37 (2026-06-10): **Option 2 — Duration everywhere**. PR 2 of the 1.0 ABI wave, building on #57's restructure.

Fixes #37.

## What changed

The public timeout contract is now `kotlin.time.Duration` everywhere, matching `Connection.getMethodCallTimeout()/setMethodCallTimeout(Duration)`:

- `Proxy.callMethod(MethodCall, Duration)` and `suspend Proxy.callMethodAsync(MethodCall, Duration)` move from extension functions onto the `Proxy` interface itself.
- The raw `ULong`-microsecond overloads (`Proxy.callMethod(MethodCall, ULong)`, `suspend Proxy.callMethodAsync(MethodCall, ULong)`, `MethodCall.send(ULong)`) leave the public surface. Since Kotlin interface members cannot be `internal`, they are re-homed following the #57 precedent: private members on the platform `Proxy` implementations (`JvmProxy`, native `ProxyImpl`), an `internal fun send(ULong)` on the `MethodCall` actuals, and the already-internal backend interfaces (`JvmDbusProxy`, `InternalConnection`, `CallbackAsyncProxy`) which were ULong all along.
- `MethodCall.send(timeout: ULong)` becomes public `MethodCall.send(timeout: Duration)`.

**BREAKING CHANGE: removes ULong-microsecond timeout overloads from the public API; Proxy and MethodCall speak kotlin.time.Duration.**

## Behavior

100% unchanged. The conversion is exactly what the old public `Duration` extensions already did: `timeout.inWholeMicroseconds.toULong()`, with `Duration.ZERO` mapping to `0u` (= connection-default timeout). `MethodInvoker.timeout`'s `Duration.INFINITE` default keeps its existing mapping too. The internal callback machinery from #57 keeps taking ULong micros unchanged.

In-repo call sites that used the ULong forms (`JvmMessageSupportTest`, `JvmProxyObjectMockkTest`, `CommonApiIntegrationTest`) now use the Duration forms; cross_test/stress_test/compile_test/samples already used Duration-based APIs.

## API dump delta

`api/sdbus-kotlin.klib.api`:
```diff
 abstract interface com.monkopedia.sdbus/Proxy {
-    abstract fun callMethod(MethodCall, kotlin/ULong): MethodReply
+    abstract fun callMethod(MethodCall, kotlin.time/Duration): MethodReply
-    abstract suspend fun callMethodAsync(MethodCall, kotlin/ULong): MethodReply
+    abstract suspend fun callMethodAsync(MethodCall, kotlin.time/Duration): MethodReply
 }
 final class com.monkopedia.sdbus/MethodCall {
-    final fun send(kotlin/ULong): MethodReply
+    final fun send(kotlin.time/Duration): MethodReply
 }
-final fun (Proxy).callMethod(MethodCall, kotlin.time/Duration): MethodReply        // extension, now a member
-final suspend inline fun (Proxy).callMethodAsync(MethodCall, kotlin.time/Duration) // extension, now a member
```

`api/sdbus-kotlin.api` (JVM): the same three members switch their value-class mangling from ULong to Duration (`send-VKZWuLQ(J)` -> `send-LRDsOJo(J)`, `callMethod-2TYgG_w` -> `callMethod-HG0u8IE`, `callMethodAsync-z13BHRw` -> `callMethodAsync-8Mi8wO0`), and the two `ProxyKt` static extension entry points are removed. Nothing else changes.

## Verification

- `./gradlew ktlintFormat` + `apiDump` (diff reviewed above)
- `./gradlew ktlintCheck apiCheck` — pass
- `dbus-run-session -- ./gradlew jvmTest` — pass
- `./gradlew compileKotlinLinuxX64 compileTestKotlinLinuxX64 :codegen:test :plugin:test :compile_test:build` — pass
- `./gradlew :cross_test:compileTestKotlinJvm :stress_test:compileTestKotlinJvm` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)