### PR TITLE
WIP: Release 0.5.0 — 1.0 API-freeze (HELD: owner cuts when ready, no auto-merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ There is a gradle plugin which can generate sources as part of the the build whe
 ```
 plugins {
     ...
-    id("com.monkopedia.sdbus.plugin") version "0.4.5"
+    id("com.monkopedia.sdbus.plugin") version "0.5.0"
 }
 
 sdbus {
@@ -51,7 +51,7 @@ a common kotlin module, its implementations are currently only for linuxX64 and 
 ```
 val nativeMain by getting {
     dependencies {
-       implementation("com.monkopedia:sdbus-kotlin:0.4.5")
+       implementation("com.monkopedia:sdbus-kotlin:0.5.0")
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.4.5
+version=0.5.0
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true


### PR DESCRIPTION
## Held — owner cuts this when 0.5.0 is RIGHT. No auto-merge.

Version bump 0.4.5 → 0.5.0. Draft until the owner explicitly decides 0.5.0 is complete and correct.

## 0.5.0 now includes the JVM-transport rewrite (owner-decided 2026-06-12)
The JVM server-export question (#90) resolved into a strategic direction: **own the JVM D-Bus connection** (epic **#93**) — replace dbus-java's transport with junixsocket + our own marshaller + dispatch, mirroring native. Feasibility proven (all risk prototypes pass). 0.5.0 WAITS for #93 (~3–4 wks, phased). ByteBuddy approach (#92) abandoned.

### Merged toward 0.5.0
ABI freeze #57–63; dbusmock suites #70/73/75/76; docs #77/79/88/91; bug fixes #78 (JVM wire ×3), #85 (#80/#81), #86 (native race / #69), #87 (remote-bus).

### Remaining before cut
- Epic #93 (own the JVM connection) — phases 1–6; closes #90 + #83; the big one.
- #89 (generated-adaptor property getter — small correctness fix; ready).
- #68 (CHANGELOG + moduledoc — lands LAST, captures everything).

Owner cuts on explicit go once #93 + #89 + #68 are done and right. No mechanism ships this automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)