### PR TITLE
JVM parity: strict reply deserialization, call-after-release throws, errno error names (#56)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -228,12 +228,14 @@ class FailurePathParityTest {
     // is time-bounded so a hang in the known native-teardown path surfaces as a deterministic
     // test failure rather than an indefinitely stuck suite.
     //
-    // NOTE: this intentionally does NOT assert that a *subsequent* call on the released proxy
-    // throws. The two backends diverge there (the native backend rejects the call; the pure-JVM
-    // backend currently still services it), so a "call-after-release fails" assertion is not a
-    // parity property today -- see the PR description.
+    // This also asserts the sub-case that was scoped down when this suite landed (PR #54) and
+    // restored by the #56 decision: a *subsequent* call on the released proxy connection must
+    // throw on BOTH backends, never be silently serviced. The native backend guards every
+    // post-release operation with require(!released) { "Connection has already been released" }
+    // (ConnectionImpl.checkNotReleased); the JVM backend now guards its in-process dispatch
+    // short circuit with the same exception type and message.
     @Test
-    fun proxyConnectionTeardown_completesCleanly() = runBlocking {
+    fun proxyConnectionTeardown_completesCleanly_andCallAfterReleaseFails() = runBlocking {
         val ids = uniqueFixtureIds("teardownClean")
         val serverConnection = createBusConnection(ids.service)
         val proxyConnection = createBusConnection()
@@ -262,8 +264,19 @@ class FailurePathParityTest {
             withTimeout(5_000) {
                 proxyConnection.stopEventLoop()
             }
-            proxy.release()
             proxyConnection.release()
+
+            // A call after the proxy's connection has been released must throw on both
+            // backends, not be serviced. The per-call timeout bounds the failure mode where
+            // a regressed backend would instead try to perform the call.
+            val thrown = assertFailsWith<IllegalArgumentException> {
+                proxy.callMethod<Int>(ids.iface, MethodName("Echo")) {
+                    call(6)
+                    timeout = 2_000.milliseconds
+                }
+            }
+            assertEquals("Connection has already been released", thrown.message)
+            proxy.release()
         } finally {
             withTimeout(5_000) {
                 serverConnection.stopEventLoop()

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TypeMatrixRoundTripTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TypeMatrixRoundTripTest.kt
@@ -1,5 +1,6 @@
 package com.monkopedia.sdbus.integration
 
+import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.ObjectPath
@@ -15,6 +16,7 @@ import com.monkopedia.sdbus.method
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.serialization.Serializable
 
@@ -362,5 +364,52 @@ class TypeMatrixRoundTripTest {
         val sent = Variant(mapOf("k" to "v"))
         val received = roundTrip("variantDict", sent)
         assertEquals(mapOf("k" to "v"), received.get<Map<String, String>>())
+    }
+
+    // --- Signature-mismatch strictness (issue #56) -----------------------------------------------
+
+    @Serializable
+    private data class IntPair(val first: Int, val second: Int)
+
+    // Restores the failure-path sub-case dropped in PR #54: deserializing a reply whose actual
+    // signature is a single Int (i) into an expected struct type (ii) must be REJECTED on both
+    // backends rather than silently returning a value. The native backend fails entering the
+    // struct container with -ENXIO (System.Error.ENXIO); the JVM deserializer enforces the same
+    // contract with the same error name.
+    @Test
+    fun mismatchedReply_intIntoStruct_throwsOnBothBackends() {
+        val ids = uniqueFixtureIds("mismatch")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        // The server's Echo is declared and replies with a single Int (signature "i") ...
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("Echo")) {
+                call { input: Int -> input }
+            }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(
+            proxyConnection,
+            ids.service,
+            ids.path,
+            runEventLoopThread = false
+        )
+
+        try {
+            // ... while the client deserializes the reply as a struct (signature "(ii)").
+            val thrown = assertFailsWith<Error> {
+                proxy.callMethod<IntPair>(ids.iface, MethodName("Echo")) {
+                    call(7)
+                }
+            }
+            assertEquals("System.Error.ENXIO", thrown.name)
+        } finally {
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
     }
 }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Error.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Error.jvm.kt
@@ -1,4 +1,72 @@
 package com.monkopedia.sdbus
 
-internal actual fun createError(errNo: Int, customMsg: String): Error =
-    Error("jvm.errno.$errNo", customMsg)
+private const val DBUS_ERROR_PREFIX = "org.freedesktop.DBus.Error."
+
+private class ErrnoMapping(val name: String, val description: String)
+
+// errno -> (D-Bus error name, strerror text), mirroring sd-bus's sd_bus_error_set_errno
+// (bus_error_name_from_errno + strerror) so that the JVM backend produces the same error
+// names and message suffixes as the native backend for the same errno values.
+private val errnoMappings: Map<Int, ErrnoMapping> = mapOf(
+    // EPERM
+    1 to ErrnoMapping("${DBUS_ERROR_PREFIX}AccessDenied", "Operation not permitted"),
+    // ENOENT
+    2 to ErrnoMapping("${DBUS_ERROR_PREFIX}FileNotFound", "No such file or directory"),
+    // ESRCH
+    3 to ErrnoMapping("${DBUS_ERROR_PREFIX}UnixProcessIdUnknown", "No such process"),
+    // EIO
+    5 to ErrnoMapping("${DBUS_ERROR_PREFIX}IOError", "Input/output error"),
+    // ENXIO
+    6 to ErrnoMapping("System.Error.ENXIO", "No such device or address"),
+    // ENOMEM
+    12 to ErrnoMapping("${DBUS_ERROR_PREFIX}NoMemory", "Cannot allocate memory"),
+    // EACCES
+    13 to ErrnoMapping("${DBUS_ERROR_PREFIX}AccessDenied", "Permission denied"),
+    // EBUSY
+    16 to ErrnoMapping("System.Error.EBUSY", "Device or resource busy"),
+    // EEXIST
+    17 to ErrnoMapping("${DBUS_ERROR_PREFIX}FileExists", "File exists"),
+    // EINVAL
+    22 to ErrnoMapping("${DBUS_ERROR_PREFIX}InvalidArgs", "Invalid argument"),
+    // EBADR
+    53 to ErrnoMapping("System.Error.EBADR", "Invalid request descriptor"),
+    // ENODATA
+    61 to ErrnoMapping("System.Error.ENODATA", "No data available"),
+    // EBADMSG
+    74 to ErrnoMapping("${DBUS_ERROR_PREFIX}InconsistentMessage", "Bad message"),
+    // EOPNOTSUPP
+    95 to ErrnoMapping("${DBUS_ERROR_PREFIX}NotSupported", "Operation not supported"),
+    // EADDRINUSE
+    98 to ErrnoMapping("${DBUS_ERROR_PREFIX}AddressInUse", "Address already in use"),
+    // ECONNRESET
+    104 to ErrnoMapping("${DBUS_ERROR_PREFIX}Disconnected", "Connection reset by peer"),
+    // ENOBUFS
+    105 to ErrnoMapping("${DBUS_ERROR_PREFIX}LimitsExceeded", "No buffer space available"),
+    // ENOTCONN
+    107 to ErrnoMapping("System.Error.ENOTCONN", "Transport endpoint is not connected"),
+    // ETIMEDOUT
+    110 to ErrnoMapping("${DBUS_ERROR_PREFIX}Timeout", "Connection timed out"),
+    // EHOSTUNREACH
+    113 to ErrnoMapping("System.Error.EHOSTUNREACH", "No route to host")
+)
+
+/**
+ * Mirrors the native [createError] (Error.native.kt), which delegates to sd-bus's
+ * `sd_bus_error_set_errno`: well-known errnos map to real D-Bus error names (e.g.
+ * EINVAL -> org.freedesktop.DBus.Error.InvalidArgs), unmapped-but-named errnos to
+ * `System.Error.<ERRNO_NAME>`, unknown values to org.freedesktop.DBus.Error.Failed,
+ * and the message is `"$customMsg (<strerror text>)"`. Keeping the same mapping on
+ * the JVM makes error names a cross-backend contract instead of a backend detail.
+ */
+internal actual fun createError(errNo: Int, customMsg: String): Error {
+    // sd_bus_error_set_errno accepts negated errnos (e.g. -EINVAL) and takes the absolute value.
+    val errno = if (errNo < 0) -errNo else errNo
+    if (errno == 0) {
+        // sd_bus_error_set_errno(0) leaves the error unset; the native createError then falls
+        // back to "$errNo" as the name and an empty strerror text.
+        return Error("$errNo", "$customMsg ()")
+    }
+    val mapping = errnoMappings[errno]
+        ?: ErrnoMapping("${DBUS_ERROR_PREFIX}Failed", "Unknown error $errno")
+    return Error(mapping.name, "$customMsg (${mapping.description})")
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -237,24 +237,35 @@ private fun inferSignature(value: Any?): String? = when (value) {
 
 private fun isSignatureCompatible(expected: String, actual: String): Boolean {
     if (expected == actual) return true
-    if (expected == "v" && actual.startsWith("v")) return true
-    return false
+    // Containers are compared by their top-level type class only: value-based inference
+    // cannot reliably reconstruct nested signatures (an empty list infers as just "a", an
+    // empty dict as "a{}", and dict/variant element types come from the first runtime
+    // value), so element types are deliberately not enforced here.
+    return when (expected.firstOrNull()) {
+        'v' -> actual.startsWith("v")
+        'a' -> actual.startsWith("a")
+        '(' -> actual.startsWith("(")
+        else -> false
+    }
 }
 
-private fun shouldEnforceSignature(expected: String): Boolean = when (expected) {
-    "b",
-    "y",
-    "n",
-    "q",
-    "i",
-    "u",
-    "x",
-    "t",
-    "d",
-    "s",
-    "o",
-    "g",
-    "h" -> true
+private fun shouldEnforceSignature(expected: String): Boolean = when (expected.firstOrNull()) {
+    'b',
+    'y',
+    'n',
+    'q',
+    'i',
+    'u',
+    'x',
+    't',
+    'd',
+    's',
+    'o',
+    'g',
+    'h',
+    'a',
+    '(',
+    'v' -> true
 
     else -> false
 }
@@ -537,8 +548,10 @@ internal actual fun <T : Any> Message.deserialize(
         shouldEnforceSignature(expectedSig) &&
         !isSignatureCompatible(expectedSig, actualSig)
     ) {
+        // ENXIO: the native backend surfaces a signature mismatch as -ENXIO from
+        // sd_bus_message_enter_container / read_basic, i.e. Error("System.Error.ENXIO", ...).
         throw createError(
-            -1,
+            6,
             "Message.deserialize failed: signature mismatch expected=$expectedSig actual=$actualSig"
         )
     }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -107,7 +107,8 @@ internal class PureJavaDbusBackend(private val fallbackBackend: JvmDbusBackend) 
             javaConnection?.javaConnection,
             destination,
             objectPath,
-            runCatching { connection.uniqueName.value }.getOrNull()
+            runCatching { connection.uniqueName.value }.getOrNull(),
+            isConnectionReleased = { javaConnection?.isReleased() == true }
         )
     }
 
@@ -776,6 +777,9 @@ private class PureJavaDbusConnection(internal val javaConnection: AbstractConnec
     JvmDbusConnection {
     private var timeout: Duration = Duration.ZERO
     private val localUniqueName: String = javaConnection.uniqueNameOrNull().orEmpty()
+    private val released = AtomicBoolean(false)
+
+    fun isReleased(): Boolean = released.get()
 
     init {
         LocalJvmServiceRegistry.registerLocalUniqueName(localUniqueName)
@@ -858,6 +862,7 @@ private class PureJavaDbusConnection(internal val javaConnection: AbstractConnec
     }
 
     override fun release(): Unit = run {
+        if (!released.compareAndSet(false, true)) return@run
         LocalJvmServiceRegistry.unregisterLocalUniqueName(localUniqueName)
         javaConnection.disconnect()
     }
@@ -867,7 +872,8 @@ private class PureJavaDbusProxy(
     private val connection: AbstractConnection?,
     private val destination: ServiceName,
     private val objectPath: ObjectPath,
-    private val callerName: String?
+    private val callerName: String?,
+    private val isConnectionReleased: () -> Boolean = { false }
 ) : JvmDbusProxy {
     private fun invalidReply(path: String, interfaceName: String, methodName: String): MethodReply =
         methodReplyFrom(
@@ -886,6 +892,21 @@ private class PureJavaDbusProxy(
     override fun currentlyProcessedMessage(): Message =
         JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
 
+    // A call made after the proxy's connection has been released must fail like it does on
+    // the native backend instead of being silently serviced via the in-process
+    // static-dispatch short circuit. Native parity: ConnectionImpl guards every
+    // post-release operation with require(!released) { "Connection has already been
+    // released" }, and a connection that dropped without an explicit release surfaces
+    // -ENOTCONN from sd_bus_call (Error("System.Error.ENOTCONN", ...)).
+    private fun requireConnectionUsable() {
+        require(!isConnectionReleased()) { "Connection has already been released" }
+        val realConnection = connection ?: return
+        if (!realConnection.isConnected) {
+            // ENOTCONN, mirroring the native error name System.Error.ENOTCONN.
+            throw createError(107, "callMethod failed: connection is not connected")
+        }
+    }
+
     override fun createMethodCall(
         interfaceName: InterfaceName,
         methodName: MethodName
@@ -901,6 +922,7 @@ private class PureJavaDbusProxy(
     }
 
     override fun callMethod(message: MethodCall): MethodReply {
+        requireConnectionUsable()
         val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "callMethod failed: missing interface name")
         val methodName = message.memberName?.value
@@ -1008,6 +1030,7 @@ private class PureJavaDbusProxy(
     }
 
     override fun callMethod(message: MethodCall, timeout: ULong): MethodReply {
+        requireConnectionUsable()
         val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "callMethod failed: missing interface name")
         val methodName = message.memberName?.value

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCreateErrorParityTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCreateErrorParityTest.kt
@@ -1,0 +1,119 @@
+package com.monkopedia.sdbus
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the JVM [createError] errno mapping to the output of the native backend, where
+ * `sd_bus_error_set_errno` maps errnos to real D-Bus error names and formats the message as
+ * `"$customMsg (<strerror text>)"`. The expectations below are the exact name/message pairs
+ * the native createError produces for the same inputs (issue #56 / #40).
+ */
+class JvmCreateErrorParityTest {
+
+    private fun assertError(errNo: Int, expectedName: String, expectedMessage: String) {
+        val error = createError(errNo, "Test failed")
+        assertEquals(expectedName, error.name, "name for errno $errNo")
+        assertEquals(expectedMessage, error.errorMessage, "message for errno $errNo")
+    }
+
+    @Test
+    fun einval_mapsToInvalidArgs() = assertError(
+        22,
+        "org.freedesktop.DBus.Error.InvalidArgs",
+        "Test failed (Invalid argument)"
+    )
+
+    @Test
+    fun eacces_mapsToAccessDenied() = assertError(
+        13,
+        "org.freedesktop.DBus.Error.AccessDenied",
+        "Test failed (Permission denied)"
+    )
+
+    @Test
+    fun eperm_mapsToAccessDenied() = assertError(
+        1,
+        "org.freedesktop.DBus.Error.AccessDenied",
+        "Test failed (Operation not permitted)"
+    )
+
+    @Test
+    fun enomem_mapsToNoMemory() = assertError(
+        12,
+        "org.freedesktop.DBus.Error.NoMemory",
+        "Test failed (Cannot allocate memory)"
+    )
+
+    @Test
+    fun etimedout_mapsToTimeout() = assertError(
+        110,
+        "org.freedesktop.DBus.Error.Timeout",
+        "Test failed (Connection timed out)"
+    )
+
+    @Test
+    fun enoent_mapsToFileNotFound() = assertError(
+        2,
+        "org.freedesktop.DBus.Error.FileNotFound",
+        "Test failed (No such file or directory)"
+    )
+
+    @Test
+    fun enxio_fallsBackToSystemErrorName() = assertError(
+        6,
+        "System.Error.ENXIO",
+        "Test failed (No such device or address)"
+    )
+
+    @Test
+    fun ebusy_fallsBackToSystemErrorName() = assertError(
+        16,
+        "System.Error.EBUSY",
+        "Test failed (Device or resource busy)"
+    )
+
+    @Test
+    fun enodata_fallsBackToSystemErrorName() = assertError(
+        61,
+        "System.Error.ENODATA",
+        "Test failed (No data available)"
+    )
+
+    @Test
+    fun enotconn_fallsBackToSystemErrorName() = assertError(
+        107,
+        "System.Error.ENOTCONN",
+        "Test failed (Transport endpoint is not connected)"
+    )
+
+    @Test
+    fun econnreset_mapsToDisconnected() = assertError(
+        104,
+        "org.freedesktop.DBus.Error.Disconnected",
+        "Test failed (Connection reset by peer)"
+    )
+
+    // sd_bus_error_set_errno takes the absolute value, so -1 behaves as EPERM. This is the
+    // errno most internal JVM-backend failures are raised with.
+    @Test
+    fun minusOne_behavesAsEperm() = assertError(
+        -1,
+        "org.freedesktop.DBus.Error.AccessDenied",
+        "Test failed (Operation not permitted)"
+    )
+
+    @Test
+    fun negatedErrno_behavesAsPositive() = assertError(
+        -22,
+        "org.freedesktop.DBus.Error.InvalidArgs",
+        "Test failed (Invalid argument)"
+    )
+
+    @Test
+    fun unknownErrno_mapsToFailed() = assertError(
+        4095,
+        "org.freedesktop.DBus.Error.Failed",
+        "Test failed (Unknown error 4095)"
+    )
+}


### PR DESCRIPTION
Implements the owner decision on #56 (2026-06-10): tighten the pure-JVM backend to match the native sd-bus backend on three failure paths. Native is the reference implementation. **Behavior-only — no public API/ABI change; the `api/*.api` dumps are untouched (`apiDump` verified as a no-op).**

## Fix 1 — strict reply deserialization (`src/jvmMain/.../Message.jvm.kt`)

The JVM deserializer only enforced signature compatibility for basic expected types, so a reply whose actual signature was `i` silently "deserialized" into an expected struct `(ii)` (the erased generic cast can't catch it). Enforcement now also covers container-shaped expected types (`a`, `(`, `v`), compared by top-level type class only — value-based inference cannot reconstruct nested signatures (an empty list infers as `a`, dict/variant element types come from the first runtime value), so element types are deliberately not over-enforced.

The mismatch now throws `Error("System.Error.ENXIO", ...)` — the exact name native produces (`sd_bus_message_enter_container` returns `-ENXIO` on a struct/body mismatch; verified empirically against libsystemd).

**Restored test** (the sub-case dropped in PR #54): `TypeMatrixRoundTripTest.mismatchedReply_intIntoStruct_throwsOnBothBackends` — server replies `i`, client deserializes `(ii)`, asserts `assertFailsWith<Error>` **and** the shared `System.Error.ENXIO` name on both backends.

## Fix 2 — call-after-release throws (`src/jvmMain/.../PureJavaDbusBackend.kt`)

After `stopEventLoop` + `release()`, the JVM proxy kept servicing calls through the in-process static-dispatch short circuit. `PureJavaDbusConnection` now tracks a released flag (making `release()` idempotent too, like native), and `PureJavaDbusProxy` guards both `callMethod` paths with `require(!released) { "Connection has already been released" }` — the **exact exception type and message** native raises (`ConnectionImpl.checkNotReleased`), plus an `ENOTCONN` `Error` for a connection that dropped without an explicit release (mirroring `sd_bus_call` on a closed bus).

**Restored test** (the sub-case scoped down in PR #54 with a code comment documenting the divergence): `FailurePathParityTest.proxyConnectionTeardown_completesCleanly_andCallAfterReleaseFails` — asserts `assertFailsWith<IllegalArgumentException>` with message `"Connection has already been released"` on both backends. (Running it against native first is what pinned the exact contract — native throws `IllegalArgumentException`, not `Error`, on this path.)

## Fix 3 — errno error-name parity (`src/jvmMain/.../Error.jvm.kt`, from #40)

JVM `createError(errNo, msg)` fabricated `Error("jvm.errno.$errNo", msg)`. It now mirrors native's `sd_bus_error_set_errno` mapping, with every table entry verified empirically against libsystemd on this machine:

- EINVAL → `org.freedesktop.DBus.Error.InvalidArgs`, EACCES/EPERM → `...AccessDenied`, ENOMEM → `...NoMemory`, ETIMEDOUT → `...Timeout`, ENOENT → `...FileNotFound`, ECONNRESET → `...Disconnected`, EIO/EEXIST/EBADMSG/ESRCH/EADDRINUSE/ENOBUFS/EOPNOTSUPP → their well-known names
- named-but-unmapped errnos → `System.Error.<NAME>` (ENXIO, EBUSY, ENODATA, ENOTCONN, EBADR, EHOSTUNREACH)
- unknown values → `org.freedesktop.DBus.Error.Failed` with `Unknown error N`
- negated errnos take the absolute value (so the ubiquitous `createError(-1, ...)` behaves as EPERM, exactly as it does on native)
- message format matches native: `"$customMsg (<strerror text>)"`

**New test**: `JvmCreateErrorParityTest` (jvmTest, same module so it can call the internal `createError`) pins 14 representative outputs to the native-format expectations.

## Verification

- `ktlintFormat` clean; **`apiDump` is a no-op** (`git diff -- api/` empty); `ktlintCheck apiCheck` pass
- `dbus-run-session -- ./gradlew jvmTest` — pass (incl. all 3 new/restored tests)
- `dbus-run-session -- ./gradlew linuxX64Test` — pass (restored parity tests green on the native backend too; **5 consecutive clean runs** of both suites)
- `compileKotlinLinuxX64`, `:codegen:test`, `:plugin:test` — pass
- New bus-using tests live in `com.monkopedia.sdbus.integration` for ARM CI

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
