### PR TITLE
JVM wire fixes: struct marshalling, foreign error names, grouped replies (#71, #72, #74)

### DIFF
--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
@@ -21,10 +21,10 @@
 package com.monkopedia.sdbus.integration
 
 /**
- * See the expect declaration: the JVM backend cannot yet marshal custom @Serializable struct
- * values to or from remote peers, so the remote-struct sub-cases are skipped on this backend.
+ * Struct marshalling to/from remote peers is supported since the issue #71 fix (structs are
+ * decomposed into wire-shaped values via JvmValueCodec on the way to/from dbus-java).
  */
-internal actual val peerStructMarshallingSupported: Boolean = false
+internal actual val peerStructMarshallingSupported: Boolean = true
 
 /**
  * The JVM has no portable way to surface a freshly created pipe as a raw integer file
@@ -44,14 +44,14 @@ internal actual fun closeTestFd(fd: Int) {
 }
 
 /**
- * See the expect declaration (DbusmockForeignErrorTest.kt): the JVM backend discards foreign
- * error names (issue #72). Flip to `true` when that bug is fixed.
+ * Foreign error names/messages are preserved verbatim since the issue #72 fix (remote error
+ * replies construct Error(wireName, wireMessage) instead of going through the errno mapping).
  */
-internal actual val peerErrorNameMappingSupported: Boolean = false
+internal actual val peerErrorNameMappingSupported: Boolean = true
 
 /**
- * See the expect declaration (DbusmockSecretServiceTest.kt): the JVM backend cannot
- * deserialize multi-out (grouped) method replies from a real remote peer (issue #74). Flip
- * to `true` when that bug is fixed.
+ * Multi-out (grouped) replies from remote peers are supported since the issue #74 fix
+ * (structured deserialization consumes one reply value per out-arg via the common
+ * degrouping machinery).
  */
-internal actual val peerGroupedReturnSupported: Boolean = false
+internal actual val peerGroupedReturnSupported: Boolean = true

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/JvmValueCodec.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/JvmValueCodec.jvm.kt
@@ -1,0 +1,387 @@
+package com.monkopedia.sdbus
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
+
+// JVM counterpart of the native MessageEncoder/MessageDecoder pair (nativeMain/internal):
+// instead of writing into an sd-bus message, values are encoded into/decoded from the JVM
+// backend's payload value tree, where a D-Bus struct is represented by
+// [Message.JvmStructPayload] (mirroring how [Message.JvmVariantPayload] represents variants).
+// This is what allows @Serializable struct types to survive the trip through the dbus-java
+// wire layer, which needs structs decomposed into positional values (issue #71), and what
+// allows multi-out (grouped) replies to consume one payload value per out-arg (issue #74,
+// via the common degrouping machinery in DegroupingReturns.kt, which bypasses
+// beginStructure/endStructure on this encoder/decoder).
+
+private val unsignedNames = listOf(
+    "UInt",
+    "ULong",
+    "UByte",
+    "UShort"
+)
+
+/**
+ * Encodes [arg] into the JVM payload value tree using its serializer: primitives and the
+ * sdbus value types stay as themselves, lists/maps become List/Map, and struct-kind classes
+ * become [Message.JvmStructPayload] holding their decomposed field values. A degrouped
+ * serializer (multi-out reply) produces one top-level value per field.
+ */
+internal fun <T> encodeToJvmValues(
+    serializer: SerializationStrategy<T>,
+    module: SerializersModule,
+    arg: T
+): List<Any?> {
+    val values = mutableListOf<Any?>()
+    JvmValueEncoder(module, values::add).encodeSerializableValue(serializer, arg)
+    return values
+}
+
+internal class JvmValueEncoder(
+    override val serializersModule: SerializersModule,
+    private val sink: (Any?) -> Unit,
+    private val onEnd: () -> Unit = {}
+) : AbstractEncoder() {
+
+    private var lastInline: SerialDescriptor? = null
+    private val isUnsigned: Boolean
+        get() = (lastInline?.serialName?.removePrefix("kotlin.") in unsignedNames).also {
+            lastInline = null
+        }
+
+    override fun encodeNotNullMark() {
+        error("Nullables are not allowed for serialization")
+    }
+
+    override fun encodeNull() {
+        error("Nullables are not allowed for serialization")
+    }
+
+    override fun encodeInline(descriptor: SerialDescriptor): Encoder {
+        lastInline = descriptor
+        return this
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder =
+        when (descriptor.kind) {
+            StructureKind.LIST -> {
+                val items = mutableListOf<Any?>()
+                JvmValueEncoder(serializersModule, items::add) { sink(items.toList()) }
+            }
+
+            StructureKind.MAP -> {
+                val entries = mutableListOf<Any?>()
+                JvmValueEncoder(serializersModule, entries::add) {
+                    val map = LinkedHashMap<Any?, Any?>()
+                    var index = 0
+                    while (index + 1 < entries.size) {
+                        map[entries[index]] = entries[index + 1]
+                        index += 2
+                    }
+                    sink(map)
+                }
+            }
+
+            StructureKind.CLASS,
+            StructureKind.OBJECT -> {
+                val signature = descriptor.asSignature.value
+                val fields = mutableListOf<Any?>()
+                JvmValueEncoder(serializersModule, fields::add) {
+                    sink(Message.JvmStructPayload(signature, fields.toList()))
+                }
+            }
+
+            else -> error("Unsupported structure kind ${descriptor.kind} for serialization")
+        }
+
+    override fun endStructure(descriptor: SerialDescriptor) = onEnd()
+
+    override fun encodeBoolean(value: Boolean) {
+        lastInline = null
+        sink(value)
+    }
+
+    // D-Bus has no signed byte; BYTE-kind values travel as 'y' (see TypeTraits signatureOf),
+    // matching the native encoder which always appends bytes as UByte.
+    override fun encodeByte(value: Byte) {
+        lastInline = null
+        sink(value.toUByte())
+    }
+
+    override fun encodeChar(value: Char) {
+        lastInline = null
+        sink(value.code.toUByte())
+    }
+
+    override fun encodeShort(value: Short) {
+        sink(if (isUnsigned) value.toUShort() else value)
+    }
+
+    override fun encodeInt(value: Int) {
+        sink(if (isUnsigned) value.toUInt() else value)
+    }
+
+    override fun encodeLong(value: Long) {
+        sink(if (isUnsigned) value.toULong() else value)
+    }
+
+    override fun encodeFloat(value: Float) {
+        lastInline = null
+        sink(value.toDouble())
+    }
+
+    override fun encodeDouble(value: Double) {
+        lastInline = null
+        sink(value)
+    }
+
+    override fun encodeString(value: String) {
+        when (lastInline?.serialName) {
+            ObjectPath.SERIAL_NAME -> sink(ObjectPath(value))
+            Signature.SERIAL_NAME -> sink(Signature(value))
+            else -> sink(value)
+        }
+        lastInline = null
+    }
+
+    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
+        lastInline = null
+        sink(index)
+    }
+
+    override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+        when (serializer.descriptor.serialName) {
+            "kotlin.Unit" -> return
+            UnixFd.SERIAL_NAME -> sink(value as UnixFd)
+            Variant.SERIAL_NAME -> sink(value as Variant)
+            else -> super.encodeSerializableValue(serializer, value)
+        }
+    }
+}
+
+/**
+ * Decodes a value of [serializer]'s type by pulling payload values from [nextSlot] and
+ * recursing into container values. The inverse of [JvmValueEncoder]; see the file comment.
+ */
+internal fun <T> decodeFromJvmValues(
+    serializer: DeserializationStrategy<T>,
+    module: SerializersModule,
+    nextSlot: (String) -> Any?
+): T = serializer.deserialize(JvmValueDecoder(module, nextSlot))
+
+internal class JvmValueDecoder(
+    override val serializersModule: SerializersModule,
+    private val nextSlot: (String) -> Any?,
+    private val collectionSize: Int = -1
+) : AbstractDecoder() {
+
+    private var lastInline: SerialDescriptor? = null
+    private var elementIndex = 0
+
+    private fun next(operation: String): Any? = nextSlot(operation)
+
+    override fun decodeNotNullMark(): Boolean {
+        error("Nullables are not allowed for serialization")
+    }
+
+    override fun decodeNull(): Nothing? {
+        error("Nullables are not allowed for serialization")
+    }
+
+    override fun decodeSequentially(): Boolean = collectionSize >= 0
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = collectionSize
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int =
+        if (elementIndex < descriptor.elementsCount) {
+            elementIndex++
+        } else {
+            CompositeDecoder.DECODE_DONE
+        }
+
+    override fun decodeInline(descriptor: SerialDescriptor): Decoder {
+        lastInline = descriptor
+        return this
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
+        when (descriptor.kind) {
+            StructureKind.LIST -> {
+                val slot = next("Message.deserialize")
+                val items = jvmValueAsList(slot)
+                    ?: throw structMismatchError(descriptor, slot)
+                JvmValueDecoder(serializersModule, items.slotSource(), collectionSize = items.size)
+            }
+
+            StructureKind.MAP -> {
+                val slot = next("Message.deserialize")
+                val map = slot as? Map<*, *> ?: throw structMismatchError(descriptor, slot)
+                val flattened = map.entries.flatMap { listOf(it.key, it.value) }
+                JvmValueDecoder(
+                    serializersModule,
+                    flattened.slotSource(),
+                    collectionSize = map.size
+                )
+            }
+
+            StructureKind.CLASS,
+            StructureKind.OBJECT -> {
+                val slot = next("Message.deserialize")
+                val fields = (slot as? Message.JvmStructPayload)?.fields
+                    ?: throw structMismatchError(descriptor, slot)
+                JvmValueDecoder(serializersModule, fields.slotSource())
+            }
+
+            else -> error("Unsupported structure kind ${descriptor.kind} for serialization")
+        }
+
+    override fun endStructure(descriptor: SerialDescriptor) = Unit
+
+    override fun decodeBoolean(): Boolean = when (val slot = next("Message.readBoolean")) {
+        is Boolean -> slot
+        is Number -> slot.toInt() != 0
+        else -> throw slotTypeError("Message.readBoolean", slot)
+    }.also { lastInline = null }
+
+    override fun decodeByte(): Byte = slotLong("Message.readByte").toByte()
+
+    override fun decodeChar(): Char = Char(slotLong("Message.readChar").toInt()).also {
+        lastInline = null
+    }
+
+    override fun decodeShort(): Short = slotLong("Message.readShort").toShort()
+
+    override fun decodeInt(): Int = slotLong("Message.readInt").toInt()
+
+    override fun decodeLong(): Long = slotLong("Message.readLong")
+
+    override fun decodeFloat(): Float = slotDouble("Message.readFloat").toFloat()
+
+    override fun decodeDouble(): Double = slotDouble("Message.readDouble")
+
+    override fun decodeString(): String {
+        lastInline = null
+        return when (val slot = next("Message.readString")) {
+            is String -> slot
+            is ObjectPath -> slot.value
+            is Signature -> slot.value
+            is BusName -> slot.value
+            is InterfaceName -> slot.value
+            is MemberName -> slot.value
+            else -> slot?.toString() ?: throw slotTypeError("Message.readString", slot)
+        }
+    }
+
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int =
+        slotLong("Message.readEnum").toInt()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T =
+        when (deserializer.descriptor.serialName) {
+            "kotlin.Unit" -> Unit as T
+            UnixFd.SERIAL_NAME -> slotUnixFd() as T
+            Variant.SERIAL_NAME -> slotVariant() as T
+            else -> super.decodeSerializableValue(deserializer)
+        }
+
+    private fun slotUnixFd(): UnixFd = when (val slot = next("Message.readUnixFd")) {
+        is UnixFd -> slot
+        is Number -> UnixFd(slot.toInt())
+        else -> throw slotTypeError("Message.readUnixFd", slot)
+    }
+
+    private fun slotVariant(): Variant = when (val slot = next("Message.readVariant")) {
+        is Variant -> slot
+        is Message.JvmVariantPayload -> PlainMessage.createPlainMessage().let { message ->
+            message.payload.add(slot)
+            Variant().apply { deserializeFrom(message) }
+        }
+
+        else -> throw slotTypeError("Message.readVariant", slot)
+    }
+
+    private fun slotLong(operation: String): Long {
+        lastInline = null
+        return when (val slot = next(operation)) {
+            is Number -> slot.toLong()
+            is UByte -> slot.toLong()
+            is UShort -> slot.toLong()
+            is UInt -> slot.toLong()
+            is ULong -> slot.toLong()
+            is Boolean -> if (slot) 1L else 0L
+            else -> throw slotTypeError(operation, slot)
+        }
+    }
+
+    private fun slotDouble(operation: String): Double {
+        lastInline = null
+        return when (val slot = next(operation)) {
+            is Number -> slot.toDouble()
+            else -> throw slotTypeError(operation, slot)
+        }
+    }
+
+    private fun slotTypeError(operation: String, slot: Any?): Error = createError(
+        -1,
+        "$operation failed: unexpected payload type ${slot?.let { it::class.simpleName }}"
+    )
+
+    // ENXIO mirrors the native backend, which fails entering a mismatched container with
+    // -ENXIO from sd_bus_message_enter_container.
+    private fun structMismatchError(descriptor: SerialDescriptor, slot: Any?): Error {
+        val expected = runCatching { descriptor.asSignature.value }.getOrNull() ?: "?"
+        val actual = inferJvmPayloadSignature(slot) ?: slot?.let { it::class.simpleName } ?: "null"
+        return createError(
+            6,
+            "Message.deserialize failed: signature mismatch expected=$expected actual=$actual"
+        )
+    }
+}
+
+private fun List<Any?>.slotSource(): (String) -> Any? {
+    val iterator = iterator()
+    return { operation ->
+        if (!iterator.hasNext()) {
+            throw createError(-1, "$operation failed: no remaining payload")
+        }
+        iterator.next()
+    }
+}
+
+/** Normalizes the JVM payload representations of D-Bus arrays into a [List]. */
+internal fun jvmValueAsList(value: Any?): List<Any?>? = when (value) {
+    is List<*> -> value
+    is Array<*> -> value.toList()
+    is ByteArray -> value.toList()
+    is ShortArray -> value.toList()
+    is IntArray -> value.toList()
+    is LongArray -> value.toList()
+    is BooleanArray -> value.toList()
+    is FloatArray -> value.toList()
+    is DoubleArray -> value.toList()
+    else -> null
+}
+
+/**
+ * Whether this payload value (or any value nested in it) is a wire-shaped struct
+ * representation that needs structured decoding to become its Kotlin type again.
+ */
+internal fun containsJvmStructPayload(value: Any?): Boolean = when (value) {
+    is Message.JvmStructPayload -> true
+    is Message.JvmVariantPayload -> containsJvmStructPayload(value.value)
+    is List<*> -> value.any(::containsJvmStructPayload)
+    is Array<*> -> value.any(::containsJvmStructPayload)
+    is Map<*, *> -> value.entries.any {
+        containsJvmStructPayload(it.key) || containsJvmStructPayload(it.value)
+    }
+
+    else -> false
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.elementDescriptors
 import kotlinx.serialization.modules.SerializersModule
 
 private fun <T> requireJvmCredential(value: T?, name: String): T = value
@@ -16,6 +17,13 @@ private fun <T> requireJvmCredential(value: T?, name: String): T = value
 
 actual sealed class Message {
     internal data class JvmVariantPayload(val signature: String, val value: Any?)
+
+    // Wire-shaped representation of a D-Bus struct value in the JVM payload model: the
+    // declared struct signature (e.g. "(is)") plus its decomposed field values in order.
+    // Produced by JvmValueEncoder (serializing @Serializable struct types) and by the
+    // signature-aware dbus-java conversion in PureJavaDbusBackend (receiving structs from a
+    // remote peer); consumed by JvmValueDecoder. See JvmValueCodec.jvm.kt (issue #71).
+    internal data class JvmStructPayload(val signature: String, val fields: List<Any?>)
     internal data class Metadata(
         val interfaceName: String? = null,
         val memberName: String? = null,
@@ -59,6 +67,14 @@ actual sealed class Message {
         } else {
             nextRawValue(operation)
         }
+
+    // Non-consuming view of the values nextDeserializedValue would produce, used to decide
+    // between the structured (struct/grouped) and legacy value paths before reading anything.
+    internal fun peekDeserializableValues(): List<Any?> = if (enteredVariantValues.isNotEmpty()) {
+        listOf(enteredVariantValues.first())
+    } else {
+        payload.subList(readIndex, payload.size).toList()
+    }
 
     internal actual fun append(item: Boolean): Unit = run { payload.add(item) }
     internal actual fun append(item: Short): Unit = run { payload.add(item) }
@@ -199,9 +215,12 @@ actual sealed class Message {
         )
 }
 
+internal fun inferJvmPayloadSignature(value: Any?): String? = inferSignature(value)
+
 private fun inferSignature(value: Any?): String? = when (value) {
     null -> null
     is Message.JvmVariantPayload -> "v${value.signature}"
+    is Message.JvmStructPayload -> value.signature
     is Variant -> value.peekValueType()?.let { "v$it" }
     is Boolean -> "b"
     is Byte, is UByte -> "y"
@@ -522,12 +541,24 @@ internal actual fun <T> Message.serialize(
     module: SerializersModule,
     arg: T
 ) {
+    val signature = runCatching { serializer.descriptor.asSignature.value }.getOrNull()
+    if (signature != null && signature.contains('(')) {
+        // Struct-containing types are decomposed into the wire-shaped value tree (structs
+        // become JvmStructPayload) so the dbus-java layer can marshal them (issue #71). A
+        // degrouped serializer (multi-out reply, see DegroupingReturns.kt) produces one
+        // top-level value per out-arg here, matching the wire shape of a grouped reply
+        // (issue #74).
+        val values = encodeToJvmValues(serializer, module, arg)
+        payload.addAll(values)
+        declaredBodySignature.append(
+            if (values.size > 1) signature.removeSurrounding("(", ")") else signature
+        )
+        return
+    }
     payload.add(arg)
     // Record the declared signature from the descriptor so the send path uses the
     // real type instead of inferring it from the (possibly empty) runtime value.
-    runCatching { serializer.descriptor.asSignature.value }
-        .getOrNull()
-        ?.let { declaredBodySignature.append(it) }
+    signature?.let { declaredBodySignature.append(it) }
 }
 
 @PublishedApi
@@ -538,6 +569,10 @@ internal actual fun <T : Any> Message.deserialize(
     if (serializer.descriptor.serialName == "kotlin.Unit") {
         @Suppress("UNCHECKED_CAST")
         return Unit as T
+    }
+    val declaredSig = runCatching { serializer.descriptor.asSignature.value }.getOrDefault("")
+    if (declaredSig.contains('(')) {
+        deserializeStructured(serializer, module, declaredSig)?.let { return it }
     }
     val value = nextDeserializedValue("Message.deserialize")
     val coerced = coerceForDescriptor(value, serializer.descriptor)
@@ -562,6 +597,81 @@ internal actual fun <T : Any> Message.deserialize(
                 it::class.simpleName
             }}"
         )
+}
+
+/**
+ * Structured deserialization for types whose D-Bus signature contains a struct: rebuilds the
+ * Kotlin value through its serializer from wire-shaped payload values (issue #71), including
+ * grouped multi-out replies, which consume one payload value per out-arg through the common
+ * degrouping machinery (issue #74). Returns `null` to fall through to the legacy value path
+ * (raw in-process objects that were never decomposed, or containers without wire-shaped
+ * struct values, which plain coercion already handles).
+ */
+private fun <T : Any> Message.deserializeStructured(
+    serializer: DeserializationStrategy<T>,
+    module: SerializersModule,
+    expectedSig: String
+): T? {
+    val remaining = peekDeserializableValues()
+    val first = remaining.firstOrNull()
+        ?: return null // The legacy path produces the canonical "no remaining payload" error.
+    if (expectedSig.first() == '(') {
+        val firstSig = inferJvmPayloadSignature(first)
+        if (first !is Message.JvmStructPayload && firstSig == null) {
+            // A raw in-process Kotlin object passed through without decomposition; the
+            // legacy cast path handles it.
+            return null
+        }
+        val elementSigs = runCatching {
+            serializer.descriptor.elementDescriptors.map { it.asSignature.value }
+        }.getOrNull()
+        // The payload is acceptable either as a single struct value or as the degrouped
+        // tuple of a multi-out reply (one top-level value per out-arg). Which one applies
+        // is decided by the serializer itself during decoding (a degrouped serializer
+        // never enters the struct container); this check only enforces the same
+        // strictness as the legacy path before any value is consumed.
+        val singleOk = first is Message.JvmStructPayload &&
+            isSignatureCompatible(expectedSig, firstSig!!)
+        val groupedOk = elementSigs != null &&
+            remaining.size >= elementSigs.size &&
+            elementSigs.withIndex().all { (index, expected) ->
+                val actual = inferJvmPayloadSignature(remaining[index])
+                actual == null ||
+                    !shouldEnforceSignature(expected) ||
+                    isSignatureCompatible(expected, actual)
+            }
+        if (!singleOk && !groupedOk) {
+            val actualSig = if (first is Message.JvmStructPayload) {
+                firstSig
+            } else {
+                remaining.take(elementSigs?.size ?: 1)
+                    .joinToString("") { inferJvmPayloadSignature(it) ?: "?" }
+            }
+            // ENXIO mirrors the native backend's sd_bus_message_enter_container failure.
+            throw createError(
+                6,
+                "Message.deserialize failed: signature mismatch expected=$expectedSig actual=$actualSig"
+            )
+        }
+    } else {
+        // Container type holding struct values somewhere inside. Only the wire-shaped
+        // representation needs structured decoding; raw pass-through values (and empty
+        // containers) keep using the legacy coercion path.
+        if (!containsJvmStructPayload(first)) return null
+        val actualSig = inferJvmPayloadSignature(first)
+        if (actualSig != null &&
+            shouldEnforceSignature(expectedSig) &&
+            !isSignatureCompatible(expectedSig, actualSig)
+        ) {
+            throw createError(
+                6,
+                "Message.deserialize failed: signature mismatch expected=$expectedSig actual=$actualSig"
+            )
+        }
+    }
+    return decodeFromJvmValues(serializer, module) { operation ->
+        nextDeserializedValue(operation)
+    }
 }
 
 internal actual fun <T> Message.deserializeArrayFast(signature: SdbusSig, items: MutableList<T>) {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -592,8 +592,8 @@ private fun DBusSignal.toSdbusMessage(connection: AbstractConnection?): Signal =
         empty = false
     ).withSenderCredentials(connection, source)
 ).also { signal ->
-    runCatching { parameters.toList() }.getOrElse { emptyList() }
-        .map(::fromJavaSignalValue)
+    val values = runCatching { parameters.toList() }.getOrElse { emptyList() }
+    fromJavaWireValues(values, runCatching { sig }.getOrNull())
         .forEach { signal.payload.add(it) }
 }
 
@@ -625,6 +625,10 @@ private fun toJavaSignalValue(value: Any?): Any? = when (value) {
     is com.monkopedia.sdbus.ObjectPath -> value.value
     is Signature -> value.value
     is Message.JvmVariantPayload -> toJavaVariantValue(value.signature, value.value)
+    // dbus-java marshals struct values from positional Object[] contents (see its
+    // Message.appendOne STRUCT1 case), so the decomposed struct payload converts its
+    // fields in order (issue #71).
+    is Message.JvmStructPayload -> value.fields.map(::toJavaSignalValue).toTypedArray()
     is Variant -> extractVariantPayload(value).let { payload ->
         toJavaVariantValue(payload.signature, payload.value)
     }
@@ -648,7 +652,7 @@ private fun fromJavaVariantValue(value: org.freedesktop.dbus.types.Variant<*>): 
     message.payload.add(
         Message.JvmVariantPayload(
             signature,
-            fromJavaSignalValue(value.value)
+            fromJavaWireValue(value.value, signature)
         )
     )
     return Variant().apply { deserializeFrom(message) }
@@ -674,10 +678,9 @@ private fun toJavaVariantValue(
     signature
 )
 
-// Counts the number of top-level D-Bus types in a signature (e.g. "sa{sv}" -> 2),
-// used to check that a declared body signature lines up with the payload it describes.
-private fun countTopLevelTypes(signature: String?): Int {
-    if (signature.isNullOrEmpty()) return 0
+// Splits a D-Bus signature into its top-level single complete types
+// (e.g. "sa{sv}(is)" -> ["s", "a{sv}", "(is)"]).
+private fun splitTopLevelTypes(signature: String): List<String> {
     fun parseOne(index: Int): Int {
         if (index >= signature.length) return index
         return when (signature[index]) {
@@ -700,15 +703,78 @@ private fun countTopLevelTypes(signature: String?): Int {
         }
     }
 
+    val types = mutableListOf<String>()
     var index = 0
-    var count = 0
     while (index < signature.length) {
         val next = parseOne(index)
         if (next <= index) break
-        count++
+        types += signature.substring(index, next)
         index = next
     }
-    return count
+    return types
+}
+
+// Counts the number of top-level D-Bus types in a signature (e.g. "sa{sv}" -> 2),
+// used to check that a declared body signature lines up with the payload it describes.
+private fun countTopLevelTypes(signature: String?): Int =
+    if (signature.isNullOrEmpty()) 0 else splitTopLevelTypes(signature).size
+
+// Signature-aware conversion of a dbus-java message body into the JVM payload model. The
+// wire signature is authoritative: it is the only way to tell a struct value (extracted by
+// dbus-java as positional Object[] contents) apart from an array, so structs become
+// Message.JvmStructPayload carrying their exact signature (issue #71). Values whose
+// signature is unavailable fall back to the value-shape-based conversion.
+private fun fromJavaWireValues(values: List<Any?>, signature: String?): List<Any?> {
+    val types = signature?.let(::splitTopLevelTypes).orEmpty()
+    return values.mapIndexed { index, value -> fromJavaWireValue(value, types.getOrNull(index)) }
+}
+
+private fun fromJavaWireValue(value: Any?, signature: String?): Any? {
+    if (value == null || signature.isNullOrEmpty()) return fromJavaSignalValue(value)
+    return when {
+        signature.startsWith("(") && signature.endsWith(")") -> {
+            val fields = wireValueAsList(value) ?: return fromJavaSignalValue(value)
+            val fieldTypes = splitTopLevelTypes(signature.substring(1, signature.length - 1))
+            Message.JvmStructPayload(
+                signature,
+                fields.mapIndexed { index, field ->
+                    fromJavaWireValue(field, fieldTypes.getOrNull(index))
+                }
+            )
+        }
+
+        signature.startsWith("a{") && signature.endsWith("}") -> {
+            val map = value as? Map<*, *> ?: return fromJavaSignalValue(value)
+            val entryTypes = splitTopLevelTypes(signature.substring(2, signature.length - 1))
+            map.entries.associate { (key, entryValue) ->
+                fromJavaWireValue(key, entryTypes.getOrNull(0)) to
+                    fromJavaWireValue(entryValue, entryTypes.getOrNull(1))
+            }
+        }
+
+        signature.startsWith("a") -> {
+            val items = wireValueAsList(value) ?: return fromJavaSignalValue(value)
+            val elementType = signature.substring(1)
+            items.map { fromJavaWireValue(it, elementType) }
+        }
+
+        // Primitives and variants: variants carry their own signature on the dbus-java side,
+        // which fromJavaVariantValue (via fromJavaSignalValue) follows recursively.
+        else -> fromJavaSignalValue(value)
+    }
+}
+
+private fun wireValueAsList(value: Any?): List<Any?>? = when (value) {
+    is List<*> -> value
+    is Array<*> -> value.toList()
+    is ByteArray -> value.toList()
+    is ShortArray -> value.toList()
+    is IntArray -> value.toList()
+    is LongArray -> value.toList()
+    is BooleanArray -> value.toList()
+    is FloatArray -> value.toList()
+    is DoubleArray -> value.toList()
+    else -> null
 }
 
 // Wire signature for an outgoing body. Prefer the declared signature accumulated from
@@ -734,6 +800,7 @@ private fun bodySignature(
 private fun inferSignalSignature(value: Any?): String? = when (value) {
     null -> null
     is Message.JvmVariantPayload -> "v"
+    is Message.JvmStructPayload -> value.signature
     is Variant -> "v"
     is Boolean -> "b"
     is Byte, is UByte -> "y"
@@ -769,6 +836,18 @@ private fun inferSignalSignature(value: Any?): String? = when (value) {
     }
 
     else -> null
+}
+
+// A remote error reply carries the D-Bus error name in its ERROR_NAME header (surfaced by
+// dbus-java's Message.getName() for Error messages) and the human-readable message as the
+// first body argument. Both must be preserved verbatim like the native backend does (sd-bus
+// copies them straight into sd_bus_error) instead of being squeezed through the errno-based
+// createError mapping, which made every foreign error surface as AccessDenied (issue #72).
+private fun org.freedesktop.dbus.messages.Error.toSdbusError(): com.monkopedia.sdbus.Error {
+    val wireName = runCatching { name }.getOrNull()?.takeIf { it.isNotBlank() }
+        ?: return createError(-1, "Remote method call failed")
+    val wireMessage = runCatching { parameters.firstOrNull() as? String }.getOrNull().orEmpty()
+    return com.monkopedia.sdbus.Error(wireName, wireMessage)
 }
 
 private fun AbstractConnection.uniqueNameOrNull(): String? = (this as? DBusConnection)?.uniqueName
@@ -1198,17 +1277,16 @@ private class PureJavaDbusProxy(
         } ?: throw createError(-1, "Method call timed out")
 
         if (rawReply is org.freedesktop.dbus.messages.Error) {
-            val remoteError = runCatching {
-                rawReply.throwException()
-                null
-            }.exceptionOrNull()
-            throw createError(-1, remoteError?.message ?: "Remote method call failed")
+            throw rawReply.toSdbusError()
         }
         val values = runCatching {
-            rawReply.parameters.toList()
+            fromJavaWireValues(
+                rawReply.parameters.toList(),
+                runCatching { rawReply.sig }.getOrNull()
+            )
         }.getOrElse {
             throw createError(-1, "callMethod failed: ${it.message}")
-        }.map(::fromJavaSignalValue)
+        }
         val sender = rawReply.source ?: destination.value
         return methodReplyFrom(
             Message.Metadata(


### PR DESCRIPTION
Fixes the three JVM backend wire-protocol bugs found by the independent-peer (dbusmock) suites, with native sd-bus behavior as the reference. All three only manifest against a real remote peer: in-process own-server calls short-circuit through `JvmStaticDispatch` and never hit the wire conversion paths.

## #71 — struct marshalling to/from real peers

**Approach:** a new `JvmValueCodec.jvm.kt` introduces a `JvmValueEncoder`/`JvmValueDecoder` pair — the JVM counterpart of the native `MessageEncoder`/`MessageDecoder` — that encodes `@Serializable` values into / decodes them from the JVM backend's payload value tree. A D-Bus struct is represented by a new `Message.JvmStructPayload(signature, fields)` (mirroring how `JvmVariantPayload` represents variants).

- **Send path:** `Message.serialize` decomposes struct-containing types into wire-shaped values; `toJavaSignalValue` converts `JvmStructPayload` to the positional `Object[]` dbus-java's `Message.appendOne` STRUCT case expects (previously: "Trying to marshall to unconvertible type").
- **Receive path:** a new signature-aware `fromJavaWireValue` conversion uses the wire signature (the only way to tell a struct apart from an array once dbus-java has extracted it to `Object[]`/`List`) to rebuild `JvmStructPayload` from reply bodies, signal bodies, and variant contents. The #63 strict-signature checks are preserved — mismatched payloads still fail with the same ENXIO signature-mismatch error (previously structs inferred as arrays and were *correctly* rejected: `expected=(is) actual=ai`).

## #72 — foreign error names discarded

Remote error replies now construct `Error(wireName, wireMessage)` verbatim from the dbus-java `Error` message's ERROR_NAME header (`getName()`) and first body argument — matching sd-bus, which copies both straight into `sd_bus_error`. Previously everything was routed through the errno-based `createError(-1, msg)` and surfaced as `org.freedesktop.DBus.Error.AccessDenied`. Sync, async (delegates to the sync path and rethrows the `Error` unchanged), and remote property Get/Set/GetAll calls all flow through the same conversion. **Local errno-derived `createError` behavior is unchanged** — `JvmCreateErrorParityTest` (14 tests) pins it and passes.

## #74 — grouped multi-out replies

`Message.deserialize` previously consumed exactly one payload value, so a degrouped tuple expectation like `(vo)` was validated against just the first reply arg (`vs`) and rejected. It now routes struct-signature types through structured decoding (`deserializeStructured` → `JvmValueDecoder`), which consumes one payload value per out-arg through the common degrouping machinery in `DegroupingReturns.kt` (a degrouped serializer bypasses the outer `beginStructure`, pulling fields directly from the message payload). Single-struct replies and struct-containing containers decode through the same path; raw in-process values fall through to the legacy coercion path.

## Inherited work note

This PR completes work started by a prior interrupted agent run. The inherited `JvmValueCodec` approach was reviewed and kept as-is — it compiled cleanly, mirrors the native encoder/decoder architecture, and covers all conversion paths (method replies, signals, variants, property values, sync/async). Verification below was run fresh.

## Acceptance evidence

All three JVM gate flags flipped to `true` in `cross_test/src/jvmTest/.../DbusmockFdSupport.jvm.kt`, un-gating:

- `DbusmockTypeMatrixTest` struct round-trip sub-cases (12 tests, #71)
- `DbusmockForeignErrorTest` (5 tests, #72) + `DbusmockBluezTest` `org.bluez.Error.*` name assertions (7 tests)
- `DbusmockSecretServiceTest` (6 tests; gates on all three flags — `(vo)`, `(aoao)`, `(aoo)` grouped replies, struct secrets, error names)

Full suite, fresh runs (`dbus-run-session`, JAVA_HOME=java-21-openjdk):

| Suite | Result |
|---|---|
| `jvmTest` | 251 passed, 0 failed, 0 skipped |
| `linuxX64Test` | 268 passed, 0 failed, 0 skipped |
| `:cross_test:jvmTest` | 58 passed (dbusmock 0.38.1 **and** CI's 0.31.1) |
| `:cross_test:linuxX64Test` | 58 passed (both dbusmock versions) |
| `:codegen:test`, `:plugin:test`, `compileKotlinLinuxX64`, `:stress_test:compileTestKotlinJvm` | green |
| `ktlintCheck`, `apiCheck` | green; `apiDump` no-op (no public API change) |

#63 parity preserved: strict deserialization checks and `JvmCreateErrorParityTest` pass unchanged.

Fixes #71. Fixes #72. Fixes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)