### PR TITLE
Add dbusmock signal / ObjectManager / PropertiesChanged + foreign-error-mapping suites (#36)

### DIFF
--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockForeignErrorTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockForeignErrorTest.kt
@@ -1,0 +1,170 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.Error
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.callMethodAsync
+import com.monkopedia.sdbus.getProperty
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Foreign error mapping against the python-dbusmock independent peer (issue #36): D-Bus error
+ * replies produced by a non-sdbus implementation (Python/GDBus raising `DBusException` with
+ * arbitrary error names) must surface as [com.monkopedia.sdbus.Error] with the error name and
+ * message preserved verbatim.
+ *
+ * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
+ * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`) — the independent-peer
+ * counterpart of the own-server error-mapping parity coverage. Skips cleanly when
+ * python3-dbusmock is not installed (see [DbusmockHarness]).
+ */
+class DbusmockForeignErrorTest {
+
+    @Test
+    fun standardErrorName_surfacesWithNameAndMessage() = withDbusmockPeer("ErrStd") {
+        addRaisingMethod("Boom", "org.freedesktop.DBus.Error.NotSupported", "peer says no")
+        val error = assertFailsWith<Error> {
+            proxy.callMethod<Unit>(iface, MethodName("Boom")) {}
+        }
+        assertForeignError(error, "org.freedesktop.DBus.Error.NotSupported", "peer says no")
+    }
+
+    @Test
+    fun arbitraryForeignErrorName_isPreservedVerbatim() = withDbusmockPeer("ErrCustom") {
+        addRaisingMethod(
+            "Custom",
+            "com.monkopedia.sdbus.test.SomethingWentWrong",
+            "completely custom failure detail"
+        )
+        val error = assertFailsWith<Error> {
+            proxy.callMethod<Unit>(iface, MethodName("Custom")) {}
+        }
+        assertForeignError(
+            error,
+            "com.monkopedia.sdbus.test.SomethingWentWrong",
+            "completely custom failure detail"
+        )
+
+        // AccessDenied-style names commonly raised by real services map the same way.
+        addRaisingMethod("Denied", "org.freedesktop.DBus.Error.AccessDenied", "not for you")
+        val denied = assertFailsWith<Error> {
+            proxy.callMethod<Unit>(iface, MethodName("Denied")) {}
+        }
+        assertForeignError(denied, "org.freedesktop.DBus.Error.AccessDenied", "not for you")
+    }
+
+    @Test
+    fun asyncCallPath_mapsForeignErrorsIdentically() = withDbusmockPeer("ErrAsync") {
+        addRaisingMethod("Boom", "org.freedesktop.DBus.Error.InvalidArgs", "async boom")
+        val error = assertFailsWith<Error> {
+            proxy.callMethodAsync<Unit>(iface, MethodName("Boom")) {}
+        }
+        assertForeignError(error, "org.freedesktop.DBus.Error.InvalidArgs", "async boom")
+    }
+
+    @Test
+    fun unknownMethodOnForeignPeer_mapsToUnknownMethodError() = withDbusmockPeer("ErrUnknown") {
+        // The error here is produced by the foreign stack itself (dbus-python's dispatch),
+        // not by scripted code; the message text is implementation-defined so only the name
+        // is asserted.
+        val error = assertFailsWith<Error> {
+            proxy.callMethod<Unit>(iface, MethodName("NoSuchMethodHere")) {}
+        }
+        assertForeignError(error, "org.freedesktop.DBus.Error.UnknownMethod")
+    }
+
+    @Test
+    fun foreignPropertyErrors_surfaceWithPeerErrorNames() = withDbusmockPeer("ErrProp") {
+        // dbusmock raises "<main interface>.UnknownProperty" for a Get on a missing property.
+        val error = assertFailsWith<Error> {
+            proxy.getProperty<Int>(iface, PropertyName("NoSuchProperty"))
+        }
+        assertForeignError(
+            error,
+            "${iface.value}.UnknownProperty",
+            "no such property NoSuchProperty"
+        )
+    }
+
+    /**
+     * Asserts that [error]'s name (and, when given, message) match what the foreign peer put
+     * in its error reply — gated on [peerErrorNameMappingSupported] where the JVM backend is
+     * known to discard both (the `Error` is still thrown, which is asserted unconditionally
+     * at each call site via `assertFailsWith`).
+     */
+    private fun assertForeignError(
+        error: Error,
+        expectedName: String,
+        expectedMessage: String? = null
+    ) {
+        if (!peerErrorNameMappingSupported) {
+            // KNOWN JVM BACKEND BUG (issue #72, found by this suite; see the
+            // peerErrorNameMappingSupported KDoc for full details).
+            println(
+                "[DbusmockForeignErrorTest] SKIP name/message assertions for $expectedName: " +
+                    "known JVM backend gap (foreign error names are discarded). " +
+                    "Actual name surfaced: ${error.name}"
+            )
+            return
+        }
+        assertEquals(expectedName, error.name, "foreign D-Bus error name was not preserved")
+        if (expectedMessage != null) {
+            assertEquals(
+                expectedMessage,
+                error.errorMessage,
+                "foreign D-Bus error message was not preserved"
+            )
+        }
+    }
+
+    /** Scripts a method on the peer that raises a DBusException with the given name/message. */
+    private fun DbusmockPeer.addRaisingMethod(method: String, errorName: String, message: String) =
+        addMethod(
+            method,
+            "",
+            "",
+            "raise dbus.exceptions.DBusException('$message', name='$errorName')"
+        )
+}
+
+/**
+ * Whether this backend preserves the D-Bus error name and message of error replies received
+ * from a real remote (out-of-process) peer.
+ *
+ * `true` on the native sd-bus backend, where the wire error name/message land verbatim in
+ * [com.monkopedia.sdbus.Error]'s `name`/`errorMessage`. `false` on the JVM backend:
+ * `PureJavaDbusBackend.remoteCall` converts an `org.freedesktop.dbus.messages.Error` reply via
+ * `createError(-1, message)`, which maps the `-1` errno through the EPERM entry of the errno
+ * table — so EVERY foreign error surfaces as `org.freedesktop.DBus.Error.AccessDenied`
+ * ("Operation not permitted...") regardless of the actual error name/message sent by the peer.
+ * The same applies on the async path and to property Get/Set errors. Own-server tests miss
+ * this because in-process calls short-circuit through JvmStaticDispatch, which rethrows the
+ * original [com.monkopedia.sdbus.Error] without ever serializing it to the wire.
+ *
+ * Found by this suite (issue #36); the fix is ticketed as issue #72 — when it lands, flip the
+ * JVM actual to `true` so the full assertions enforce parity.
+ */
+internal expect val peerErrorNameMappingSupported: Boolean

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
@@ -65,11 +65,15 @@ internal expect class DbusmockHandle {
  * Launches `python3 -m dbusmock` on the current (session) bus, claiming [busName] and exposing
  * a generic mock object at [objectPath] with main interface [interfaceName].
  *
+ * @param objectManager When `true`, dbusmock is started with `-m` so that the mock object also
+ *   implements `org.freedesktop.DBus.ObjectManager` (its `GetManagedObjects` reports the
+ *   objects added below [objectPath] via the mock `AddObject` control call).
  * @return a [DbusmockHandle] if the process started, or `null` if dbusmock / python is not
  *   available (the caller should then SKIP).
  */
 internal expect fun launchDbusmock(
     busName: String,
     objectPath: String,
-    interfaceName: String
+    interfaceName: String,
+    objectManager: Boolean = false
 ): DbusmockHandle?

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockObjectManagerTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockObjectManagerTest.kt
@@ -1,0 +1,183 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectManagerProxy
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.onSignal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+
+/**
+ * ObjectManager coverage against the python-dbusmock independent peer (issue #36): the peer is
+ * launched with dbusmock's `-m` flag so it implements `org.freedesktop.DBus.ObjectManager` for
+ * the objects it adds/removes via its `AddObject`/`RemoveObject` scripting calls.
+ *
+ * Verifies the raw `InterfacesAdded`/`InterfacesRemoved` payloads emitted by the foreign stack,
+ * the `GetManagedObjects` round-trip, and that [ObjectManagerProxy]'s reactive state flows
+ * converge on the same view.
+ *
+ * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
+ * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Skips cleanly when
+ * python3-dbusmock is not installed (see [DbusmockHarness]).
+ */
+class DbusmockObjectManagerTest {
+
+    @Test
+    fun interfacesAddedAndRemoved_trackForeignObjectLifecycle() =
+        withDbusmockPeer("ObjMgr", objectManager = true) {
+            val childPath = ObjectPath("${objectPath.value}/child0")
+            val childIface = InterfaceName("${iface.value}.Child")
+            addSpawnAndDropMethods(childIface)
+
+            // Raw signal subscriptions, registered before the peer adds any object.
+            val added = CompletableDeferred<Pair<ObjectPath, InterfacesAndProperties>>()
+            val removed = CompletableDeferred<Pair<ObjectPath, List<InterfaceName>>>()
+            val addedRegistration = proxy.onSignal(
+                ObjectManagerProxy.INTERFACE_NAME,
+                SignalName("InterfacesAdded")
+            ) {
+                call { path: ObjectPath, ifaces: InterfacesAndProperties ->
+                    added.complete(path to ifaces)
+                }
+            }
+            val removedRegistration = proxy.onSignal(
+                ObjectManagerProxy.INTERFACE_NAME,
+                SignalName("InterfacesRemoved")
+            ) {
+                call { path: ObjectPath, ifaces: List<InterfaceName> ->
+                    removed.complete(path to ifaces)
+                }
+            }
+
+            try {
+                val om = ObjectManagerProxy(proxy)
+                assertTrue(
+                    om.getManagedObjects().isEmpty(),
+                    "peer should manage no objects before AddObject"
+                )
+
+                proxy.callMethod<Unit>(iface, MethodName("SpawnChild")) { call(childPath.value) }
+
+                // Raw InterfacesAdded payload decoded from the foreign emitter.
+                val (addedPath, addedIfaces) = withTimeout(10_000) { added.await() }
+                assertEquals(childPath, addedPath)
+                val signalProps = assertNotNull(
+                    addedIfaces[childIface],
+                    "child interface missing from InterfacesAdded payload"
+                )
+                assertEquals("first-child", signalProps[PropertyName("Name")]?.get<String>())
+                assertEquals(7, signalProps[PropertyName("Level")]?.get<Int>())
+
+                // ObjectManagerProxy's reactive flows converge on the same view.
+                withTimeout(10_000) { om.objects.first { childPath in it } }
+                withTimeout(10_000) { om.interfacesFor(childPath).first { childIface in it } }
+                withTimeout(10_000) { om.objectsFor(childIface).first { childPath in it } }
+                val data =
+                    withTimeout(10_000) { om.objectData(childPath).first { it.isNotEmpty() } }
+                assertEquals(7, data[childIface]?.get(PropertyName("Level"))?.get<Int>())
+
+                // GetManagedObjects agrees with the signal-tracked state.
+                val managed = om.getManagedObjects()
+                val managedProps = assertNotNull(
+                    managed[childPath]?.get(childIface),
+                    "child missing from GetManagedObjects"
+                )
+                assertEquals("first-child", managedProps[PropertyName("Name")]?.get<String>())
+                assertEquals(7, managedProps[PropertyName("Level")]?.get<Int>())
+
+                // Removal: raw payload carries the dropped interface names...
+                proxy.callMethod<Unit>(iface, MethodName("DropChild")) { call(childPath.value) }
+                val (removedPath, removedIfaces) = withTimeout(10_000) { removed.await() }
+                assertEquals(childPath, removedPath)
+                assertEquals(listOf(childIface), removedIfaces)
+
+                // ...and both the proxy state and the peer agree the object is gone. (The
+                // path itself intentionally stays in [ObjectManagerProxy.objects] with no
+                // interfaces; interfacesFor is the lifecycle-accurate view.)
+                withTimeout(10_000) { om.interfacesFor(childPath).first { it.isEmpty() } }
+                assertTrue(
+                    om.getManagedObjects().isEmpty(),
+                    "peer should manage no objects after RemoveObject"
+                )
+            } finally {
+                addedRegistration.release()
+                removedRegistration.release()
+            }
+        }
+
+    @Test
+    fun objectManagerProxy_seedsInitialStateFromGetManagedObjects() =
+        withDbusmockPeer("ObjMgrSeed", objectManager = true) {
+            val childIface = InterfaceName("${iface.value}.Child")
+            addSpawnAndDropMethods(childIface)
+            val childA = ObjectPath("${objectPath.value}/a")
+            val childB = ObjectPath("${objectPath.value}/b")
+            proxy.callMethod<Unit>(iface, MethodName("SpawnChild")) { call(childA.value) }
+            proxy.callMethod<Unit>(iface, MethodName("SpawnChild")) { call(childB.value) }
+
+            // Both children exist before the ObjectManagerProxy is created: its initial state
+            // must come from GetManagedObjects, not from signals (which were never observed).
+            val om = ObjectManagerProxy(proxy)
+            assertEquals(setOf(childA, childB), om.objects.first().toSet())
+            assertEquals(listOf(childIface), om.interfacesFor(childA).first())
+            assertEquals(
+                "first-child",
+                om.objectData(childB).first()[childIface]?.get(PropertyName("Name"))?.get<String>()
+            )
+        }
+
+    /**
+     * Scripts `SpawnChild`/`DropChild` methods on the peer that add/remove a child object with
+     * interface [childIface] (properties `Name`/`Level`) and emit the corresponding
+     * `InterfacesAdded`/`InterfacesRemoved` signals from the foreign ObjectManager.
+     */
+    private fun DbusmockPeer.addSpawnAndDropMethods(childIface: InterfaceName) {
+        addMethod(
+            "SpawnChild",
+            "s",
+            "",
+            "self.AddObject(args[0], '${childIface.value}', " +
+                "{'Name': dbus.String('first-child'), 'Level': dbus.Int32(7)}, []); " +
+                "self.object_manager_emit_added(args[0])"
+        )
+        addMethod(
+            "DropChild",
+            "s",
+            "",
+            "self.object_manager_emit_removed(args[0]); self.RemoveObject(args[0])"
+        )
+    }
+}
+
+/** The `a{sa{sv}}` payload of `InterfacesAdded` / a `GetManagedObjects` entry. */
+private typealias InterfacesAndProperties = Map<InterfaceName, Map<PropertyName, Variant>>

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPeerFixture.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPeerFixture.kt
@@ -1,0 +1,206 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.Connection
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertiesProxy
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createProxy
+import kotlin.random.Random
+import kotlin.time.TimeSource
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** The python-dbusmock runtime-scripting control interface. */
+internal val MOCK_INTERFACE = InterfaceName("org.freedesktop.DBus.Mock")
+
+/**
+ * A scripted python-dbusmock peer plus the sdbus-kotlin client side talking to it: [control]
+ * drives the `org.freedesktop.DBus.Mock` scripting interface while [proxy] is used for the
+ * actual assertions against the mocked [iface]. See [DbusmockHarness] for the underlying
+ * process management and [withDbusmockPeer] for the lifecycle.
+ */
+internal class DbusmockPeer(
+    val connection: Connection,
+    val control: Proxy,
+    val proxy: Proxy,
+    val busName: ServiceName,
+    val objectPath: ObjectPath,
+    val iface: InterfaceName
+) {
+    /** Scripts a method on the peer: dbusmock executes [code] (Python) when it is called. */
+    fun addMethod(name: String, inSig: String, outSig: String, code: String) {
+        control.callMethod<Unit>(MOCK_INTERFACE, MethodName("AddMethod")) {
+            call(iface.value, name, inSig, outSig, code)
+        }
+    }
+
+    /** Scripts an identity method that replies with its single argument unchanged. */
+    fun addEcho(name: String, signature: String) =
+        addMethod(name, signature, signature, "ret = args[0]")
+
+    /** Adds a property on the peer's main interface (no PropertiesChanged is emitted). */
+    fun addProperty(name: String, value: Variant) {
+        control.callMethod<Unit>(MOCK_INTERFACE, MethodName("AddProperty")) {
+            call(iface.value, name, value)
+        }
+    }
+
+    /**
+     * Updates properties on the peer's main interface. dbusmock emits a real
+     * `org.freedesktop.DBus.Properties.PropertiesChanged` signal carrying the new values.
+     */
+    fun updateProperties(properties: Map<String, Variant>) {
+        control.callMethod<Unit>(MOCK_INTERFACE, MethodName("UpdateProperties")) {
+            call(iface.value, properties)
+        }
+    }
+
+    /**
+     * Makes the peer emit an arbitrary signal: [args] are variant-wrapped values that dbusmock
+     * unpacks according to [signature] (one variant per top-level signature element).
+     */
+    fun emitSignal(
+        interfaceName: String,
+        name: String,
+        signature: String,
+        args: List<Variant> = emptyList()
+    ) {
+        control.callMethod<Unit>(MOCK_INTERFACE, MethodName("EmitSignal")) {
+            call(interfaceName, name, signature, args)
+        }
+    }
+
+    /** [emitSignal] on the peer's main interface. */
+    fun emitSignal(name: String, signature: String, args: List<Variant> = emptyList()) =
+        emitSignal(iface.value, name, signature, args)
+
+    /**
+     * Makes the peer emit a `PropertiesChanged` signal for its main interface that lists
+     * [invalidated] property names as invalidated (no new value carried) alongside the
+     * optionally non-empty [changed] map. dbusmock's own `UpdateProperties` only ever emits
+     * changed values, so invalidation is scripted through the generic signal emitter.
+     */
+    fun emitPropertiesChanged(
+        invalidated: List<String>,
+        changed: Map<String, Variant> = emptyMap()
+    ) = emitSignal(
+        PropertiesProxy.INTERFACE_NAME.value,
+        "PropertiesChanged",
+        "sa{sv}as",
+        listOf(Variant(iface.value), Variant(changed), Variant(invalidated))
+    )
+}
+
+/**
+ * Flow-based subscribers ([com.monkopedia.sdbus.signalFlow] and everything built on it, like
+ * `PropertyDelegate.changes()`) register their signal handler only once collection starts,
+ * which the test cannot otherwise observe. This repeatedly invokes [poke] (which must
+ * eventually cause an element to land in [received]) until the first element arrives —
+ * proving the subscription is live — and consumes that element.
+ */
+internal suspend fun <T> pumpUntilSubscribed(received: ReceiveChannel<T>, poke: () -> Unit): Unit =
+    withTimeout(15_000) {
+        var first: T? = null
+        while (first == null) {
+            poke()
+            first = withTimeoutOrNull(250) { received.receive() }
+        }
+    }
+
+/**
+ * Launches a fresh dbusmock peer (unique bus name / path / interface), waits for it to claim
+ * its name, runs [block] against it, and tears everything down. If python-dbusmock is not
+ * available the test SKIPs cleanly (runs no assertions).
+ *
+ * @param suffix Distinguishes the peer's bus name / object path between tests.
+ * @param objectManager When `true`, the peer also implements
+ *   `org.freedesktop.DBus.ObjectManager` at [DbusmockPeer.objectPath] (dbusmock `-m`).
+ */
+internal fun withDbusmockPeer(
+    suffix: String,
+    objectManager: Boolean = false,
+    block: suspend DbusmockPeer.() -> Unit
+) = runBlocking {
+    val id = Random.nextInt(100_000, 999_999)
+    val busName = "com.monkopedia.sdbus.dbusmock.$suffix$id"
+    val objectPath = "/com/monkopedia/sdbus/dbusmock/$suffix$id"
+
+    val handle = launchDbusmock(busName, objectPath, busName, objectManager)
+    if (handle == null) {
+        println(
+            "[withDbusmockPeer] SKIP: python-dbusmock unavailable. " +
+                "Install via 'apt install python3-dbusmock' / 'pip install python-dbusmock' " +
+                "(see DbusmockHarness KDoc)."
+        )
+        return@runBlocking
+    }
+
+    val connection: Connection = createBusConnection()
+    connection.startEventLoop()
+    val control = createProxy(connection, ServiceName(busName), ObjectPath(objectPath))
+    val proxy = createProxy(connection, ServiceName(busName), ObjectPath(objectPath))
+    val peer = DbusmockPeer(
+        connection,
+        control,
+        proxy,
+        ServiceName(busName),
+        ObjectPath(objectPath),
+        InterfaceName(busName)
+    )
+
+    try {
+        // dbusmock takes a moment to claim its bus name; retry a no-op control call until
+        // the name is owned (or we time out).
+        dbusmockRetry(timeoutMillis = 15_000) {
+            peer.addMethod("Ready", "", "i", "ret = 0")
+        }
+        peer.block()
+    } finally {
+        proxy.release()
+        control.release()
+        connection.stopEventLoop()
+        connection.release()
+        handle.stop()
+    }
+}
+
+/** Repeats [block] (spaced by a busy-wait) until it stops throwing or [timeoutMillis] passes. */
+internal inline fun dbusmockRetry(timeoutMillis: Long, block: () -> Unit) {
+    val start = TimeSource.Monotonic.markNow()
+    var last: Throwable? = null
+    while (start.elapsedNow().inWholeMilliseconds < timeoutMillis) {
+        val result = runCatching(block)
+        if (result.isSuccess) return
+        last = result.exceptionOrNull()
+        busyWait(100)
+    }
+    throw AssertionError("Timed out waiting for dbusmock to become ready", last)
+}

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPropertiesChangedTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPropertiesChangedTest.kt
@@ -1,0 +1,213 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.PropertiesProxy
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.propDelegate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Foreign-emitted `PropertiesChanged` coverage against the python-dbusmock independent peer
+ * (issue #36): real **changed values** (dbusmock's `UpdateProperties` emits the new values, not
+ * just invalidations) plus scripted invalidation-only signals, observed through both the raw
+ * [PropertiesProxy.registerPropertiesProxy] callback and the reactive
+ * `PropertyDelegate.changes()`/`changesOrNull()`/`values()`/`valuesOrNull()` flows.
+ *
+ * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
+ * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`) — settling the JVM-vs-native
+ * parity question for changed-value payloads from an independent emitter. Skips cleanly when
+ * python3-dbusmock is not installed (see [DbusmockHarness]).
+ */
+class DbusmockPropertiesChangedTest {
+
+    @Test
+    fun propertiesChanged_carriesChangedValuesAndInvalidatedNames() = withDbusmockPeer("PropSig") {
+        addProperty("Level", Variant(1))
+        addProperty("Mode", Variant("idle"))
+
+        val events = Channel<Triple<InterfaceName, Map<PropertyName, Variant>, List<PropertyName>>>(
+            Channel.UNLIMITED
+        )
+        // onSignal-based registration is active as soon as this returns; no pumping needed.
+        PropertiesProxy(proxy).registerPropertiesProxy { interfaceName, changed, invalidated ->
+            events.trySend(Triple(interfaceName, changed, invalidated))
+        }
+
+        // Changed values: dbusmock emits the real new values in the changed map.
+        updateProperties(mapOf("Level" to Variant(5), "Mode" to Variant("busy")))
+        val changedEvent = withTimeout(10_000) { events.receive() }
+        assertEquals(iface, changedEvent.first)
+        assertEquals(5, changedEvent.second[PropertyName("Level")]?.get<Int>())
+        assertEquals("busy", changedEvent.second[PropertyName("Mode")]?.get<String>())
+        assertTrue(changedEvent.third.isEmpty(), "no properties should be invalidated")
+
+        // Invalidation-only: empty changed map, names listed as invalidated.
+        emitPropertiesChanged(invalidated = listOf("Mode"))
+        val invalidatedEvent = withTimeout(10_000) { events.receive() }
+        assertEquals(iface, invalidatedEvent.first)
+        assertTrue(invalidatedEvent.second.isEmpty(), "no changed values expected")
+        assertEquals(listOf(PropertyName("Mode")), invalidatedEvent.third)
+
+        // Mixed: one property changes value while another is invalidated, in a single signal.
+        emitPropertiesChanged(invalidated = listOf("Mode"), changed = mapOf("Level" to Variant(9)))
+        val mixedEvent = withTimeout(10_000) { events.receive() }
+        assertEquals(9, mixedEvent.second[PropertyName("Level")]?.get<Int>())
+        assertEquals(listOf(PropertyName("Mode")), mixedEvent.third)
+    }
+
+    @Test
+    fun propertyDelegate_changes_emitsForeignChangedValues_andDropsInvalidations() =
+        withDbusmockPeer("PropChanges") {
+            addProperty("Level", Variant(1))
+            val delegate = proxy.propDelegate<Any?, Int>(iface, PropertyName("Level"))
+            assertEquals(1, delegate.get())
+
+            coroutineScope {
+                val received = Channel<Int>(Channel.UNLIMITED)
+                val collector = launch {
+                    delegate.changes().collect { received.trySend(it) }
+                }
+                pumpUntilSubscribed(received) { updateProperty(nextMarker()) }
+
+                updateProperty(7)
+                assertEquals(7, received.nextNonMarker())
+
+                // Invalidation events are dropped by changes(): after invalidating, the very
+                // next emission must be the subsequent real value.
+                emitPropertiesChanged(invalidated = listOf("Level"))
+                updateProperty(8)
+                assertEquals(8, received.nextNonMarker())
+
+                collector.cancelAndJoin()
+            }
+        }
+
+    @Test
+    fun propertyDelegate_changesOrNull_emitsNullOnForeignInvalidation() =
+        withDbusmockPeer("PropChangesNull") {
+            addProperty("Level", Variant(1))
+            val delegate = proxy.propDelegate<Any?, Int>(iface, PropertyName("Level"))
+
+            coroutineScope {
+                val received = Channel<Int?>(Channel.UNLIMITED)
+                val collector = launch {
+                    delegate.changesOrNull().collect { received.trySend(it) }
+                }
+                pumpUntilSubscribed(received) { updateProperty(nextMarker()) }
+
+                updateProperty(5)
+                assertEquals(5, received.nextNonMarker())
+
+                emitPropertiesChanged(invalidated = listOf("Level"))
+                assertNull(received.nextNonMarker(), "invalidation should surface as null")
+
+                updateProperty(6)
+                assertEquals(6, received.nextNonMarker())
+
+                collector.cancelAndJoin()
+            }
+        }
+
+    @Test
+    fun propertyDelegate_values_emitsCurrentValueThenForeignChanges() =
+        withDbusmockPeer("PropValues") {
+            addProperty("Level", Variant(21))
+            val delegate = proxy.propDelegate<Any?, Int>(iface, PropertyName("Level"))
+
+            coroutineScope {
+                val received = Channel<Int>(Channel.UNLIMITED)
+                val collector = launch {
+                    delegate.values().collect { received.trySend(it) }
+                }
+                // The current value is read (a real Get round-trip to the peer) and emitted
+                // before the change subscription goes live.
+                assertEquals(21, withTimeout(10_000) { received.receive() })
+
+                pumpUntilSubscribed(received) { updateProperty(nextMarker()) }
+                updateProperty(22)
+                assertEquals(22, received.nextNonMarker())
+
+                collector.cancelAndJoin()
+            }
+        }
+
+    @Test
+    fun propertyDelegate_valuesOrNull_emitsInitialThenNullOnInvalidation() =
+        withDbusmockPeer("PropValuesNull") {
+            addProperty("Level", Variant(31))
+            val delegate = proxy.propDelegate<Any?, Int>(iface, PropertyName("Level"))
+
+            coroutineScope {
+                val received = Channel<Int?>(Channel.UNLIMITED)
+                val collector = launch {
+                    delegate.valuesOrNull().collect { received.trySend(it) }
+                }
+                assertEquals(31, withTimeout(10_000) { received.receive() })
+
+                pumpUntilSubscribed(received) { updateProperty(nextMarker()) }
+                emitPropertiesChanged(invalidated = listOf("Level"))
+                assertNull(received.nextNonMarker(), "invalidation should surface as null")
+
+                updateProperty(32)
+                assertEquals(32, received.nextNonMarker())
+
+                collector.cancelAndJoin()
+            }
+        }
+
+    /** Updates the `Level` property on the peer, triggering a foreign PropertiesChanged. */
+    private fun DbusmockPeer.updateProperty(value: Int) =
+        updateProperties(mapOf("Level" to Variant(value)))
+
+    private var marker = MARKER_BASE
+
+    private fun nextMarker(): Int = marker++
+
+    /**
+     * Receives the next element that is not a subscription-probe marker (see
+     * [pumpUntilSubscribed]); markers are always emitted before the real test values, so
+     * skipping them preserves the assertion ordering.
+     */
+    private suspend fun ReceiveChannel<Int?>.nextNonMarker(): Int? = withTimeout(10_000) {
+        var value: Int? = MARKER_BASE
+        while (value != null && value >= MARKER_BASE) {
+            value = receive()
+        }
+        value
+    }
+
+    private companion object {
+        /** Probe values are >= this; real test values must stay below it. */
+        private const val MARKER_BASE = 1_000
+    }
+}

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSignalTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSignalTest.kt
@@ -1,0 +1,202 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.onSignal
+import com.monkopedia.sdbus.signalFlow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Signal coverage against the python-dbusmock independent peer (issue #36): subscription via
+ * [onSignal], reactive collection via [signalFlow], payload shapes encoded by the foreign
+ * (Python/GDBus) stack, and the subscribe/unsubscribe lifecycle.
+ *
+ * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
+ * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Skips cleanly when
+ * python3-dbusmock is not installed (see [DbusmockHarness]).
+ */
+class DbusmockSignalTest {
+
+    @Test
+    fun onSignal_deliversForeignEmittedPayloadShapes() = withDbusmockPeer("SigShapes") {
+        val noArgs = CompletableDeferred<Unit>()
+        val intArg = CompletableDeferred<Int>()
+        val multiArg = CompletableDeferred<Pair<Long, String>>()
+        val stringList = CompletableDeferred<List<String>>()
+        val dict = CompletableDeferred<Map<String, Variant>>()
+        val big = CompletableDeferred<ULong>()
+
+        val registrations = listOf(
+            proxy.onSignal(iface, SignalName("NoArgs")) {
+                // Explicit type argument selects the zero-parameter handler overload.
+                call<Boolean> { noArgs.complete(Unit) }
+            },
+            proxy.onSignal(iface, SignalName("IntArg")) {
+                call { value: Int -> intArg.complete(value) }
+            },
+            proxy.onSignal(iface, SignalName("MultiArg")) {
+                call { x: Long, s: String -> multiArg.complete(x to s) }
+            },
+            proxy.onSignal(iface, SignalName("StringList")) {
+                call { values: List<String> -> stringList.complete(values) }
+            },
+            proxy.onSignal(iface, SignalName("Dict")) {
+                call { values: Map<String, Variant> -> dict.complete(values) }
+            },
+            proxy.onSignal(iface, SignalName("Big")) {
+                call { value: ULong -> big.complete(value) }
+            }
+        )
+
+        try {
+            // The registrations above sent their AddMatch before these EmitSignal control
+            // calls, so the bus routes every emission below back to us.
+            emitSignal("NoArgs", "")
+            emitSignal("IntArg", "i", listOf(Variant(-42)))
+            emitSignal(
+                "MultiArg",
+                "xs",
+                listOf(Variant(-5_000_000_000L), Variant("payload from foreign peer"))
+            )
+            emitSignal("StringList", "as", listOf(Variant(listOf("a", "", "déjà-vu"))))
+            emitSignal(
+                "Dict",
+                "a{sv}",
+                listOf(Variant(mapOf("count" to Variant(7), "name" to Variant("widget"))))
+            )
+            emitSignal("Big", "t", listOf(Variant(ULong.MAX_VALUE)))
+
+            withTimeout(10_000) { noArgs.await() }
+            assertEquals(-42, withTimeout(10_000) { intArg.await() })
+            assertEquals(
+                -5_000_000_000L to "payload from foreign peer",
+                withTimeout(10_000) { multiArg.await() }
+            )
+            assertEquals(listOf("a", "", "déjà-vu"), withTimeout(10_000) { stringList.await() })
+            val dictValue = withTimeout(10_000) { dict.await() }
+            assertEquals(setOf("count", "name"), dictValue.keys)
+            assertEquals(7, dictValue.getValue("count").get<Int>())
+            assertEquals("widget", dictValue.getValue("name").get<String>())
+            assertEquals(ULong.MAX_VALUE, withTimeout(10_000) { big.await() })
+        } finally {
+            registrations.forEach { it.release() }
+        }
+    }
+
+    @Test
+    fun signalFlow_emitsForeignSignalsInOrder() = withDbusmockPeer("SigFlow") {
+        coroutineScope {
+            val received = Channel<Int>(Channel.UNLIMITED)
+            val collector = launch {
+                proxy.signalFlow<Int>(iface, SignalName("Counted")) {
+                    call { value: Int -> value }
+                }.collect { received.trySend(it) }
+            }
+
+            // signalFlow registers its handler only once collection starts; poke the peer
+            // with marker payloads until the first delivery proves the subscription is live.
+            pumpUntilSubscribed(received) {
+                emitSignal("Counted", "i", listOf(Variant(MARKER)))
+            }
+
+            emitSignal("Counted", "i", listOf(Variant(1)))
+            emitSignal("Counted", "i", listOf(Variant(2)))
+            emitSignal("Counted", "i", listOf(Variant(3)))
+
+            // All markers were emitted before the real payloads, and D-Bus preserves the
+            // ordering of messages from one sender to one receiver.
+            val seen = mutableListOf<Int>()
+            withTimeout(10_000) {
+                while (seen.size < 3) {
+                    val value = received.receive()
+                    if (value != MARKER) seen += value
+                }
+            }
+            assertEquals(listOf(1, 2, 3), seen)
+
+            // Cancelling collection releases the registration through awaitClose.
+            collector.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun onSignal_unsubscribeStopsDelivery_andResubscribeWorks() = withDbusmockPeer("SigLifecycle") {
+        val events = Channel<Int>(Channel.UNLIMITED)
+        val flushes = Channel<Int>(Channel.UNLIMITED)
+        val flushRegistration = proxy.onSignal(iface, SignalName("Flush")) {
+            call { value: Int ->
+                flushes.trySend(value)
+                Unit
+            }
+        }
+
+        try {
+            var registration = proxy.onSignal(iface, SignalName("Evt")) {
+                call { value: Int ->
+                    events.trySend(value)
+                    Unit
+                }
+            }
+            emitSignal("Evt", "i", listOf(Variant(1)))
+            assertEquals(1, withTimeout(10_000) { events.receive() })
+
+            // Unsubscribe, then emit again. The Flush signal (whose handler is still live)
+            // is emitted after Evt#2, so once it arrives, Evt#2 would have been delivered
+            // too if the released subscription were still active.
+            registration.release()
+            emitSignal("Evt", "i", listOf(Variant(2)))
+            emitSignal("Flush", "i", listOf(Variant(99)))
+            assertEquals(99, withTimeout(10_000) { flushes.receive() })
+            assertTrue(
+                events.tryReceive().isFailure,
+                "signal was delivered to a released subscription"
+            )
+
+            // Re-subscribing during the proxy lifetime resumes delivery.
+            registration = proxy.onSignal(iface, SignalName("Evt")) {
+                call { value: Int ->
+                    events.trySend(value)
+                    Unit
+                }
+            }
+            emitSignal("Evt", "i", listOf(Variant(3)))
+            assertEquals(3, withTimeout(10_000) { events.receive() })
+            registration.release()
+        } finally {
+            flushRegistration.release()
+        }
+    }
+
+    private companion object {
+        /** Payload used to detect when a flow subscription has gone live; see callers. */
+        private const val MARKER = -1
+    }
+}

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockTypeMatrixTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockTypeMatrixTest.kt
@@ -20,28 +20,19 @@
  */
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Connection
-import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PropertiesProxy
 import com.monkopedia.sdbus.PropertyName
-import com.monkopedia.sdbus.Proxy
-import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.Signature
 import com.monkopedia.sdbus.UnixFd
 import com.monkopedia.sdbus.Variant
 import com.monkopedia.sdbus.callMethod
 import com.monkopedia.sdbus.callMethodAsync
-import com.monkopedia.sdbus.createBusConnection
-import com.monkopedia.sdbus.createProxy
 import com.monkopedia.sdbus.getProperty
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.time.TimeSource
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 
 /**
@@ -90,7 +81,7 @@ class DbusmockTypeMatrixTest {
     // --- Basic types -----------------------------------------------------------------------
 
     @Test
-    fun integralTypes_roundTripThroughForeignPeer() = withDbusmockPeer("Integral") {
+    fun integralTypes_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixIntegral") {
         addEcho("EchoY", "y")
         assertEchoes("EchoY", UByte.MIN_VALUE)
         assertEchoes("EchoY", 42.toUByte())
@@ -134,35 +125,36 @@ class DbusmockTypeMatrixTest {
     }
 
     @Test
-    fun floatingPointAndStringLikeTypes_roundTripThroughForeignPeer() = withDbusmockPeer("Fp") {
-        addEcho("EchoD", "d")
-        assertEchoes("EchoD", 3.141592653589793)
-        assertEchoes("EchoD", -2.718281828459045)
-        assertEchoes("EchoD", 1.0E-300)
-        assertEchoes("EchoD", 1.0E300)
-        assertEchoes("EchoD", Double.POSITIVE_INFINITY)
-        assertEchoes("EchoD", Double.NEGATIVE_INFINITY)
-        // NaN and -0.0 must survive bit-exact; kotlin boxed equality distinguishes both.
-        assertEchoes("EchoD", Double.NaN)
-        assertEchoes("EchoD", -0.0)
+    fun floatingPointAndStringLikeTypes_roundTripThroughForeignPeer() =
+        withDbusmockPeer("MatrixFp") {
+            addEcho("EchoD", "d")
+            assertEchoes("EchoD", 3.141592653589793)
+            assertEchoes("EchoD", -2.718281828459045)
+            assertEchoes("EchoD", 1.0E-300)
+            assertEchoes("EchoD", 1.0E300)
+            assertEchoes("EchoD", Double.POSITIVE_INFINITY)
+            assertEchoes("EchoD", Double.NEGATIVE_INFINITY)
+            // NaN and -0.0 must survive bit-exact; kotlin boxed equality distinguishes both.
+            assertEchoes("EchoD", Double.NaN)
+            assertEchoes("EchoD", -0.0)
 
-        addEcho("EchoS", "s")
-        assertEchoes("EchoS", "")
-        assertEchoes("EchoS", "Hello, D-Bus éàü 你好 🚀")
-        assertEchoes("EchoS", "line1\nline2\ttab \"quoted\" back\\slash")
+            addEcho("EchoS", "s")
+            assertEchoes("EchoS", "")
+            assertEchoes("EchoS", "Hello, D-Bus éàü 你好 🚀")
+            assertEchoes("EchoS", "line1\nline2\ttab \"quoted\" back\\slash")
 
-        addEcho("EchoO", "o")
-        assertEchoes("EchoO", ObjectPath("/com/monkopedia/sdbus/some/object"))
-        assertEchoes("EchoO", ObjectPath("/"))
+            addEcho("EchoO", "o")
+            assertEchoes("EchoO", ObjectPath("/com/monkopedia/sdbus/some/object"))
+            assertEchoes("EchoO", ObjectPath("/"))
 
-        addEcho("EchoG", "g")
-        assertEchoes("EchoG", Signature("a{sv}"))
-        assertEchoes("EchoG", Signature("(ybnqiuxtdsogv)"))
-        assertEchoes("EchoG", Signature(""))
-    }
+            addEcho("EchoG", "g")
+            assertEchoes("EchoG", Signature("a{sv}"))
+            assertEchoes("EchoG", Signature("(ybnqiuxtdsogv)"))
+            assertEchoes("EchoG", Signature(""))
+        }
 
     @Test
-    fun variants_roundTripThroughForeignPeer() = withDbusmockPeer("Variant") {
+    fun variants_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixVariant") {
         addEcho("EchoV", "v")
         assertEquals(7, echo("EchoV", Variant(7)).get<Int>())
         assertEquals("inside-variant", echo("EchoV", Variant("inside-variant")).get<String>())
@@ -209,7 +201,7 @@ class DbusmockTypeMatrixTest {
     // --- Arrays ----------------------------------------------------------------------------
 
     @Test
-    fun arrays_roundTripThroughForeignPeer() = withDbusmockPeer("Array") {
+    fun arrays_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixArray") {
         addEcho("EchoAi", "ai")
         assertEchoes("EchoAi", listOf(1, 2, 3, -4, Int.MAX_VALUE, Int.MIN_VALUE))
         assertEchoes("EchoAi", emptyList<Int>())
@@ -249,7 +241,7 @@ class DbusmockTypeMatrixTest {
     // --- Dictionaries ----------------------------------------------------------------------
 
     @Test
-    fun dictionaries_roundTripThroughForeignPeer() = withDbusmockPeer("Dict") {
+    fun dictionaries_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixDict") {
         addEcho("EchoDss", "a{ss}")
         assertEchoes("EchoDss", mapOf("one" to "1", "two" to "2", "" to "empty-key"))
         assertEchoes("EchoDss", emptyMap<String, String>())
@@ -298,46 +290,47 @@ class DbusmockTypeMatrixTest {
     // --- Structs ---------------------------------------------------------------------------
 
     @Test
-    fun structs_receivedFromForeignPeer_deserializeCorrectly() = withDbusmockPeer("StructIn") {
-        if (!peerStructMarshallingSupported) {
-            // KNOWN JVM BACKEND BUG (see peerStructMarshallingSupported KDoc): struct replies
-            // from a real remote peer fail signature validation ("expected=(is) actual=ai").
-            println(
-                "[DbusmockTypeMatrixTest] SKIP struct receive sub-cases: known JVM backend " +
-                    "struct marshalling gap against remote peers."
+    fun structs_receivedFromForeignPeer_deserializeCorrectly() =
+        withDbusmockPeer("MatrixStructIn") {
+            if (!peerStructMarshallingSupported) {
+                // KNOWN JVM BACKEND BUG (see peerStructMarshallingSupported KDoc): struct replies
+                // from a real remote peer fail signature validation ("expected=(is) actual=ai").
+                println(
+                    "[DbusmockTypeMatrixTest] SKIP struct receive sub-cases: known JVM backend " +
+                        "struct marshalling gap against remote peers."
+                )
+                return@withDbusmockPeer
+            }
+
+            // Receive-direction struct coverage: the foreign peer constructs the struct values,
+            // our client only deserializes them.
+            addMethod("MakeStruct", "", "(is)", "ret = (99, 'ninety-nine')")
+            assertEquals(
+                SimpleStruct(99, "ninety-nine"),
+                proxy.callMethod(iface, MethodName("MakeStruct")) {}
             )
-            return@withDbusmockPeer
+
+            addMethod("MakeArrStruct", "", "a(is)", "ret = [(1, 'one'), (2, 'two')]")
+            assertEquals(
+                listOf(SimpleStruct(1, "one"), SimpleStruct(2, "two")),
+                proxy.callMethod(iface, MethodName("MakeArrStruct")) {}
+            )
+
+            addMethod("MakeEmptyArrStruct", "", "a(is)", "ret = []")
+            assertEquals(
+                emptyList(),
+                proxy.callMethod<List<SimpleStruct>>(iface, MethodName("MakeEmptyArrStruct")) {}
+            )
+
+            addMethod("MakeNested", "", "((is)ai)", "ret = ((1, 'a'), [7, 8, 9])")
+            assertEquals(
+                NestedStruct(SimpleStruct(1, "a"), listOf(7, 8, 9)),
+                proxy.callMethod(iface, MethodName("MakeNested")) {}
+            )
         }
 
-        // Receive-direction struct coverage: the foreign peer constructs the struct values,
-        // our client only deserializes them.
-        addMethod("MakeStruct", "", "(is)", "ret = (99, 'ninety-nine')")
-        assertEquals(
-            SimpleStruct(99, "ninety-nine"),
-            proxy.callMethod(iface, MethodName("MakeStruct")) {}
-        )
-
-        addMethod("MakeArrStruct", "", "a(is)", "ret = [(1, 'one'), (2, 'two')]")
-        assertEquals(
-            listOf(SimpleStruct(1, "one"), SimpleStruct(2, "two")),
-            proxy.callMethod(iface, MethodName("MakeArrStruct")) {}
-        )
-
-        addMethod("MakeEmptyArrStruct", "", "a(is)", "ret = []")
-        assertEquals(
-            emptyList(),
-            proxy.callMethod<List<SimpleStruct>>(iface, MethodName("MakeEmptyArrStruct")) {}
-        )
-
-        addMethod("MakeNested", "", "((is)ai)", "ret = ((1, 'a'), [7, 8, 9])")
-        assertEquals(
-            NestedStruct(SimpleStruct(1, "a"), listOf(7, 8, 9)),
-            proxy.callMethod(iface, MethodName("MakeNested")) {}
-        )
-    }
-
     @Test
-    fun structs_roundTripThroughForeignPeer() = withDbusmockPeer("Struct") {
+    fun structs_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixStruct") {
         if (!peerStructMarshallingSupported) {
             // KNOWN JVM BACKEND BUG (see peerStructMarshallingSupported KDoc).
             println(
@@ -394,7 +387,7 @@ class DbusmockTypeMatrixTest {
     // --- Large payloads --------------------------------------------------------------------
 
     @Test
-    fun largePayloads_roundTripThroughForeignPeer() = withDbusmockPeer("Large") {
+    fun largePayloads_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixLarge") {
         addEcho("EchoAy", "ay")
         val bigBytes = List(128 * 1024) { (it % 256).toUByte() }
         assertEquals(bigBytes, echo("EchoAy", bigBytes), "128KiB byte array corrupted")
@@ -411,7 +404,7 @@ class DbusmockTypeMatrixTest {
     // --- Multi-arg / no-arg / no-return methods ---------------------------------------------
 
     @Test
-    fun argumentShapes_roundTripThroughForeignPeer() = withDbusmockPeer("Args") {
+    fun argumentShapes_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixArgs") {
         // Multiple heterogeneous in-args, single out.
         addMethod("Concat", "iis", "s", "ret = '%d|%d|%s' % (args[0], args[1], args[2])")
         val concat = proxy.callMethod<String>(iface, MethodName("Concat")) {
@@ -448,27 +441,25 @@ class DbusmockTypeMatrixTest {
     // --- Suspend/async call path ------------------------------------------------------------
 
     @Test
-    fun asyncCalls_roundTripThroughForeignPeer() = withDbusmockPeer("Async") {
+    fun asyncCalls_roundTripThroughForeignPeer() = withDbusmockPeer("MatrixAsync") {
         addEcho("EchoAi", "ai")
         addEcho("EchoDsv", "a{sv}")
-        runBlocking {
-            val ints = proxy.callMethodAsync<List<Int>>(iface, MethodName("EchoAi")) {
-                call(listOf(5, 6, 7))
-            }
-            assertEquals(listOf(5, 6, 7), ints)
-
-            val dict = proxy.callMethodAsync<Map<String, Variant>>(iface, MethodName("EchoDsv")) {
-                call(mapOf("answer" to Variant(42)))
-            }
-            assertEquals(setOf("answer"), dict.keys)
-            assertEquals(42, dict.getValue("answer").get<Int>())
+        val ints = proxy.callMethodAsync<List<Int>>(iface, MethodName("EchoAi")) {
+            call(listOf(5, 6, 7))
         }
+        assertEquals(listOf(5, 6, 7), ints)
+
+        val dict = proxy.callMethodAsync<Map<String, Variant>>(iface, MethodName("EchoDsv")) {
+            call(mapOf("answer" to Variant(42)))
+        }
+        assertEquals(setOf("answer"), dict.keys)
+        assertEquals(42, dict.getValue("answer").get<Int>())
     }
 
     // --- Properties with complex types -------------------------------------------------------
 
     @Test
-    fun complexProperties_readThroughForeignPeer() = withDbusmockPeer("Props") {
+    fun complexProperties_readThroughForeignPeer() = withDbusmockPeer("MatrixProps") {
         addProperty("Dict", Variant(mapOf("k1" to "v1", "k2" to "v2")))
         addProperty("Ints", Variant(listOf(3, 1, 4, 1, 5)))
         addProperty("Big", Variant(ULong.MAX_VALUE))
@@ -500,7 +491,7 @@ class DbusmockTypeMatrixTest {
     // --- Unix fd passing ----------------------------------------------------------------------
 
     @Test
-    fun unixFd_passesThroughForeignPeer_whereSupported() = withDbusmockPeer("Fd") {
+    fun unixFd_passesThroughForeignPeer_whereSupported() = withDbusmockPeer("MatrixFd") {
         val pipe = createTestPipe()
         if (pipe == null) {
             println(
@@ -534,23 +525,8 @@ class DbusmockTypeMatrixTest {
     }
 
     // --- Fixture ------------------------------------------------------------------------------
-
-    private class DbusmockPeer(val control: Proxy, val proxy: Proxy, val iface: InterfaceName) {
-        fun addMethod(name: String, inSig: String, outSig: String, code: String) {
-            control.callMethod<Unit>(MOCK_INTERFACE, MethodName("AddMethod")) {
-                call(iface.value, name, inSig, outSig, code)
-            }
-        }
-
-        fun addEcho(name: String, signature: String) =
-            addMethod(name, signature, signature, "ret = args[0]")
-
-        fun addProperty(name: String, value: Variant) {
-            control.callMethod<Unit>(MOCK_INTERFACE, MethodName("AddProperty")) {
-                call(iface.value, name, value)
-            }
-        }
-    }
+    // The peer lifecycle ([withDbusmockPeer] / [DbusmockPeer]) is shared with the other
+    // dbusmock suites; see DbusmockPeerFixture.kt.
 
     /** Calls the identity method [name] on the peer with [value] and returns the reply. */
     private inline fun <reified T : Any> DbusmockPeer.echo(name: String, value: T): T =
@@ -564,64 +540,6 @@ class DbusmockTypeMatrixTest {
             echo(name, value),
             "$name: value did not round-trip through the dbusmock peer"
         )
-    }
-
-    /**
-     * Launches a fresh dbusmock peer (unique bus name / path / interface), waits for it to claim
-     * its name, runs [block] against it, and tears everything down. If python-dbusmock is not
-     * available the test SKIPs cleanly (runs no assertions).
-     */
-    private fun withDbusmockPeer(suffix: String, block: DbusmockPeer.() -> Unit) = runBlocking {
-        val id = Random.nextInt(100_000, 999_999)
-        val busName = "com.monkopedia.sdbus.dbusmock.Matrix$suffix$id"
-        val objectPath = "/com/monkopedia/sdbus/dbusmock/Matrix$suffix$id"
-
-        val handle = launchDbusmock(busName, objectPath, busName)
-        if (handle == null) {
-            println(
-                "[DbusmockTypeMatrixTest] SKIP: python-dbusmock unavailable. " +
-                    "Install via 'apt install python3-dbusmock' / 'pip install python-dbusmock' " +
-                    "(see DbusmockHarness KDoc)."
-            )
-            return@runBlocking
-        }
-
-        val connection: Connection = createBusConnection()
-        connection.startEventLoop()
-        val control = createProxy(connection, ServiceName(busName), ObjectPath(objectPath))
-        val proxy = createProxy(connection, ServiceName(busName), ObjectPath(objectPath))
-        val peer = DbusmockPeer(control, proxy, InterfaceName(busName))
-
-        try {
-            // dbusmock takes a moment to claim its bus name; retry a no-op control call until
-            // the name is owned (or we time out).
-            retry(timeoutMillis = 15_000) {
-                peer.addMethod("Ready", "", "i", "ret = 0")
-            }
-            peer.block()
-        } finally {
-            proxy.release()
-            control.release()
-            connection.stopEventLoop()
-            connection.release()
-            handle.stop()
-        }
-    }
-
-    private inline fun retry(timeoutMillis: Long, block: () -> Unit) {
-        val start = TimeSource.Monotonic.markNow()
-        var last: Throwable? = null
-        while (start.elapsedNow().inWholeMilliseconds < timeoutMillis) {
-            val result = runCatching(block)
-            if (result.isSuccess) return
-            last = result.exceptionOrNull()
-            busyWait(100)
-        }
-        throw AssertionError("Timed out waiting for dbusmock to become ready", last)
-    }
-
-    private companion object {
-        private val MOCK_INTERFACE = InterfaceName("org.freedesktop.DBus.Mock")
     }
 }
 

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
@@ -42,3 +42,9 @@ internal actual fun readFromFd(fd: Int, maxBytes: Int): ByteArray? =
 internal actual fun closeTestFd(fd: Int) {
     // No raw fds are ever created on the JVM backend; nothing to close.
 }
+
+/**
+ * See the expect declaration (DbusmockForeignErrorTest.kt): the JVM backend discards foreign
+ * error names (issue #72). Flip to `true` when that bug is fixed.
+ */
+internal actual val peerErrorNameMappingSupported: Boolean = false

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.jvm.kt
@@ -36,22 +36,25 @@ internal actual class DbusmockHandle(private val process: Process) {
 internal actual fun launchDbusmock(
     busName: String,
     objectPath: String,
-    interfaceName: String
+    interfaceName: String,
+    objectManager: Boolean
 ): DbusmockHandle? {
     // No session bus -> nothing to launch dbusmock on; skip.
     if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) return null
 
     val python = dbusmockGetenv("DBUSMOCK_PYTHON") ?: "python3"
+    val command = buildList {
+        add(python)
+        add("-m")
+        add("dbusmock")
+        add("--session")
+        if (objectManager) add("-m")
+        add(busName)
+        add(objectPath)
+        add(interfaceName)
+    }
     return try {
-        val process = ProcessBuilder(
-            python,
-            "-m",
-            "dbusmock",
-            "--session",
-            busName,
-            objectPath,
-            interfaceName
-        ).redirectErrorStream(true)
+        val process = ProcessBuilder(command).redirectErrorStream(true)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .start()
 

--- a/cross_test/src/linuxX64Test/kotlin/integration/DbusmockFdSupport.linuxX64.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/DbusmockFdSupport.linuxX64.kt
@@ -60,3 +60,6 @@ internal actual fun readFromFd(fd: Int, maxBytes: Int): ByteArray? {
 internal actual fun closeTestFd(fd: Int) {
     close(fd)
 }
+
+/** See the expect declaration (DbusmockForeignErrorTest.kt): sd-bus preserves foreign error names. */
+internal actual val peerErrorNameMappingSupported: Boolean = true

--- a/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
@@ -59,21 +59,23 @@ internal actual class DbusmockHandle(private val pid: Int) {
 internal actual fun launchDbusmock(
     busName: String,
     objectPath: String,
-    interfaceName: String
+    interfaceName: String,
+    objectManager: Boolean
 ): DbusmockHandle? {
     // No session bus -> nothing to launch dbusmock on; skip.
     if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) return null
 
     val python = dbusmockGetenv("DBUSMOCK_PYTHON") ?: "python3"
-    val args = listOf(
-        python,
-        "-m",
-        "dbusmock",
-        "--session",
-        busName,
-        objectPath,
-        interfaceName
-    )
+    val args = buildList {
+        add(python)
+        add("-m")
+        add("dbusmock")
+        add("--session")
+        if (objectManager) add("-m")
+        add(busName)
+        add(objectPath)
+        add(interfaceName)
+    }
 
     val pid = fork()
     if (pid < 0) return null


### PR DESCRIPTION
Independent-peer (python-dbusmock) coverage for the event-driven half of the client API, per the #36 spec. All suites live in `cross_test` commonTest so the **exact same assertions** run against the native sd-bus backend (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`), following the #35/#70 pattern (graceful skip without python3-dbusmock, busyWait readiness polling, event-driven waits only).

Fixes #36.

## Coverage added (15 new tests, ×2 backends)

**`DbusmockSignalTest` (3)**
- `onSignal` payload shapes emitted by the foreign Python/GDBus stack: no-arg, `i`, multi-arg `xs`, `as`, `a{sv}`, and `t` at `ULong.MAX_VALUE`.
- `signalFlow` delivery and ordering (3 sequenced payloads), including unregistration via collection cancel.
- Subscribe → release → re-subscribe lifecycle; the no-delivery-after-release check is event-driven (a still-live "flush" signal emitted after the released one proves ordering, no sleeps).

**`DbusmockObjectManagerTest` (2)** — peer launched with dbusmock `-m` (harness gained an `objectManager` flag)
- Raw `InterfacesAdded`/`InterfacesRemoved` payloads (path + interface→properties map / interface list) from the foreign ObjectManager as the peer `AddObject`s/`RemoveObject`s children.
- `GetManagedObjects` round-trips (empty → populated → empty) agreeing with the signal-tracked state.
- `ObjectManagerProxy` flows (`objects`, `interfacesFor`, `objectsFor`, `objectData`) converging on the same view, plus initial-state seeding from `GetManagedObjects` when objects pre-date proxy construction.

**`DbusmockPropertiesChangedTest` (5)**
- Foreign `PropertiesChanged` with **real changed values** (dbusmock `UpdateProperties`), invalidation-only signals, and mixed changed+invalidated in one signal, via `registerPropertiesProxy`.
- `PropertyDelegate.changes()` (values delivered, invalidations dropped), `changesOrNull()` (invalidation → `null`), `values()` (initial Get + changes), `valuesOrNull()` (initial + `null` + recovery). This settles the #28 JVM-vs-native parity question for changed-value payloads: **both backends pass identically**.

**`DbusmockForeignErrorTest` (5)** — the independent-peer counterpart to #29 / validation of the #63 parity work
- Errors raised by the Python peer with standard names (`NotSupported`, `AccessDenied`, `InvalidArgs`), arbitrary custom names, dbus-python's own `UnknownMethod`, and property-path errors (`<iface>.UnknownProperty`), on both the sync and suspend call paths, asserted to surface as `com.monkopedia.sdbus.Error` with `name`/`errorMessage` preserved verbatim.

Shared infrastructure: the per-test peer lifecycle was extracted from `DbusmockTypeMatrixTest` into `DbusmockPeerFixture.kt` (now suspend-friendly, with `UpdateProperties`/`EmitSignal`/invalidation helpers and a `pumpUntilSubscribed` probe for flow-based subscriptions, since `signalFlow` registers only once collection starts).

## Library bug found (not fixed here): #72

**The JVM backend discards foreign D-Bus error names — every remote error reply surfaces as `org.freedesktop.DBus.Error.AccessDenied`.** `PureJavaDbusBackend` converts `org.freedesktop.dbus.messages.Error` replies via the errno-style `createError(-1, message)` (sync, async, and property paths alike), which maps through the EPERM table entry; the wire error name/message never reach `Error(name, errorMessage)`. The native backend preserves both verbatim (the full assertions pass ungated on linuxX64). Own-server JVM tests can't see this because in-process calls short-circuit through `JvmStaticDispatch` and rethrow the original exception object.

Filed as #72 with root cause + acceptance criteria. The JVM name/message assertions are gated behind `internal expect val peerErrorNameMappingSupported` (same pattern as #71's `peerStructMarshallingSupported`); `assertFailsWith<Error>` still runs ungated on JVM, and flipping the JVM actual to `true` after the #72 fix re-enables full parity enforcement.

No new #71 (struct-marshalling) exposure: all signal/property/OM payloads here are maps/lists/variants/primitives, so nothing needed that gate.

## Verification

- `./gradlew ktlintFormat` → `apiDump` is a **no-op** (`git diff -- api/` empty) → `ktlintCheck apiCheck` pass (test-only change, no `src/` modifications).
- `./gradlew compileKotlinLinuxX64 :cross_test:compileTestKotlinLinuxX64` pass.
- `dbus-run-session -- ./gradlew :cross_test:jvmTest :cross_test:linuxX64Test` with python-dbusmock 0.38.1: **all green** — jvm: 41 tests (28 dbusmock incl. 12 matrix + smoke), linuxX64: 43 tests, 0 failures, 0 skips. Without python3-dbusmock the new suites skip cleanly (assert nothing), preserving the ARM CI behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)