### PR TITLE
1.0 ABI: rename PropertyDelegate flow()/flowOrNull() to values()/valuesOrNull() (#46)

### DIFF
--- a/api/sdbus-kotlin.api
+++ b/api/sdbus-kotlin.api
@@ -425,8 +425,6 @@ public class com/monkopedia/sdbus/PropertyDelegate : kotlin/properties/ReadOnlyP
 	public final fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun changes ()Lkotlinx/coroutines/flow/Flow;
 	public final fun changesOrNull ()Lkotlinx/coroutines/flow/Flow;
-	public final fun flow ()Lkotlinx/coroutines/flow/Flow;
-	public final fun flowOrNull ()Lkotlinx/coroutines/flow/Flow;
 	public final fun get ()Ljava/lang/Object;
 	public final fun getInterfaceName-DgtVVXE ()Ljava/lang/String;
 	protected final fun getModule ()Lkotlinx/serialization/modules/SerializersModule;
@@ -437,6 +435,8 @@ public class com/monkopedia/sdbus/PropertyDelegate : kotlin/properties/ReadOnlyP
 	protected final fun getSignature ()Lcom/monkopedia/sdbus/SdbusSig;
 	protected final fun getType ()Lkotlinx/serialization/KSerializer;
 	public fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun values ()Lkotlinx/coroutines/flow/Flow;
+	public final fun valuesOrNull ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/monkopedia/sdbus/PropertyGetReply : com/monkopedia/sdbus/Message {

--- a/api/sdbus-kotlin.klib.api
+++ b/api/sdbus-kotlin.klib.api
@@ -659,10 +659,10 @@ open class <#A: kotlin/Any?, #B: kotlin/Any> com.monkopedia.sdbus/PropertyDelega
 
     final fun changes(): kotlinx.coroutines.flow/Flow<#B> // com.monkopedia.sdbus/PropertyDelegate.changes|changes(){}[0]
     final fun changesOrNull(): kotlinx.coroutines.flow/Flow<#B?> // com.monkopedia.sdbus/PropertyDelegate.changesOrNull|changesOrNull(){}[0]
-    final fun flow(): kotlinx.coroutines.flow/Flow<#B> // com.monkopedia.sdbus/PropertyDelegate.flow|flow(){}[0]
-    final fun flowOrNull(): kotlinx.coroutines.flow/Flow<#B?> // com.monkopedia.sdbus/PropertyDelegate.flowOrNull|flowOrNull(){}[0]
     final fun get(): #B // com.monkopedia.sdbus/PropertyDelegate.get|get(){}[0]
     final fun getOrNull(): #B? // com.monkopedia.sdbus/PropertyDelegate.getOrNull|getOrNull(){}[0]
+    final fun values(): kotlinx.coroutines.flow/Flow<#B> // com.monkopedia.sdbus/PropertyDelegate.values|values(){}[0]
+    final fun valuesOrNull(): kotlinx.coroutines.flow/Flow<#B?> // com.monkopedia.sdbus/PropertyDelegate.valuesOrNull|valuesOrNull(){}[0]
     final suspend fun await(): #B // com.monkopedia.sdbus/PropertyDelegate.await|await(){}[0]
     open fun getValue(#A, kotlin.reflect/KProperty<*>): #B // com.monkopedia.sdbus/PropertyDelegate.getValue|getValue(1:0;kotlin.reflect.KProperty<*>){}[0]
 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
@@ -128,8 +128,17 @@ inline fun <R, reified T : Any> Proxy.mutableDelegate(
  * A read-only Kotlin property delegate backed by a D-Bus property.
  *
  * Reading the delegated property issues a D-Bus `Get`. The delegate also offers convenience
- * accessors ([getOrNull], [await]) and reactive observation of changes ([changes], [flow],
- * [changesOrNull], [flowOrNull]). Obtain one via [Proxy.propDelegate].
+ * accessors ([getOrNull], [await]) and reactive observation of the property ([changes], [values],
+ * [changesOrNull], [valuesOrNull]). Obtain one via [Proxy.propDelegate].
+ *
+ * The observation methods come in two families:
+ * - [changes]/[changesOrNull] emit change events only — nothing is emitted until the property
+ *   changes after collection starts.
+ * - [values]/[valuesOrNull] emit the current value first, then all subsequent changes.
+ *
+ * Each family has a throwing and a nullable variant: [get], [changes] and [values] surface a
+ * missing/invalidated property as an exception or by dropping the event, while [getOrNull],
+ * [changesOrNull] and [valuesOrNull] represent it as `null`.
  *
  * @property interfaceName Interface that declares the property
  * @property propertyName Name of the property
@@ -149,15 +158,19 @@ open class PropertyDelegate<R, T : Any>(
     override fun getValue(thisRef: R, property: KProperty<*>): T = get()
 
     /**
-     * Get the current value of the property.
+     * Gets the current value of the property.
+     *
+     * @throws [com.monkopedia.sdbus.Error] in case of failure, including when the property
+     * doesn't currently exist (use [getOrNull] for a null-returning variant)
      */
     fun get(): T = proxy.callMethod<Variant>(DBUS_PROPERTIES_INTERFACE_NAME, MethodName("Get")) {
         call(interfaceName, propertyName)
     }.get(type, module, signature)
 
     /**
-     * Gets the current value of the property, however if the property doesn't currently exist,
-     * returns null rather than throwing.
+     * Gets the current value of the property, however if the property doesn't currently exist
+     * (`org.freedesktop.DBus.Error.InvalidArgs`), returns null rather than throwing. Any other
+     * [com.monkopedia.sdbus.Error] is still thrown.
      */
     fun getOrNull(): T? = try {
         get()
@@ -175,8 +188,13 @@ open class PropertyDelegate<R, T : Any>(
     suspend fun await(): T = getOrNull() ?: changesOrNull().filterNotNull().first()
 
     /**
-     * Produces a flow that observes the properties changed signal of a [PropertiesProxy]
-     * and will emit the new values for this property when it has changed.
+     * Produces a flow that observes the `PropertiesChanged` signal and emits the new value of
+     * this property each time it changes.
+     *
+     * This is a change-event stream only: nothing is emitted until the property changes after
+     * collection starts (use [values] to also receive the current value first), and signals
+     * that merely invalidate the property (without carrying a new value) are dropped (use
+     * [changesOrNull] to observe invalidations as `null`).
      */
     fun changes(): Flow<T> = proxy.signalFlow<PropertiesChange>(
         DBUS_PROPERTIES_INTERFACE_NAME,
@@ -189,7 +207,12 @@ open class PropertyDelegate<R, T : Any>(
     }
 
     /**
-     * Like [changes] but also will emit null whenever the property has been invalidated.
+     * Like [changes] but also emits `null` whenever the property has been invalidated (i.e. it
+     * appears in the `invalidatedProperties` of a `PropertiesChanged` signal), instead of
+     * dropping the event.
+     *
+     * Like [changes], this emits change events only; use [valuesOrNull] to also receive the
+     * current value first.
      */
     fun changesOrNull(): Flow<T?> = proxy.signalFlow<PropertiesChange>(
         DBUS_PROPERTIES_INTERFACE_NAME,
@@ -204,14 +227,22 @@ open class PropertyDelegate<R, T : Any>(
     }
 
     /**
-     * Emits all the values from [changes] but also emits value from [get] at start.
+     * Produces a flow of all values of the property: the current value (from [get]) is emitted
+     * first when collection starts, followed by every subsequent change (from [changes]).
+     *
+     * Because the initial emission uses [get], collecting this flow throws
+     * [com.monkopedia.sdbus.Error] if the property doesn't currently exist; use [valuesOrNull]
+     * for a null-emitting variant. Use [changes] to observe change events only, without the
+     * initial value.
      */
-    fun flow(): Flow<T> = changes().onStart { emit(get()) }
+    fun values(): Flow<T> = changes().onStart { emit(get()) }
 
     /**
-     * Emits all the values from [changesOrNull] but also emits value from [getOrNull] at start.
+     * Like [values] but null-safe: the current value (from [getOrNull], `null` if the property
+     * doesn't currently exist) is emitted first when collection starts, followed by every
+     * subsequent change (from [changesOrNull], which emits `null` on invalidation).
      */
-    fun flowOrNull(): Flow<T?> = changesOrNull().onStart { emit(getOrNull()) }
+    fun valuesOrNull(): Flow<T?> = changesOrNull().onStart { emit(getOrNull()) }
 
     @Serializable
     private data class PropertiesChange(


### PR DESCRIPTION
Implements the owner-approved decision on #46 (2026-06-10): keep both observation semantics on `PropertyDelegate`, rename for contrast.

## Changes

- `flow(): Flow<T>` → **`values(): Flow<T>`** — semantics unchanged: `changes().onStart { emit(get()) }`, i.e. current value first, then changes.
- `flowOrNull(): Flow<T?>` → **`valuesOrNull(): Flow<T?>`** — semantics unchanged: `changesOrNull().onStart { emit(getOrNull()) }`.
- `changes()` / `changesOrNull()` keep their names — they accurately say "change events only".
- Documentation pass on the whole accessor family:
  - `changes` vs `values` distinction made explicit on all four flow methods (change events only vs current-value-first).
  - Throwing-vs-null contract documented: `get()`/`values()` throw when the property is absent; `getOrNull()` returns null on `org.freedesktop.DBus.Error.InvalidArgs` (other errors still thrown); `changes()` drops invalidation events; `changesOrNull()` emits `null` on invalidation.

**BREAKING CHANGE:** `PropertyDelegate.flow()/flowOrNull()` renamed to `values()/valuesOrNull()`; `changes()/changesOrNull()` unchanged. Behavior is 100% identical — rename + docs only.

## API dump delta

Exactly four lines in each of `sdbus-kotlin.api` / `sdbus-kotlin.klib.api`: `flow`/`flowOrNull` removed, `values`/`valuesOrNull` added. Nothing else.

## Call sites

No call sites existed outside the definitions — no tests, samples (incl. bluez-scan), or generated code use `flow()`/`flowOrNull()`.

## Verification (JAVA_HOME=java-21-openjdk)

- `ktlintFormat` + `apiDump` (delta as above)
- `ktlintCheck apiCheck` — pass
- `dbus-run-session -- ./gradlew jvmTest` — pass
- `compileKotlinLinuxX64 compileTestKotlinLinuxX64 :codegen:test :plugin:test :compile_test:build :cross_test:compileTestKotlinJvm :stress_test:compileTestKotlinJvm` — pass

Fixes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)