### PR TITLE
1.0 ABI: idiomize Message accessors — typed val properties, named peekType result (#44)

### DIFF
--- a/api/sdbus-kotlin.api
+++ b/api/sdbus-kotlin.api
@@ -221,16 +221,16 @@ public abstract class com/monkopedia/sdbus/Message {
 	public final fun getCredsPid ()I
 	public final fun getCredsSupplementaryGids ()Ljava/util/List;
 	public final fun getCredsUid-pVg5ArA ()I
-	public final fun getDestination ()Ljava/lang/String;
-	public final fun getInterfaceName ()Ljava/lang/String;
-	public final fun getMemberName ()Ljava/lang/String;
-	public final fun getPath ()Ljava/lang/String;
-	public final fun getSELinuxContext ()Ljava/lang/String;
-	public final fun getSender ()Ljava/lang/String;
+	public final fun getDestination-wEJio8Y ()Ljava/lang/String;
+	public final fun getInterfaceName-BGuB-K0 ()Ljava/lang/String;
+	public final fun getMemberName-Y7feF3Q ()Ljava/lang/String;
+	public final fun getPath-IynOJ1Q ()Ljava/lang/String;
+	public final fun getSeLinuxContext ()Ljava/lang/String;
+	public final fun getSender-wEJio8Y ()Ljava/lang/String;
 	public final fun isAtEnd (Z)Z
 	public final fun isEmpty ()Z
 	public final fun isValid ()Z
-	public final fun peekType ()Lkotlin/Pair;
+	public final fun peekType ()Lcom/monkopedia/sdbus/PeekedType;
 	public final fun rewind (Z)V
 	public final fun seal ()V
 }
@@ -367,6 +367,13 @@ public final class com/monkopedia/sdbus/ObjectPath$Companion : kotlinx/serializa
 
 public final class com/monkopedia/sdbus/Object_jvmKt {
 	public static final fun createObject-NvYYnfA (Lcom/monkopedia/sdbus/Connection;Ljava/lang/String;)Lcom/monkopedia/sdbus/Object;
+}
+
+public final class com/monkopedia/sdbus/PeekedType {
+	public fun <init> (Ljava/lang/Character;Ljava/lang/String;)V
+	public final fun getContents ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/Character;
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/monkopedia/sdbus/PeerProxy : com/monkopedia/sdbus/ProxyHolder {

--- a/api/sdbus-kotlin.klib.api
+++ b/api/sdbus-kotlin.klib.api
@@ -334,6 +334,17 @@ final class com.monkopedia.sdbus/ObjectManagerProxy { // com.monkopedia.sdbus/Ob
     }
 }
 
+final class com.monkopedia.sdbus/PeekedType { // com.monkopedia.sdbus/PeekedType|null[0]
+    constructor <init>(kotlin/Char?, kotlin/String?) // com.monkopedia.sdbus/PeekedType.<init>|<init>(kotlin.Char?;kotlin.String?){}[0]
+
+    final val contents // com.monkopedia.sdbus/PeekedType.contents|{}contents[0]
+        final fun <get-contents>(): kotlin/String? // com.monkopedia.sdbus/PeekedType.contents.<get-contents>|<get-contents>(){}[0]
+    final val type // com.monkopedia.sdbus/PeekedType.type|{}type[0]
+        final fun <get-type>(): kotlin/Char? // com.monkopedia.sdbus/PeekedType.type.<get-type>|<get-type>(){}[0]
+
+    final fun toString(): kotlin/String // com.monkopedia.sdbus/PeekedType.toString|toString(){}[0]
+}
+
 final class com.monkopedia.sdbus/PlainMessage : com.monkopedia.sdbus/Message { // com.monkopedia.sdbus/PlainMessage|null[0]
     constructor <init>(com.monkopedia.sdbus/PlainMessage) // com.monkopedia.sdbus/PlainMessage.<init>|<init>(com.monkopedia.sdbus.PlainMessage){}[0]
 
@@ -746,26 +757,38 @@ sealed class <#A: com.monkopedia.sdbus/TypedMethodCall<#A>> com.monkopedia.sdbus
 }
 
 sealed class com.monkopedia.sdbus/Message { // com.monkopedia.sdbus/Message|null[0]
+    final val credsEgid // com.monkopedia.sdbus/Message.credsEgid|{}credsEgid[0]
+        final fun <get-credsEgid>(): kotlin/UInt // com.monkopedia.sdbus/Message.credsEgid.<get-credsEgid>|<get-credsEgid>(){}[0]
+    final val credsEuid // com.monkopedia.sdbus/Message.credsEuid|{}credsEuid[0]
+        final fun <get-credsEuid>(): kotlin/UInt // com.monkopedia.sdbus/Message.credsEuid.<get-credsEuid>|<get-credsEuid>(){}[0]
+    final val credsGid // com.monkopedia.sdbus/Message.credsGid|{}credsGid[0]
+        final fun <get-credsGid>(): kotlin/UInt // com.monkopedia.sdbus/Message.credsGid.<get-credsGid>|<get-credsGid>(){}[0]
+    final val credsPid // com.monkopedia.sdbus/Message.credsPid|{}credsPid[0]
+        final fun <get-credsPid>(): kotlin/Int // com.monkopedia.sdbus/Message.credsPid.<get-credsPid>|<get-credsPid>(){}[0]
+    final val credsSupplementaryGids // com.monkopedia.sdbus/Message.credsSupplementaryGids|{}credsSupplementaryGids[0]
+        final fun <get-credsSupplementaryGids>(): kotlin.collections/List<kotlin/UInt> // com.monkopedia.sdbus/Message.credsSupplementaryGids.<get-credsSupplementaryGids>|<get-credsSupplementaryGids>(){}[0]
+    final val credsUid // com.monkopedia.sdbus/Message.credsUid|{}credsUid[0]
+        final fun <get-credsUid>(): kotlin/UInt // com.monkopedia.sdbus/Message.credsUid.<get-credsUid>|<get-credsUid>(){}[0]
+    final val destination // com.monkopedia.sdbus/Message.destination|{}destination[0]
+        final fun <get-destination>(): com.monkopedia.sdbus/BusName? // com.monkopedia.sdbus/Message.destination.<get-destination>|<get-destination>(){}[0]
+    final val interfaceName // com.monkopedia.sdbus/Message.interfaceName|{}interfaceName[0]
+        final fun <get-interfaceName>(): com.monkopedia.sdbus/InterfaceName? // com.monkopedia.sdbus/Message.interfaceName.<get-interfaceName>|<get-interfaceName>(){}[0]
     final val isEmpty // com.monkopedia.sdbus/Message.isEmpty|{}isEmpty[0]
         final fun <get-isEmpty>(): kotlin/Boolean // com.monkopedia.sdbus/Message.isEmpty.<get-isEmpty>|<get-isEmpty>(){}[0]
     final val isValid // com.monkopedia.sdbus/Message.isValid|{}isValid[0]
         final fun <get-isValid>(): kotlin/Boolean // com.monkopedia.sdbus/Message.isValid.<get-isValid>|<get-isValid>(){}[0]
+    final val memberName // com.monkopedia.sdbus/Message.memberName|{}memberName[0]
+        final fun <get-memberName>(): com.monkopedia.sdbus/MemberName? // com.monkopedia.sdbus/Message.memberName.<get-memberName>|<get-memberName>(){}[0]
+    final val path // com.monkopedia.sdbus/Message.path|{}path[0]
+        final fun <get-path>(): com.monkopedia.sdbus/ObjectPath? // com.monkopedia.sdbus/Message.path.<get-path>|<get-path>(){}[0]
+    final val seLinuxContext // com.monkopedia.sdbus/Message.seLinuxContext|{}seLinuxContext[0]
+        final fun <get-seLinuxContext>(): kotlin/String // com.monkopedia.sdbus/Message.seLinuxContext.<get-seLinuxContext>|<get-seLinuxContext>(){}[0]
+    final val sender // com.monkopedia.sdbus/Message.sender|{}sender[0]
+        final fun <get-sender>(): com.monkopedia.sdbus/BusName? // com.monkopedia.sdbus/Message.sender.<get-sender>|<get-sender>(){}[0]
 
     final fun copyTo(com.monkopedia.sdbus/Message, kotlin/Boolean) // com.monkopedia.sdbus/Message.copyTo|copyTo(com.monkopedia.sdbus.Message;kotlin.Boolean){}[0]
-    final fun getCredsEgid(): kotlin/UInt // com.monkopedia.sdbus/Message.getCredsEgid|getCredsEgid(){}[0]
-    final fun getCredsEuid(): kotlin/UInt // com.monkopedia.sdbus/Message.getCredsEuid|getCredsEuid(){}[0]
-    final fun getCredsGid(): kotlin/UInt // com.monkopedia.sdbus/Message.getCredsGid|getCredsGid(){}[0]
-    final fun getCredsPid(): kotlin/Int // com.monkopedia.sdbus/Message.getCredsPid|getCredsPid(){}[0]
-    final fun getCredsSupplementaryGids(): kotlin.collections/List<kotlin/UInt> // com.monkopedia.sdbus/Message.getCredsSupplementaryGids|getCredsSupplementaryGids(){}[0]
-    final fun getCredsUid(): kotlin/UInt // com.monkopedia.sdbus/Message.getCredsUid|getCredsUid(){}[0]
-    final fun getDestination(): kotlin/String? // com.monkopedia.sdbus/Message.getDestination|getDestination(){}[0]
-    final fun getInterfaceName(): kotlin/String? // com.monkopedia.sdbus/Message.getInterfaceName|getInterfaceName(){}[0]
-    final fun getMemberName(): kotlin/String? // com.monkopedia.sdbus/Message.getMemberName|getMemberName(){}[0]
-    final fun getPath(): kotlin/String? // com.monkopedia.sdbus/Message.getPath|getPath(){}[0]
-    final fun getSELinuxContext(): kotlin/String // com.monkopedia.sdbus/Message.getSELinuxContext|getSELinuxContext(){}[0]
-    final fun getSender(): kotlin/String? // com.monkopedia.sdbus/Message.getSender|getSender(){}[0]
     final fun isAtEnd(kotlin/Boolean): kotlin/Boolean // com.monkopedia.sdbus/Message.isAtEnd|isAtEnd(kotlin.Boolean){}[0]
-    final fun peekType(): kotlin/Pair<kotlin/Char?, kotlin/String?> // com.monkopedia.sdbus/Message.peekType|peekType(){}[0]
+    final fun peekType(): com.monkopedia.sdbus/PeekedType // com.monkopedia.sdbus/Message.peekType|peekType(){}[0]
     final fun rewind(kotlin/Boolean) // com.monkopedia.sdbus/Message.rewind|rewind(kotlin.Boolean){}[0]
     final fun seal() // com.monkopedia.sdbus/Message.seal|seal(){}[0]
 }

--- a/cross_test/src/linuxX64Test/kotlin/integration/NativeInteropPeerTest.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/NativeInteropPeerTest.kt
@@ -732,7 +732,7 @@ class NativeInteropPeerTest {
             InterfaceName("org.freedesktop.DBus.Properties"),
             SignalName("PropertiesChanged")
         ) { message ->
-            signalMember.value = message.getMemberName()
+            signalMember.value = message.memberName?.value
             signalReceived.value = true
         }
         try {

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -129,27 +129,27 @@ expect sealed class Message {
     internal operator fun invoke(): Boolean
     internal fun clearFlags()
 
-    /** Returns the interface name this message targets, or `null` if not set. */
-    fun getInterfaceName(): String?
+    /** The interface name this message targets, or `null` if not set. */
+    val interfaceName: InterfaceName?
 
-    /** Returns the member (method/signal) name this message targets, or `null` if not set. */
-    fun getMemberName(): String?
+    /** The member (method/signal) name this message targets, or `null` if not set. */
+    val memberName: MemberName?
 
-    /** Returns the bus name of the message sender, or `null` if not available. */
-    fun getSender(): String?
+    /** The bus name of the message sender, or `null` if not available. */
+    val sender: BusName?
 
-    /** Returns the object path this message targets, or `null` if not set. */
-    fun getPath(): String?
+    /** The object path this message targets, or `null` if not set. */
+    val path: ObjectPath?
 
-    /** Returns the destination bus name of the message, or `null` if not set. */
-    fun getDestination(): String?
+    /** The destination bus name of the message, or `null` if not set. */
+    val destination: BusName?
 
     /**
      * Peeks at the type of the value at the current read position without consuming it.
      *
-     * @return A pair of the D-Bus type code and, for containers, the contained signature
+     * @return The D-Bus type code and, for containers, the contained signature
      */
-    fun peekType(): Pair<Char?, String?>
+    fun peekType(): PeekedType
 
     /** Whether this message wraps a valid underlying D-Bus message. */
     val isValid: Boolean
@@ -182,24 +182,37 @@ expect sealed class Message {
      */
     fun rewind(complete: Boolean)
 
-    /** Returns the PID of the sending process, if credentials are available. */
-    fun getCredsPid(): Int
+    /** The PID of the sending process, if credentials are available. */
+    val credsPid: Int
 
-    /** Returns the real UID of the sender, if credentials are available. */
-    fun getCredsUid(): UInt
+    /** The real UID of the sender, if credentials are available. */
+    val credsUid: UInt
 
-    /** Returns the effective UID of the sender, if credentials are available. */
-    fun getCredsEuid(): UInt
+    /** The effective UID of the sender, if credentials are available. */
+    val credsEuid: UInt
 
-    /** Returns the real GID of the sender, if credentials are available. */
-    fun getCredsGid(): UInt
+    /** The real GID of the sender, if credentials are available. */
+    val credsGid: UInt
 
-    /** Returns the effective GID of the sender, if credentials are available. */
-    fun getCredsEgid(): UInt
+    /** The effective GID of the sender, if credentials are available. */
+    val credsEgid: UInt
 
-    /** Returns the supplementary GIDs of the sender, if credentials are available. */
-    fun getCredsSupplementaryGids(): List<UInt>
+    /** The supplementary GIDs of the sender, if credentials are available. */
+    val credsSupplementaryGids: List<UInt>
 
-    /** Returns the SELinux security context of the sender. */
-    fun getSELinuxContext(): String
+    /** The SELinux security context of the sender. */
+    val seLinuxContext: String
+}
+
+/**
+ * Result of [Message.peekType]: the D-Bus type code at the current read position and,
+ * for container types, the signature of the contained elements.
+ */
+class PeekedType(
+    /** The D-Bus type code of the value at the read position, or `null` if at the end. */
+    val type: Char?,
+    /** For container types, the signature of the contained elements, otherwise `null`. */
+    val contents: String?
+) {
+    override fun toString(): String = "PeekedType(type=$type, contents=$contents)"
 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
@@ -162,8 +162,7 @@ class Variant constructor() {
      */
     fun peekValueType(): String? {
         msg.rewind(false)
-        val (_, contents) = msg.peekType()
-        return contents
+        return msg.peekType().contents
     }
 
     override fun toString(): String = "Variant(${peekValueType()})"

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -194,9 +194,9 @@ class CommonApiIntegrationTest {
 
         try {
             val call = proxy.createMethodCall(ids.iface, MethodName("Ping"))
-            assertEquals(ids.iface.value, call.getInterfaceName())
-            assertEquals("Ping", call.getMemberName())
-            assertEquals(ids.path.value, call.getPath())
+            assertEquals(ids.iface, call.interfaceName)
+            assertEquals("Ping", call.memberName?.value)
+            assertEquals(ids.path, call.path)
         } finally {
             proxy.release()
             connection.release()
@@ -849,8 +849,8 @@ class CommonApiIntegrationTest {
         val pathSeen = CompletableDeferred<String>()
         val signalRegistration = proxy.registerSignalHandler(ids.iface, SignalName("Changed")) {
             val current = proxy.currentlyProcessedMessage
-            memberSeen.complete(current.getMemberName().orEmpty())
-            pathSeen.complete(current.getPath().orEmpty())
+            memberSeen.complete(current.memberName?.value.orEmpty())
+            pathSeen.complete(current.path?.value.orEmpty())
         }
 
         try {
@@ -1138,7 +1138,7 @@ class CommonApiIntegrationTest {
         val match = proxyConnection.addMatch(
             "path='${ids.path.value}',interface='${ids.iface.value}',member='Changed'"
         ) { message ->
-            if (message.getPath() == ids.path.value && message.getMemberName() == "Changed") {
+            if (message.path == ids.path && message.memberName?.value == "Changed") {
                 callbackCount += 1
                 seen.complete(Unit)
             }
@@ -1299,8 +1299,8 @@ class CommonApiIntegrationTest {
                 withSetter<Boolean> { value ->
                     state = value
                     val current = obj.currentlyProcessedMessage
-                    memberSeen.complete(current.getMemberName().orEmpty())
-                    senderSeen.complete(current.getSender().orEmpty())
+                    memberSeen.complete(current.memberName?.value.orEmpty())
+                    senderSeen.complete(current.sender?.value.orEmpty())
                 }
             }
         }
@@ -1348,14 +1348,14 @@ class CommonApiIntegrationTest {
             InterfaceName("org.freedesktop.DBus.ObjectManager"),
             SignalName("InterfacesAdded")
         ) {
-            seenMembers += it.getMemberName().orEmpty()
+            seenMembers += it.memberName?.value.orEmpty()
             added.complete(Unit)
         }
         val removedRegistration = proxy.registerSignalHandler(
             InterfaceName("org.freedesktop.DBus.ObjectManager"),
             SignalName("InterfacesRemoved")
         ) {
-            seenMembers += it.getMemberName().orEmpty()
+            seenMembers += it.memberName?.value.orEmpty()
             removed.complete(Unit)
         }
 

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/EmptyCollectionWireTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/EmptyCollectionWireTest.kt
@@ -376,8 +376,8 @@ class EmptyCollectionWireTest {
                 // failure rather than a 2s timeout.
                 try {
                     message.rewind(false)
-                    val (type, contents) = message.peekType()
-                    observedSignature.complete("${type ?: ""}${contents ?: ""}")
+                    val peeked = message.peekType()
+                    observedSignature.complete("${peeked.type ?: ""}${peeked.contents ?: ""}")
                     message.rewind(false)
                     decoded.complete(message.deserialize<T>())
                 } catch (t: Throwable) {

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/unit/MessageCommonTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/unit/MessageCommonTest.kt
@@ -228,10 +228,10 @@ class MessageCommonTest {
         msg.serialize(123)
         msg.seal()
 
-        val (type, contents) = msg.peekType()
+        val peeked = msg.peekType()
 
-        assertEquals('i', type)
-        assertNull(contents)
+        assertEquals('i', peeked.type)
+        assertNull(peeked.contents)
     }
 
     @Test
@@ -240,10 +240,10 @@ class MessageCommonTest {
         msg.serialize(mapOf(1 to "one", 2 to "two"))
         msg.seal()
 
-        val (type, contents) = msg.peekType()
+        val peeked = msg.peekType()
 
-        assertEquals('a', type)
-        assertEquals("{is}", contents)
+        assertEquals('a', peeked.type)
+        assertEquals("{is}", peeked.contents)
     }
 
     @Test

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -148,15 +148,20 @@ actual sealed class Message {
     internal actual operator fun invoke(): Boolean = false
     internal actual fun clearFlags(): Unit = Unit
 
-    actual fun getInterfaceName(): String? = metadata.interfaceName
-    actual fun getMemberName(): String? = metadata.memberName
-    actual fun getSender(): String? = metadata.sender
-    actual fun getPath(): String? = metadata.path
-    actual fun getDestination(): String? = metadata.destination
-    actual fun peekType(): Pair<Char?, String?> {
-        val next = payload.getOrNull(readIndex) ?: return null to null
-        val signature = inferSignature(next) ?: return null to null
-        return signature.first() to signature.drop(1).ifEmpty { null }
+    actual val interfaceName: InterfaceName?
+        get() = metadata.interfaceName?.let(::InterfaceName)
+    actual val memberName: MemberName?
+        get() = metadata.memberName?.let(::MemberName)
+    actual val sender: BusName?
+        get() = metadata.sender?.let(::BusName)
+    actual val path: ObjectPath?
+        get() = metadata.path?.let(::ObjectPath)
+    actual val destination: BusName?
+        get() = metadata.destination?.let(::BusName)
+    actual fun peekType(): PeekedType {
+        val next = payload.getOrNull(readIndex) ?: return PeekedType(null, null)
+        val signature = inferSignature(next) ?: return PeekedType(null, null)
+        return PeekedType(signature.first(), signature.drop(1).ifEmpty { null })
     }
     actual val isValid: Boolean
         get() = metadata.valid
@@ -172,21 +177,26 @@ actual sealed class Message {
         readIndex = 0
         enteredVariantValues.clear()
     }
-    actual fun getCredsPid(): Int = requireJvmCredential(metadata.credsPid, "Message.getCredsPid")
-    actual fun getCredsUid(): UInt = requireJvmCredential(metadata.credsUid, "Message.getCredsUid")
-    actual fun getCredsEuid(): UInt =
-        requireJvmCredential(metadata.credsEuid, "Message.getCredsEuid")
-    actual fun getCredsGid(): UInt = requireJvmCredential(metadata.credsGid, "Message.getCredsGid")
-    actual fun getCredsEgid(): UInt =
-        requireJvmCredential(metadata.credsEgid, "Message.getCredsEgid")
-    actual fun getCredsSupplementaryGids(): List<UInt> = requireJvmCredential(
-        metadata.credsSupplementaryGids,
-        "Message.getCredsSupplementaryGids"
-    )
-    actual fun getSELinuxContext(): String = requireJvmCredential(
-        metadata.selinuxContext,
-        "Message.getSELinuxContext"
-    )
+    actual val credsPid: Int
+        get() = requireJvmCredential(metadata.credsPid, "Message.credsPid")
+    actual val credsUid: UInt
+        get() = requireJvmCredential(metadata.credsUid, "Message.credsUid")
+    actual val credsEuid: UInt
+        get() = requireJvmCredential(metadata.credsEuid, "Message.credsEuid")
+    actual val credsGid: UInt
+        get() = requireJvmCredential(metadata.credsGid, "Message.credsGid")
+    actual val credsEgid: UInt
+        get() = requireJvmCredential(metadata.credsEgid, "Message.credsEgid")
+    actual val credsSupplementaryGids: List<UInt>
+        get() = requireJvmCredential(
+            metadata.credsSupplementaryGids,
+            "Message.credsSupplementaryGids"
+        )
+    actual val seLinuxContext: String
+        get() = requireJvmCredential(
+            metadata.selinuxContext,
+            "Message.seLinuxContext"
+        )
 }
 
 private fun inferSignature(value: Any?): String? = when (value) {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
@@ -230,9 +230,9 @@ private class StubJvmDbusProxy(
     ): PendingAsyncCall {
         val cancelled = AtomicBoolean(false)
         val pending = AtomicBoolean(true)
-        val interfaceName = message.getInterfaceName().orEmpty()
-        val methodName = message.getMemberName().orEmpty()
-        val path = message.getPath() ?: objectPath.value
+        val interfaceName = message.interfaceName?.value.orEmpty()
+        val methodName = message.memberName?.value.orEmpty()
+        val path = message.path?.value ?: objectPath.value
         thread(
             start = true,
             isDaemon = true,
@@ -320,13 +320,13 @@ private class StubJvmDbusObject(
         ) { emitSignal(it) }
 
     override fun emitSignal(message: Signal) {
-        val interfaceName = message.getInterfaceName()
+        val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "emitSignal failed: missing interface name")
-        val signalName = message.getMemberName()
+        val signalName = message.memberName?.value
             ?: throw createError(-1, "emitSignal failed: missing signal name")
-        val path = message.getPath() ?: objectPath.value
+        val path = message.path?.value ?: objectPath.value
         LocalJvmMatchBus.emit(
-            sender = message.getSender() ?: senderName,
+            sender = message.sender?.value ?: senderName,
             path = path,
             interfaceName = interfaceName,
             member = signalName,

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -901,11 +901,11 @@ private class PureJavaDbusProxy(
     }
 
     override fun callMethod(message: MethodCall): MethodReply {
-        val interfaceName = message.getInterfaceName()
+        val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "callMethod failed: missing interface name")
-        val methodName = message.getMemberName()
+        val methodName = message.memberName?.value
             ?: throw createError(-1, "callMethod failed: missing method name")
-        val path = message.getPath() ?: objectPath.value
+        val path = message.path?.value ?: objectPath.value
         val realConnection = connection
         if (realConnection != null) {
             val localDestination = resolveLocalDispatchDestination(realConnection)
@@ -1008,11 +1008,11 @@ private class PureJavaDbusProxy(
     }
 
     override fun callMethod(message: MethodCall, timeout: ULong): MethodReply {
-        val interfaceName = message.getInterfaceName()
+        val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "callMethod failed: missing interface name")
-        val methodName = message.getMemberName()
+        val methodName = message.memberName?.value
             ?: throw createError(-1, "callMethod failed: missing method name")
-        val path = message.getPath() ?: objectPath.value
+        val path = message.path?.value ?: objectPath.value
         val realConnection = connection
         if (realConnection != null) {
             val localDestination = resolveLocalDispatchDestination(realConnection)
@@ -1213,9 +1213,9 @@ private class PureJavaDbusProxy(
     ): PendingAsyncCall {
         val cancelled = AtomicBoolean(false)
         val pending = AtomicBoolean(true)
-        val interfaceName = message.getInterfaceName().orEmpty()
-        val methodName = message.getMemberName().orEmpty()
-        val path = message.getPath() ?: objectPath.value
+        val interfaceName = message.interfaceName?.value.orEmpty()
+        val methodName = message.memberName?.value.orEmpty()
+        val path = message.path?.value ?: objectPath.value
 
         thread(
             start = true,
@@ -1432,8 +1432,8 @@ private class PureJavaDbusObject(
             call.metadata = Message.Metadata(
                 interfaceName = propertiesInterfaceName,
                 memberName = "Set",
-                sender = inbound?.getSender(),
-                destination = inbound?.getDestination(),
+                sender = inbound?.sender?.value,
+                destination = inbound?.destination?.value,
                 path = objectPath.value,
                 valid = true,
                 empty = false
@@ -1690,8 +1690,8 @@ private class PureJavaDbusObject(
                     it.metadata = Message.Metadata(
                         interfaceName = interfaceName.value,
                         memberName = method.name.value,
-                        sender = inbound?.getSender(),
-                        destination = inbound?.getDestination(),
+                        sender = inbound?.sender?.value,
+                        destination = inbound?.destination?.value,
                         path = objectPath.value,
                         valid = true,
                         empty = args.isEmpty()
@@ -1752,11 +1752,11 @@ private class PureJavaDbusObject(
         ) { emitSignal(it) }
 
     override fun emitSignal(message: Signal) {
-        val interfaceName = message.getInterfaceName()
+        val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "emitSignal failed: missing interface name")
-        val signalName = message.getMemberName()
+        val signalName = message.memberName?.value
             ?: throw createError(-1, "emitSignal failed: missing signal name")
-        val path = message.getPath() ?: objectPath.value
+        val path = message.path?.value ?: objectPath.value
         // Prefer the declared signature (correct even for empty collections, which carry no
         // runtime element to infer from); fall back to value inference only when no usable
         // declared signature is available. Mirrors the method-call body path.
@@ -1765,7 +1765,7 @@ private class PureJavaDbusObject(
             message.declaredBodySignature.toString()
         ) { "emitSignal failed: unsupported signal payload type" }
         val args = message.payload.map(::toJavaSignalValue).toTypedArray()
-        val sender = message.getSender() ?: senderName ?: javaConnection?.uniqueNameOrNull()
+        val sender = message.sender?.value ?: senderName ?: javaConnection?.uniqueNameOrNull()
         val realConnection = javaConnection
         if (realConnection == null) {
             LocalJvmSignalBus.emit(sender, path, interfaceName, signalName, message.payload)

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
@@ -143,13 +143,13 @@ class JvmMessageSupportTest {
         val message = PlainMessage.createPlainMessage()
 
         val failures = listOf(
-            runCatching { message.getCredsPid() }.exceptionOrNull(),
-            runCatching { message.getCredsUid() }.exceptionOrNull(),
-            runCatching { message.getCredsEuid() }.exceptionOrNull(),
-            runCatching { message.getCredsGid() }.exceptionOrNull(),
-            runCatching { message.getCredsEgid() }.exceptionOrNull(),
-            runCatching { message.getCredsSupplementaryGids() }.exceptionOrNull(),
-            runCatching { message.getSELinuxContext() }.exceptionOrNull()
+            runCatching { message.credsPid }.exceptionOrNull(),
+            runCatching { message.credsUid }.exceptionOrNull(),
+            runCatching { message.credsEuid }.exceptionOrNull(),
+            runCatching { message.credsGid }.exceptionOrNull(),
+            runCatching { message.credsEgid }.exceptionOrNull(),
+            runCatching { message.credsSupplementaryGids }.exceptionOrNull(),
+            runCatching { message.seLinuxContext }.exceptionOrNull()
         )
 
         failures.forEach { failure ->
@@ -161,13 +161,13 @@ class JvmMessageSupportTest {
     fun credentialAccessors_withoutSenderCredentialsFailWithSdbusError() {
         val message = PlainMessage.createPlainMessage()
 
-        assertFailsWith<Error> { message.getCredsPid() }
-        assertFailsWith<Error> { message.getCredsUid() }
-        assertFailsWith<Error> { message.getCredsEuid() }
-        assertFailsWith<Error> { message.getCredsGid() }
-        assertFailsWith<Error> { message.getCredsEgid() }
-        assertFailsWith<Error> { message.getCredsSupplementaryGids() }
-        assertFailsWith<Error> { message.getSELinuxContext() }
+        assertFailsWith<Error> { message.credsPid }
+        assertFailsWith<Error> { message.credsUid }
+        assertFailsWith<Error> { message.credsEuid }
+        assertFailsWith<Error> { message.credsGid }
+        assertFailsWith<Error> { message.credsEgid }
+        assertFailsWith<Error> { message.credsSupplementaryGids }
+        assertFailsWith<Error> { message.seLinuxContext }
     }
 
     // Regression: D-Bus `ay` (e.g. a GATT characteristic value) arrives from dbus-java as

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -112,7 +112,7 @@ class JvmRealBusIntegrationTest {
         try {
             obj.emitInterfacesAddedSignal(listOf(childInterface))
             val message = withTimeout(2_000) { seen.await() }
-            assertEquals(managerPath.value, message.getPath())
+            assertEquals(managerPath, message.path)
         } finally {
             signalRegistration.release()
             proxy.release()
@@ -259,8 +259,8 @@ class JvmRealBusIntegrationTest {
         val proxy = createProxy(proxyConnection, service, objectPath)
         val signalRegistration = proxy.registerSignalHandler(interfaceName, signalName) { message ->
             if (!senderSeen.isCompleted) {
-                senderSeen.complete(message.getSender().orEmpty())
-                pidSeen.complete(message.getCredsPid())
+                senderSeen.complete(message.sender?.value.orEmpty())
+                pidSeen.complete(message.credsPid)
             }
         }
 

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmSignalPropertyUnsupportedTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmSignalPropertyUnsupportedTest.kt
@@ -43,7 +43,7 @@ class JvmSignalPropertyUnsupportedTest {
                 InterfaceName("org.freedesktop.DBus.Properties"),
                 SignalName("PropertiesChanged")
             ) { message ->
-                seenMember[0] = message.getMemberName()
+                seenMember[0] = message.memberName?.value
                 latch.countDown()
             }
             obj.emitPropertiesChangedSignal(iface)

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Message.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Message.native.kt
@@ -562,24 +562,29 @@ actual sealed class Message(
         isOk = true
     }
 
-    actual fun getInterfaceName(): String? = sd_bus_message_get_interface(msg)?.toKString()
+    actual val interfaceName: InterfaceName?
+        get() = sd_bus_message_get_interface(msg)?.toKString()?.let(::InterfaceName)
 
-    actual fun getMemberName(): String? = sd_bus_message_get_member(msg)?.toKString()
+    actual val memberName: MemberName?
+        get() = sd_bus_message_get_member(msg)?.toKString()?.let(::MemberName)
 
-    actual fun getSender(): String? = sd_bus_message_get_sender(msg)?.toKString()
+    actual val sender: BusName?
+        get() = sd_bus_message_get_sender(msg)?.toKString()?.let(::BusName)
 
-    actual fun getPath(): String? = sd_bus_message_get_path(msg)?.toKString()
+    actual val path: ObjectPath?
+        get() = sd_bus_message_get_path(msg)?.toKString()?.let(::ObjectPath)
 
-    actual fun getDestination(): String? = sd_bus_message_get_destination(msg)?.toKString()
+    actual val destination: BusName?
+        get() = sd_bus_message_get_destination(msg)?.toKString()?.let(::BusName)
 
-    actual fun peekType(): Pair<Char?, String?> = memScoped {
+    actual fun peekType(): PeekedType = memScoped {
         val typeSignature = cValuesOf(0.toByte()).getPointer(this)
         val contentsSignature = cValuesOf(interpretCPointer<ByteVar>(NULL)).getPointer(this)
         val r: Int = sd_bus_message_peek_type(msg, typeSignature, contentsSignature)
         sdbusRequire(r < 0, "Failed to peek message type", -r)
         val type = typeSignature[0].toInt().toChar().takeIf { r > 0 }
 
-        return type to contentsSignature[0]?.toKString()
+        return PeekedType(type, contentsSignature[0]?.toKString())
     }
 
     actual val isValid: Boolean
@@ -607,78 +612,85 @@ actual sealed class Message(
         sdbusRequire(r < 0, "Failed to rewind the message", -r)
     }
 
-    actual fun getCredsPid(): pid_t = memScoped {
-        val mask = SD_BUS_CREDS_PID or SD_BUS_CREDS_AUGMENT
-        val creds = getCreds(mask)
+    actual val credsPid: pid_t
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_PID or SD_BUS_CREDS_AUGMENT
+            val creds = getCreds(mask)
 
-        val pid = cValuesOf(0.convert<pid_t>()).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_pid(creds[0], pid)
-        sdbusRequire(r < 0, "Failed to get bus cred pid", -r)
-        return pid[0]
-    }
-
-    actual fun getCredsUid(): uid_t = memScoped {
-        val mask = SD_BUS_CREDS_UID or SD_BUS_CREDS_AUGMENT
-        val creds = getCreds(mask)
-
-        val uid = cValuesOf((-1).convert<uid_t>()).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_uid(creds[0], uid)
-        sdbusRequire(r < 0, "Failed to get bus cred uid", -r)
-        return uid[0]
-    }
-
-    actual fun getCredsEuid(): uid_t = memScoped {
-        val mask = SD_BUS_CREDS_EUID or SD_BUS_CREDS_AUGMENT
-        val creds = getCreds(mask)
-
-        val euid = cValuesOf((-1).convert<uid_t>()).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_euid(creds[0], euid)
-        sdbusRequire(r < 0, "Failed to get bus cred euid", -r)
-        return euid[0]
-    }
-
-    actual fun getCredsGid(): gid_t = memScoped {
-        val mask = SD_BUS_CREDS_GID or SD_BUS_CREDS_AUGMENT
-        val creds = getCreds(mask)
-
-        val gid = cValuesOf((-1).convert<gid_t>()).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_gid(creds[0], gid)
-        sdbusRequire(r < 0, "Failed to get bus cred gid", -r)
-        return gid[0]
-    }
-
-    actual fun getCredsEgid(): gid_t = memScoped {
-        val mask = SD_BUS_CREDS_EGID or SD_BUS_CREDS_AUGMENT
-        val creds = getCreds(mask)
-
-        val egid = cValuesOf((-1).convert<gid_t>()).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_egid(creds[0], egid)
-        sdbusRequire(r < 0, "Failed to get bus cred egid", -r)
-        return egid[0]
-    }
-
-    actual fun getCredsSupplementaryGids(): List<gid_t> = memScoped {
-        val mask = SD_BUS_CREDS_SUPPLEMENTARY_GIDS or SD_BUS_CREDS_AUGMENT
-        val creds = getCreds(mask)
-
-        val cGids = cValuesOf(interpretCPointer<gid_tVar>(NULL)).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_supplementary_gids(creds[0], cGids)
-        sdbusRequire(r < 0, "Failed to get bus cred supplementary gids", -r)
-
-        return List(r) {
-            cGids[0]!![it]
+            val pid = cValuesOf(0.convert<pid_t>()).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_pid(creds[0], pid)
+            sdbusRequire(r < 0, "Failed to get bus cred pid", -r)
+            return pid[0]
         }
-    }
 
-    actual fun getSELinuxContext(): String = memScoped {
-        val mask = SD_BUS_CREDS_AUGMENT or SD_BUS_CREDS_SELINUX_CONTEXT
-        val creds = getCreds(mask)
+    actual val credsUid: uid_t
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_UID or SD_BUS_CREDS_AUGMENT
+            val creds = getCreds(mask)
 
-        val cLabel = cValuesOf(interpretCPointer<ByteVar>(NULL)).getPointer(this)
-        val r = sdbus.sd_bus_creds_get_selinux_context(creds[0], cLabel)
-        sdbusRequire(r < 0, "Failed to get bus cred selinux context", -r)
-        return cLabel[0]?.toKString()!!
-    }
+            val uid = cValuesOf((-1).convert<uid_t>()).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_uid(creds[0], uid)
+            sdbusRequire(r < 0, "Failed to get bus cred uid", -r)
+            return uid[0]
+        }
+
+    actual val credsEuid: uid_t
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_EUID or SD_BUS_CREDS_AUGMENT
+            val creds = getCreds(mask)
+
+            val euid = cValuesOf((-1).convert<uid_t>()).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_euid(creds[0], euid)
+            sdbusRequire(r < 0, "Failed to get bus cred euid", -r)
+            return euid[0]
+        }
+
+    actual val credsGid: gid_t
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_GID or SD_BUS_CREDS_AUGMENT
+            val creds = getCreds(mask)
+
+            val gid = cValuesOf((-1).convert<gid_t>()).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_gid(creds[0], gid)
+            sdbusRequire(r < 0, "Failed to get bus cred gid", -r)
+            return gid[0]
+        }
+
+    actual val credsEgid: gid_t
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_EGID or SD_BUS_CREDS_AUGMENT
+            val creds = getCreds(mask)
+
+            val egid = cValuesOf((-1).convert<gid_t>()).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_egid(creds[0], egid)
+            sdbusRequire(r < 0, "Failed to get bus cred egid", -r)
+            return egid[0]
+        }
+
+    actual val credsSupplementaryGids: List<gid_t>
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_SUPPLEMENTARY_GIDS or SD_BUS_CREDS_AUGMENT
+            val creds = getCreds(mask)
+
+            val cGids = cValuesOf(interpretCPointer<gid_tVar>(NULL)).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_supplementary_gids(creds[0], cGids)
+            sdbusRequire(r < 0, "Failed to get bus cred supplementary gids", -r)
+
+            return List(r) {
+                cGids[0]!![it]
+            }
+        }
+
+    actual val seLinuxContext: String
+        get() = memScoped {
+            val mask = SD_BUS_CREDS_AUGMENT or SD_BUS_CREDS_SELINUX_CONTEXT
+            val creds = getCreds(mask)
+
+            val cLabel = cValuesOf(interpretCPointer<ByteVar>(NULL)).getPointer(this)
+            val r = sdbus.sd_bus_creds_get_selinux_context(creds[0], cLabel)
+            sdbusRequire(r < 0, "Failed to get bus cred selinux context", -r)
+            return cLabel[0]?.toKString()!!
+        }
 
     private fun MemScope.getCreds(mask: ULong): CPointer<CPointerVar<sd_bus_creds>> {
         val creds = cValuesOf(interpretCPointer<sd_bus_creds>(NULL)).getPointer(this)

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/MessageDecoder.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/MessageDecoder.kt
@@ -247,7 +247,7 @@ internal class NonSequentialListDecoder(private val baseDecoder: MessageDecoder)
     private var index = 0
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
-        if (baseDecoder.target.peekType().first == null) {
+        if (baseDecoder.target.peekType().type == null) {
             return CompositeDecoder.DECODE_DONE
         }
         return index++

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ObjectImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ObjectImpl.kt
@@ -422,7 +422,7 @@ internal class ObjectImpl(
                     vtable!!.obj!!.connection.getSdBusInterface()
                 )
 
-                val methodItem = findMethod(vtable, message.getMemberName()!!)
+                val methodItem = findMethod(vtable, message.memberName!!.value)
                 assert(methodItem != null)
 
                 methodItem!!.callback(message)

--- a/src/nativeTest/kotlin/integration/DBusGeneralTests.kt
+++ b/src/nativeTest/kotlin/integration/DBusGeneralTests.kt
@@ -64,7 +64,7 @@ class CppEventLoop : BaseTest() {
         val matchRule = "sender='$SERVICE_NAME',path='$OBJECT_PATH'"
         var matchingMessageReceived = atomic(false)
         val slot = globalProxyConnection.addMatch(matchRule) { msg: Message ->
-            if (msg.getPath() == OBJECT_PATH.value) {
+            if (msg.path == OBJECT_PATH) {
                 matchingMessageReceived.value = true
             }
         }
@@ -81,7 +81,7 @@ class CppEventLoop : BaseTest() {
         val matchingMessageReceived = atomic(false)
         val matchRuleInstalled = atomic(false)
         val slot = globalProxyConnection.addMatchAsync(matchRule, { msg: Message ->
-            if (msg.getPath() == OBJECT_PATH.value) {
+            if (msg.path == OBJECT_PATH) {
                 matchingMessageReceived.value = true
             }
         }, {
@@ -101,7 +101,7 @@ class CppEventLoop : BaseTest() {
         val matchRule = "sender='${SERVICE_NAME.value}',path='${OBJECT_PATH.value}'"
         val matchingMessageReceived = atomic(false)
         val slot = globalProxyConnection.addMatch(matchRule) { msg: Message ->
-            if (msg.getPath() == OBJECT_PATH.value) matchingMessageReceived.value = true
+            if (msg.path == OBJECT_PATH) matchingMessageReceived.value = true
         }
         slot.release()
 
@@ -119,7 +119,7 @@ class CppEventLoop : BaseTest() {
         try {
             con.enterEventLoopAsync()
             val callback = { msg: Message ->
-                if (msg.getPath() == OBJECT_PATH.value) {
+                if (msg.path == OBJECT_PATH) {
                     matchingMessageReceived.value = true
                 }
             }
@@ -148,7 +148,7 @@ class CppEventLoop : BaseTest() {
         val slot = globalProxyConnection.addMatchAsync(
             match = matchRule,
             callback = { msg: Message ->
-                if (msg.getMemberName() == "simpleSignal") {
+                if (msg.memberName?.value == "simpleSignal") {
                     numberOfMatchingMessages.value++
                 }
             },

--- a/src/nativeTest/kotlin/integration/TestAdaptor.kt
+++ b/src/nativeTest/kotlin/integration/TestAdaptor.kt
@@ -24,7 +24,6 @@
 
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.MemberName
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.Object
@@ -98,14 +97,14 @@ class TestAdaptor(connection: com.monkopedia.sdbus.Connection, path: ObjectPath)
         usleep(param * 1000u)
 
         methodCallMsg = obj.currentlyProcessedMessage
-        methodName = methodCallMsg!!.getMemberName()?.let(::MemberName)
+        methodName = methodCallMsg!!.memberName
 
         return param
     }
 
     override suspend fun doOperationAsync(param: UInt): UInt {
         methodCallMsg = obj.currentlyProcessedMessage
-        methodName = methodCallMsg!!.getMemberName()?.let(::MemberName)
+        methodName = methodCallMsg!!.memberName
 
         if (param == 0u) {
             // Don't sleep and return the result from this thread
@@ -170,7 +169,7 @@ class TestAdaptor(connection: com.monkopedia.sdbus.Connection, path: ObjectPath)
 
     override fun blocking(value: Boolean) {
         propertySetMessage = obj.currentlyProcessedMessage
-        propertySetSender = propertySetMessage!!.getSender()
+        propertySetSender = propertySetMessage!!.sender?.value
 
         blocking = value
     }

--- a/src/nativeTest/kotlin/integration/TestProxy.kt
+++ b/src/nativeTest/kotlin/integration/TestProxy.kt
@@ -83,7 +83,7 @@ class TestProxy private constructor(proxy: Proxy) : IntegrationTestsProxy(proxy)
 
     override fun onSimpleSignal() {
         signalMsg = proxy.currentlyProcessedMessage
-        signalName = signalMsg!!.getMemberName()?.let(::SignalName)
+        signalName = signalMsg!!.memberName
 
         gotSimpleSignal.value = true
     }


### PR DESCRIPTION
PR 3 of the 1.0 ABI wave. Implements the owner decision commented on #44 (2026-06-10): Option 2 — full idiomization of the `Message` accessors.

Fixes #44.

## What changed

On `sealed class Message` (expect + jvm/native actuals), all pure `getX()` accessors become `val` properties, with name-shaped returns using the library's existing value classes:

| Before | After |
|---|---|
| `getDestination(): String?` | `val destination: BusName?` |
| `getSender(): String?` | `val sender: BusName?` |
| `getInterfaceName(): String?` | `val interfaceName: InterfaceName?` |
| `getMemberName(): String?` | `val memberName: MemberName?` |
| `getPath(): String?` | `val path: ObjectPath?` |
| `getSELinuxContext(): String` | `val seLinuxContext: String` |
| `getCredsPid(): Int` | `val credsPid: Int` |
| `getCredsUid()/getCredsEuid()/getCredsGid()/getCredsEgid(): UInt` | `val credsUid/credsEuid/credsGid/credsEgid: UInt` |
| `getCredsSupplementaryGids(): List<UInt>` | `val credsSupplementaryGids: List<UInt>` |
| `peekType(): Pair<Char?, String?>` | `fun peekType(): PeekedType` |

- The raw string is wrapped at the accessor boundary; `null` stays `null`. Creds accessors keep primitive types per the decision (no uid/gid value classes).
- `PeekedType` is a new small named result type (`val type: Char?`, `val contents: String?`) replacing the anonymous `Pair` — per the #45 precedent it is a plain class (not a data class): it is a transient peek result, not a value type, so no `copy`/`componentN`/structural equality is exposed in the ABI. `peekType()` stays a function since it performs a wire-cursor peek, not a stable attribute read.
- `BREAKING CHANGE`: source-breaking for any consumer of these accessors; behavior is 100% unchanged (accessor shape only).

## Scope

- Message hierarchy only (`Message` + its subclasses, which inherit these accessors — none duplicated them). Connection/Proxy/StandardInterfaces `getX` methods are untouched; those belong to #49's PR.
- `Signal.setDestination(String)` left alone (mutator, not a pure accessor; #49 / later wave can address it if desired).
- All call sites updated across commonMain/jvmMain/nativeMain, common/jvm/native tests, and cross_test. compile_test, stress_test, samples, codegen, plugin had no usages.
- Minor flag: the JVM credential-unavailable error strings were renamed to match the new property names (e.g. `Message.getCredsPid failed: ...` → `Message.credsPid failed: ...`).

## API dump delta

`api/sdbus-kotlin.api` / `api/sdbus-kotlin.klib.api` (apiDump committed):
- klib: all 13 `getX()` functions removed, replaced by the corresponding `val` properties with value-class types; `peekType(): kotlin/Pair<...>` → `peekType(): com.monkopedia.sdbus/PeekedType`; new `final class com.monkopedia.sdbus/PeekedType`.
- JVM: getter names mostly stable (Kotlin property getters), but the value-class returns mangle the name-shaped getters (`getDestination-wEJio8Y` etc.), `getSELinuxContext` → `getSeLinuxContext`, `peekType` now returns `PeekedType`; `PeekedType` class added. Nothing else changed.

## Verification (JAVA_HOME=java-21-openjdk)

- `./gradlew ktlintFormat` + `./gradlew apiDump` (diff reviewed, as above)
- `./gradlew ktlintCheck apiCheck` — pass
- `dbus-run-session -- ./gradlew jvmTest` — pass
- `./gradlew compileKotlinLinuxX64 compileTestKotlinLinuxX64 :codegen:test :plugin:test :compile_test:build :cross_test:compileTestKotlinJvm :cross_test:compileTestKotlinLinuxX64 :stress_test:compileTestKotlinJvm` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)