### PR TITLE
JVM: apply connection methodCallTimeout; throw on unreachable bus instead of stub fallback (#80, #81)

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -24,7 +24,7 @@ Every row below is pinned by tests on current `main`, not by intention:
 | Struct (`@Serializable`) marshalling to/from remote peers | ✅ | ✅ | JVM fixed in #71 |
 | Multi-out (grouped) replies (`isGroupedReturn`) | ✅ | ✅ | JVM fixed in #74 |
 | Per-call timeout (`timeout = …` in the invoker block) | ✅ | ✅ | Timeout *error name* may differ, see below |
-| Connection-level `Connection.methodCallTimeout` | ⚠️ stored but not applied | ✅ applied | Known divergence, see below |
+| Connection-level `Connection.methodCallTimeout` | ✅ | ✅ | Applied as the default for calls without an explicit timeout; JVM fixed in #80 |
 | Error propagation: named D-Bus errors round-trip name + message verbatim | ✅ | ✅ | Incl. foreign (non-sdbus) peers; JVM fixed in #72 |
 | errno → D-Bus error-name mapping for locally created errors | ✅ | ✅ | JVM pinned to native output |
 | Call-after-release fails with `IllegalArgumentException("Connection has already been released")` | ✅ | ✅ | |
@@ -35,7 +35,7 @@ Every row below is pinned by tests on current `main`, not by intention:
 | `UnixFd` type semantics (dup constructor vs `adopt`, `release` closes) | ✅* | ✅ | *JVM dup needs junixsocket native support |
 | Unix FD passing over the wire | ⚠️ untested | ✅ | JVM has the conversion path but no independent-peer test |
 | Connection factories (11 total) | 9 of 11 | 11 of 11 | fd-based factories are native-only |
-| Behavior when the bus is unreachable | ⚠️ silent in-process stub | throws `Error` | Known divergence, see below |
+| Behavior when the bus is unreachable | ✅ throws `Error` | ✅ throws `Error` | JVM fixed in #81; the in-process stub backend is an explicit internal test opt-in only |
 | Event loop (`startEventLoop`/`stopEventLoop`) | no-op (always running) | required for dispatch | Same calling pattern works on both |
 | Strict deserialization (signature mismatch rejected) | ✅ | ✅ | Same `System.Error.ENXIO` error |
 
@@ -81,17 +81,23 @@ timeout-shaped `com.monkopedia.sdbus.Error` — never a hang.
   (`methodCallTimeout_surfacesTimeoutError`) and the `callbackAsyncMethodCall_timeout*` tests
   in `CommonApiIntegrationTest.kt`.
 
-Two honest caveats, both visible in the tests:
+The **connection-level default** (`Connection.methodCallTimeout`) applies on both backends to
+calls made *without* an explicit per-call timeout: on native it maps to
+`sd_bus_set/get_method_call_timeout` (sd_bus resolves a 0 per-call timeout through the
+connection default inside `sd_bus_call`); the JVM call paths consult the stored value the same
+way (issue #80). An explicit per-call timeout always wins over the connection default; if
+neither is set, each backend's own default reply timeout applies (sd-bus's 25 s default /
+dbus-java's default reply timeout).
+
+- Proven by: `FailurePathParityTest.connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout`
+  (both backends: connection default expires a slow call made with no per-call timeout, and an
+  explicit per-call timeout overrides the connection default).
+
+One honest caveat, visible in the tests:
 
 - The exact timeout **error name** is not pinned across backends/daemons: it is
   `org.freedesktop.DBus.Error.Timeout`, `…NoReply`, or a message containing "timed out".
   `FailurePathParityTest` deliberately asserts membership in that set, not an exact name.
-- **Known divergence — `Connection.methodCallTimeout`:** on native this property maps to
-  `sd_bus_set/get_method_call_timeout` and applies as the default for calls without an
-  explicit timeout (`ConnectionImpl.kt`). On JVM the setter stores the value and the getter
-  returns it, but no call path consults it (`PureJavaDbusConnection` in
-  `PureJavaDbusBackend.kt`) — calls without a per-call timeout use dbus-java's own default
-  reply timeout instead. Use per-call timeouts for portable behavior.
 
 ## Error propagation and name mapping
 
@@ -210,14 +216,19 @@ There are 11 `create*Connection` entry points (`src/commonMain/.../Connection.kt
   hostname), while the JVM backend passes the string as a dbus-java bus *address* (e.g.
   `tcp:host=…,port=…`). Neither path is covered by CI tests; do not assume portability.
 
-**Known divergence — bus-unreachable behavior:** when opening the bus fails (e.g. no
-`DBUS_SESSION_BUS_ADDRESS`), the native backend throws `com.monkopedia.sdbus.Error`. The JVM
-backend instead **silently falls back to an in-process stub backend**
-(`StubJvmDbusBackend` in `src/jvmMain/.../JvmDbusBackend.kt`): the returned connection only
-reaches objects/proxies created inside the same process (in-process match bus), and
-bus-level operations are no-ops. Only `createDirectBusConnection(address)` propagates the
-connect failure as an `Error` on JVM. If your JVM application must talk to a real bus,
-verify reachability explicitly (e.g. check `connection.uniqueName` is not `:jvm-stub`).
+**Bus-unreachable behavior:** when opening the bus fails (e.g. no
+`DBUS_SESSION_BUS_ADDRESS`, or an address that points nowhere), **both backends throw
+`com.monkopedia.sdbus.Error`** (issue #81; previously the JVM backend silently fell back to
+an in-process stub that faked success). The exact error *name* is not pinned across backends
+— native carries the errno from `sd_bus_open_*`, while dbus-java does not expose an errno —
+but the type and the throw are the contract. The in-process stub backend
+(`StubJvmDbusBackend` in `src/jvmMain/.../JvmDbusBackend.kt`) still exists for unit tests
+that need connection plumbing without a real bus, but it is an **explicit internal opt-in**
+(tests construct it directly or mock `JvmDbusBackendProvider`); it is never selected
+implicitly by any factory.
+
+- Proven by: `src/jvmTest/.../JvmUnreachableBusTest.kt` (unreachable session/direct addresses
+  throw `Error`) and `PureJavaDbusBackendTest.createConnection_throwsWhenEndpointMissing`.
 
 ## Event loop semantics
 
@@ -262,14 +273,15 @@ on native. `currentlyProcessedMessage` is valid inside handlers on both backends
 2. **Raw-fd semantics depend on junixsocket native support**: without it, `UnixFd`
    duplication/closing degrade (no dup, no close). Wire fd passing is implemented but not
    CI-verified against an independent peer.
-3. **`Connection.methodCallTimeout` is not applied** to calls — use per-call timeouts.
-4. **Silent stub fallback when the bus is unreachable** instead of throwing.
-5. **`createRemoteSystemBusConnection(host)` interprets its argument differently** (bus
+3. **`createRemoteSystemBusConnection(host)` interprets its argument differently** (bus
    address, not ssh host).
-6. Historical gaps — object-side signal emission and `PropertiesChanged` emission — are
+4. Historical gaps — object-side signal emission and `PropertiesChanged` emission — are
    closed and pinned by `JvmSignalPropertyUnsupportedTest`; struct marshalling, foreign error
    names, and grouped replies are closed (#71/#72/#74) and pinned by the un-gated
-   `cross_test` dbusmock suites.
+   `cross_test` dbusmock suites; `Connection.methodCallTimeout` application and
+   throw-on-unreachable-bus are closed (#80/#81) and pinned by
+   `FailurePathParityTest.connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout`
+   and `JvmUnreachableBusTest`.
 
 Everything not listed above is contract-level parity, enforced by the commonTest and
 cross_test suites on every CI run.

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -115,6 +115,74 @@ class FailurePathParityTest {
         }
     }
 
+    // The connection-level default timeout (Connection.methodCallTimeout) must apply to calls
+    // made WITHOUT an explicit per-call timeout on both backends (issue #80): native wires it
+    // to sd_bus_set_method_call_timeout (a 0 per-call timeout resolves to the connection
+    // default inside sd_bus_call); the JVM backend now consults the stored value the same way.
+    // An explicit per-call timeout must still win over the connection default.
+    @Test
+    fun connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout() = runBlocking {
+        val ids = uniqueFixtureIds("connTimeout")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        proxyConnection.methodCallTimeout = 100.milliseconds
+        val obj = createObject(serverConnection, ids.path)
+        // Same slow-method fixture as methodCallTimeout_surfacesTimeoutError: the handler
+        // sleeps past the (connection-default) timeout, then completes while both loops are
+        // still up so its late reply doesn't hit a torn-down native connection.
+        val serverDelayMs = 600L
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("Slow")) {
+                acall { value: Int ->
+                    delay(serverDelayMs)
+                    value
+                }
+            }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path)
+
+        try {
+            // No per-call timeout anywhere in this call: the raw message API's
+            // callMethod(message) overload carries the unset sentinel, so the connection's
+            // methodCallTimeout default must apply and expire the call.
+            val thrown = assertFailsWith<Error> {
+                val call = proxy.createMethodCall(ids.iface, MethodName("Slow"))
+                call.append(1)
+                proxy.callMethod(call)
+            }
+            assertTrue(
+                thrown.name.contains("Timeout") ||
+                    thrown.name.contains("NoReply") ||
+                    thrown.errorMessage.contains("timed out", ignoreCase = true),
+                "expected a timeout-shaped error, got name='${thrown.name}' " +
+                    "message='${thrown.errorMessage}'"
+            )
+
+            // An explicit per-call timeout always wins over the connection default: with a
+            // generous per-call timeout the same slow method completes successfully.
+            val result = proxy.callMethod<Int>(ids.iface, MethodName("Slow")) {
+                call(2)
+                timeout = 5_000.milliseconds
+            }
+            assertEquals(2, result)
+
+            // Let the first (timed-out) handler invocation flush its late reply while the
+            // loops are still alive.
+            delay(serverDelayMs + 400)
+        } finally {
+            withTimeout(5_000) {
+                proxyConnection.stopEventLoop()
+                serverConnection.stopEventLoop()
+            }
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
     // --- remote D-Bus error propagation ----------------------------------------------------
 
     // A handler that throws a named D-Bus Error must reach the client with the same name AND

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
@@ -113,9 +113,19 @@ internal interface JvmDbusBackend {
 }
 
 internal object JvmDbusBackendProvider {
-    val backend: JvmDbusBackend = PureJavaDbusBackend(StubJvmDbusBackend())
+    val backend: JvmDbusBackend = PureJavaDbusBackend()
 }
 
+/**
+ * In-process stub backend for unit tests that need connection/proxy/object plumbing without a
+ * real bus (signals via [LocalJvmMatchBus], method dispatch via [JvmStaticDispatch]).
+ *
+ * This backend is never selected implicitly: the real connection factories throw when the bus
+ * is unreachable, matching the native backend (issue #81). Tests opt in explicitly by
+ * constructing [StubJvmDbusBackend] and wrapping its connections in
+ * [com.monkopedia.sdbus.JvmConnection] (see StubJvmDbusBackendTest), or by mocking
+ * [JvmDbusBackendProvider].
+ */
 internal class StubJvmDbusBackend : JvmDbusBackend {
     override fun createConnection(
         busType: JvmBusType,

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -56,7 +56,7 @@ import org.freedesktop.dbus.types.UInt64
 private const val OBJECT_MANAGER_INTERFACE_NAME = "org.freedesktop.DBus.ObjectManager"
 private const val OBJECT_MANAGER_GET_MANAGED_OBJECTS = "GetManagedObjects"
 
-internal class PureJavaDbusBackend(private val fallbackBackend: JvmDbusBackend) : JvmDbusBackend {
+internal class PureJavaDbusBackend : JvmDbusBackend {
     override fun createConnection(
         busType: JvmBusType,
         endpoint: String?,
@@ -75,17 +75,22 @@ internal class PureJavaDbusBackend(private val fallbackBackend: JvmDbusBackend) 
                 "JVM backend does not support createServerBusConnection(fd)"
             )
         }
+        // Native parity (issue #81): an unreachable bus must surface as a thrown Error, like
+        // the native backend's openBus ("Failed to open bus", errno from sd_bus_open_*) --
+        // never a silent fallback to an in-process stub that fakes success. dbus-java does
+        // not expose an errno, so the exact error *name* is not pinned across backends, but
+        // the Error type and the throw are.
         val connection = runCatching {
             tryCreateConnection(busType, endpoint, fd)
         }.getOrElse {
-            if (busType == JvmBusType.DIRECT_ADDRESS && endpoint != null) {
-                throw createError(
-                    -1,
-                    "Failed to create direct JVM D-Bus connection for '$endpoint': ${it.message}"
-                )
-            }
-            null
-        } ?: return fallbackBackend.createConnection(busType, endpoint, name, fd)
+            throw createError(
+                -1,
+                "Failed to open bus${endpoint?.let { e -> " '$e'" }.orEmpty()}: ${it.message}"
+            )
+        } ?: throw createError(
+            -1,
+            "Failed to open bus: unsupported connection request for $busType"
+        )
         return PureJavaDbusConnection(connection).also { conn ->
             if (name != null) {
                 conn.requestName(name)
@@ -102,13 +107,21 @@ internal class PureJavaDbusBackend(private val fallbackBackend: JvmDbusBackend) 
         if (runEventLoopThread) {
             connection.startEventLoop()
         }
-        val javaConnection = (connection as? JvmConnection)?.backend as? PureJavaDbusConnection
+        val connectionBackend = (connection as? JvmConnection)?.backend
+        val javaConnection = connectionBackend as? PureJavaDbusConnection
         return PureJavaDbusProxy(
             javaConnection?.javaConnection,
             destination,
             objectPath,
             runCatching { connection.uniqueName.value }.getOrNull(),
-            isConnectionReleased = { javaConnection?.isReleased() == true }
+            isConnectionReleased = { javaConnection?.isReleased() == true },
+            defaultTimeoutMicros = {
+                connectionBackend?.getMethodCallTimeout()
+                    ?.inWholeMicroseconds
+                    ?.coerceAtLeast(0L)
+                    ?.toULong()
+                    ?: 0uL
+            }
         )
     }
 
@@ -952,7 +965,8 @@ private class PureJavaDbusProxy(
     private val destination: ServiceName,
     private val objectPath: ObjectPath,
     private val callerName: String?,
-    private val isConnectionReleased: () -> Boolean = { false }
+    private val isConnectionReleased: () -> Boolean = { false },
+    private val defaultTimeoutMicros: () -> ULong = { 0uL }
 ) : JvmDbusProxy {
     private fun invalidReply(path: String, interfaceName: String, methodName: String): MethodReply =
         methodReplyFrom(
@@ -1000,52 +1014,10 @@ private class PureJavaDbusProxy(
         )
     }
 
-    override fun callMethod(message: MethodCall): MethodReply {
-        requireConnectionUsable()
-        val interfaceName = message.interfaceName?.value
-            ?: throw createError(-1, "callMethod failed: missing interface name")
-        val methodName = message.memberName?.value
-            ?: throw createError(-1, "callMethod failed: missing method name")
-        val path = message.path?.value ?: objectPath.value
-        val realConnection = connection
-        if (realConnection != null) {
-            val localDestination = resolveLocalDispatchDestination(realConnection)
-            val dispatchDestination = localDestination ?: destination.value
-            if (
-                JvmStaticDispatch.hasHandler(
-                    objectPath = path,
-                    interfaceName = interfaceName,
-                    methodName = methodName,
-                    args = message.payload,
-                    destination = dispatchDestination
-                )
-            ) {
-                return callStaticDispatch(
-                    message = message,
-                    interfaceName = interfaceName,
-                    methodName = methodName,
-                    path = path,
-                    dispatchDestination = dispatchDestination
-                )
-            }
-            return callRemoteMethod(
-                connection = realConnection,
-                interfaceName = interfaceName,
-                methodName = methodName,
-                path = path,
-                payload = message.payload.toList(),
-                declaredSignature = message.declaredBodySignature.toString(),
-                timeout = null
-            )
-        }
-        return callStaticDispatch(
-            message = message,
-            interfaceName = interfaceName,
-            methodName = methodName,
-            path = path,
-            dispatchDestination = destination.value
-        )
-    }
+    // A call without a timeout argument carries the same "no explicit timeout" meaning as the
+    // 0 sentinel (Duration.ZERO at the API surface), so it funnels through the same resolution
+    // and picks up the connection-level methodCallTimeout default when one is set (issue #80).
+    override fun callMethod(message: MethodCall): MethodReply = callMethod(message, 0uL)
 
     private fun callStaticDispatch(
         message: MethodCall,
@@ -1110,6 +1082,11 @@ private class PureJavaDbusProxy(
 
     override fun callMethod(message: MethodCall, timeout: ULong): MethodReply {
         requireConnectionUsable()
+        // Native parity (issue #80): an explicit per-call timeout always wins; the
+        // connection-level methodCallTimeout only fills the unset (0) case -- exactly how
+        // sd_bus_call resolves a 0 timeout via sd_bus_get_method_call_timeout. If neither is
+        // set, the effective timeout stays 0 and the pre-existing default behavior applies.
+        val effectiveTimeout = if (timeout == 0uL) defaultTimeoutMicros() else timeout
         val interfaceName = message.interfaceName?.value
             ?: throw createError(-1, "callMethod failed: missing interface name")
         val methodName = message.memberName?.value
@@ -1128,7 +1105,7 @@ private class PureJavaDbusProxy(
                     destination = dispatchDestination
                 )
             ) {
-                return if (timeout == 0uL) {
+                return if (effectiveTimeout == 0uL) {
                     callStaticDispatch(
                         message = message,
                         interfaceName = interfaceName,
@@ -1142,7 +1119,7 @@ private class PureJavaDbusProxy(
                         interfaceName = interfaceName,
                         methodName = methodName,
                         path = path,
-                        timeout = timeout,
+                        timeout = effectiveTimeout,
                         dispatchDestination = dispatchDestination
                     )
                 }
@@ -1154,10 +1131,10 @@ private class PureJavaDbusProxy(
                 path = path,
                 payload = message.payload.toList(),
                 declaredSignature = message.declaredBodySignature.toString(),
-                timeout = timeout.takeUnless { it == 0uL }
+                timeout = effectiveTimeout.takeUnless { it == 0uL }
             )
         }
-        if (timeout == 0uL) {
+        if (effectiveTimeout == 0uL) {
             return callStaticDispatch(
                 message = message,
                 interfaceName = interfaceName,
@@ -1171,7 +1148,7 @@ private class PureJavaDbusProxy(
             interfaceName = interfaceName,
             methodName = methodName,
             path = path,
-            timeout = timeout,
+            timeout = effectiveTimeout,
             dispatchDestination = destination.value
         )
     }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -9,6 +9,16 @@ import kotlinx.coroutines.withTimeout
 
 class JvmRealBusIntegrationTest {
 
+    // These tests need a *real* bus. The connection factories throw when the bus is
+    // unreachable (issue #81) instead of silently returning the in-process stub backend, so
+    // "no usable bus in this environment" now surfaces as a thrown Error -- treat it as a
+    // skip, the way the old ":jvm-stub" unique-name gate did.
+    private fun connectOrNull(connect: () -> Connection): Connection? = try {
+        connect()
+    } catch (e: Error) {
+        null
+    }
+
     // Regression for the BlueZ-on-JVM failure, exercised over the real wire (same-process
     // calls short-circuit through local dispatch and never serialize, so they can't catch
     // this). An empty collection argument used to be serialized with an inferred signature,
@@ -19,11 +29,7 @@ class JvmRealBusIntegrationTest {
     // serializes as "as" and succeeds; without it the connection is torn down.
     @Test
     fun methodCall_withEmptyArrayArg_overWire_doesNotDropConnection() = runBlocking {
-        val connection = createBusConnection()
-        if (connection.uniqueName.value == ":jvm-stub") {
-            connection.release()
-            return@runBlocking
-        }
+        val connection = connectOrNull { createBusConnection() } ?: return@runBlocking
         val proxy = createProxy(
             connection,
             ServiceName("org.freedesktop.DBus"),
@@ -46,13 +52,13 @@ class JvmRealBusIntegrationTest {
 
     @Test
     fun createSystemBusConnection_usesDistinctConnectionsWhenRealBusIsAvailable() {
-        val first = createSystemBusConnection()
-        val second = createSystemBusConnection()
+        val first = connectOrNull { createSystemBusConnection() } ?: return
+        val second = connectOrNull { createSystemBusConnection() } ?: run {
+            first.release()
+            return
+        }
         try {
-            val firstUnique = first.uniqueName.value
-            val secondUnique = second.uniqueName.value
-            if (firstUnique == ":jvm-stub" || secondUnique == ":jvm-stub") return
-            assertNotEquals(firstUnique, secondUnique)
+            assertNotEquals(first.uniqueName.value, second.uniqueName.value)
         } finally {
             second.release()
             first.release()
@@ -61,13 +67,13 @@ class JvmRealBusIntegrationTest {
 
     @Test
     fun createSessionBusConnection_usesDistinctConnectionsWhenRealBusIsAvailable() {
-        val first = createSessionBusConnection()
-        val second = createSessionBusConnection()
+        val first = connectOrNull { createSessionBusConnection() } ?: return
+        val second = connectOrNull { createSessionBusConnection() } ?: run {
+            first.release()
+            return
+        }
         try {
-            val firstUnique = first.uniqueName.value
-            val secondUnique = second.uniqueName.value
-            if (firstUnique == ":jvm-stub" || secondUnique == ":jvm-stub") return
-            assertNotEquals(firstUnique, secondUnique)
+            assertNotEquals(first.uniqueName.value, second.uniqueName.value)
         } finally {
             second.release()
             first.release()
@@ -84,12 +90,9 @@ class JvmRealBusIntegrationTest {
         val objectManagerInterface = InterfaceName("org.freedesktop.DBus.ObjectManager")
         val interfacesAdded = SignalName("InterfacesAdded")
 
-        val serverConnection = createSessionBusConnection(service)
-        val proxyConnection = createSessionBusConnection()
-        val serverUnique = serverConnection.uniqueName.value
-        val proxyUnique = proxyConnection.uniqueName.value
-        if (serverUnique == ":jvm-stub" || proxyUnique == ":jvm-stub") {
-            proxyConnection.release()
+        val serverConnection = connectOrNull { createSessionBusConnection(service) }
+            ?: return@runBlocking
+        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
             serverConnection.release()
             return@runBlocking
         }
@@ -135,12 +138,9 @@ class JvmRealBusIntegrationTest {
         val valueProperty = PropertyName("value")
         var value = 17
 
-        val serverConnection = createSessionBusConnection(service)
-        val proxyConnection = createSessionBusConnection()
-        val serverUnique = serverConnection.uniqueName.value
-        val proxyUnique = proxyConnection.uniqueName.value
-        if (serverUnique == ":jvm-stub" || proxyUnique == ":jvm-stub") {
-            proxyConnection.release()
+        val serverConnection = connectOrNull { createSessionBusConnection(service) }
+            ?: return@runBlocking
+        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
             serverConnection.release()
             return@runBlocking
         }
@@ -188,15 +188,13 @@ class JvmRealBusIntegrationTest {
         val valueProperty = PropertyName("value")
         var value = 23
 
-        val serverConnection = createSystemBusConnection()
-        val proxyConnection = createSystemBusConnection()
-        val serverUnique = serverConnection.uniqueName.value
-        val proxyUnique = proxyConnection.uniqueName.value
-        if (serverUnique == ":jvm-stub" || proxyUnique == ":jvm-stub") {
-            proxyConnection.release()
+        val serverConnection = connectOrNull { createSystemBusConnection() }
+            ?: return@runBlocking
+        val proxyConnection = connectOrNull { createSystemBusConnection() } ?: run {
             serverConnection.release()
             return@runBlocking
         }
+        val serverUnique = serverConnection.uniqueName.value
 
         serverConnection.startEventLoop()
         proxyConnection.startEventLoop()
@@ -241,15 +239,13 @@ class JvmRealBusIntegrationTest {
         val signalName = SignalName("Changed")
         val expectedPid = ProcessHandle.current().pid().toInt()
 
-        val serverConnection = createSessionBusConnection(service)
-        val proxyConnection = createSessionBusConnection()
-        val serverUnique = serverConnection.uniqueName.value
-        val proxyUnique = proxyConnection.uniqueName.value
-        if (serverUnique == ":jvm-stub" || proxyUnique == ":jvm-stub") {
-            proxyConnection.release()
+        val serverConnection = connectOrNull { createSessionBusConnection(service) }
+            ?: return@runBlocking
+        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
             serverConnection.release()
             return@runBlocking
         }
+        val serverUnique = serverConnection.uniqueName.value
 
         val senderSeen = CompletableDeferred<String>()
         val pidSeen = CompletableDeferred<Int>()

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmScaffoldTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmScaffoldTest.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.runBlocking
 
 class JvmScaffoldTest {
     @Test
-    fun createBusConnection_hasStubUniqueName() {
+    fun createBusConnection_hasUniqueName() {
         val connection = createBusConnection()
         assertTrue(connection.uniqueName.value.isNotBlank())
     }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmUnreachableBusTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmUnreachableBusTest.kt
@@ -1,0 +1,47 @@
+package com.monkopedia.sdbus
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Pins the issue #81 fix: when the bus is unreachable, the JVM connection factories must THROW
+ * a [com.monkopedia.sdbus.Error] like the native backend (whose openBus fails with
+ * "Failed to open bus") -- never silently fall back to the in-process stub backend
+ * (`StubJvmDbusBackend`, unique name `:jvm-stub`) and fake a successful connection.
+ *
+ * The exact D-Bus error *name* is not pinned across backends because dbus-java does not expose
+ * the underlying errno that sd-bus would surface; the contract is the Error type and the throw.
+ */
+class JvmUnreachableBusTest {
+
+    private fun unreachableAddress(): String =
+        "unix:path=/nonexistent/sdbus-kotlin-test-${System.nanoTime()}"
+
+    // createSessionBusConnection(address) is the deterministic way to point a session-bus
+    // connection at an address that goes nowhere, independent of the DBUS_SESSION_BUS_ADDRESS
+    // the test runner itself was started with.
+    @Test
+    fun createSessionBusConnection_withUnreachableAddress_throwsInsteadOfStubFallback() {
+        val error = assertFailsWith<Error> {
+            createSessionBusConnection(unreachableAddress())
+        }
+        assertTrue(
+            error.errorMessage.contains("Failed to open bus"),
+            "expected a bus-open failure, got name='${error.name}' " +
+                "message='${error.errorMessage}'"
+        )
+    }
+
+    @Test
+    fun createDirectBusConnection_withUnreachableAddress_throwsError() {
+        val error = assertFailsWith<Error> {
+            createDirectBusConnection(unreachableAddress())
+        }
+        assertTrue(
+            error.errorMessage.contains("Failed to open bus"),
+            "expected a bus-open failure, got name='${error.name}' " +
+                "message='${error.errorMessage}'"
+        )
+    }
+}

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackendTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackendTest.kt
@@ -9,15 +9,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class PureJavaDbusBackendTest {
     @Test
     fun createProxy_startsEventLoopUnlessDisabled() {
-        val fallback = mockk<JvmDbusBackend>(relaxed = true)
-        val backend = PureJavaDbusBackend(fallback)
+        val backend = PureJavaDbusBackend()
         val connection = mockk<Connection>(relaxed = true)
         val destination = ServiceName("org.example.Proxy")
         val objectPath = ObjectPath("/org/example/proxy")
@@ -42,8 +40,7 @@ class PureJavaDbusBackendTest {
 
     @Test
     fun createConnection_rejectsFdBackedBuses() {
-        val fallback = mockk<JvmDbusBackend>(relaxed = true)
-        val backend = PureJavaDbusBackend(fallback)
+        val backend = PureJavaDbusBackend()
 
         val directError = assertFailsWith<Error> {
             backend.createConnection(JvmBusType.DIRECT_FD, null, null, 11)
@@ -54,41 +51,22 @@ class PureJavaDbusBackendTest {
 
         assertTrue(directError.message.orEmpty().contains("createDirectBusConnection(fd)"))
         assertTrue(serverError.message.orEmpty().contains("createServerBusConnection(fd)"))
-        verify(exactly = 0) {
-            fallback.createConnection(JvmBusType.DIRECT_FD, null, null, 11)
-        }
-        verify(exactly = 0) {
-            fallback.createConnection(JvmBusType.SERVER_FD, null, null, 12)
-        }
     }
 
+    // Native parity (issue #81): an unsatisfiable connection request must throw, never fall
+    // back to an in-process stub that fakes success.
     @Test
-    fun createConnection_usesFallbackWhenEndpointMissing() {
-        val fallback = mockk<JvmDbusBackend>()
-        val backend = PureJavaDbusBackend(fallback)
-        val sessionAddressConnection = mockk<JvmDbusConnection>()
-        val remoteSystemConnection = mockk<JvmDbusConnection>()
-        val named = ServiceName("org.example.Named")
+    fun createConnection_throwsWhenEndpointMissing() {
+        val backend = PureJavaDbusBackend()
 
-        every {
-            fallback.createConnection(JvmBusType.SESSION_ADDRESS, null, named, null)
-        } returns sessionAddressConnection
-        every {
-            fallback.createConnection(JvmBusType.REMOTE_SYSTEM, null, null, null)
-        } returns remoteSystemConnection
-
-        val sessionAddressResult =
-            backend.createConnection(JvmBusType.SESSION_ADDRESS, null, named, null)
-        val remoteSystemResult =
+        val sessionAddressError = assertFailsWith<Error> {
+            backend.createConnection(JvmBusType.SESSION_ADDRESS, null, null, null)
+        }
+        val remoteSystemError = assertFailsWith<Error> {
             backend.createConnection(JvmBusType.REMOTE_SYSTEM, null, null, null)
+        }
 
-        assertEquals(sessionAddressConnection, sessionAddressResult)
-        assertEquals(remoteSystemConnection, remoteSystemResult)
-        verify(exactly = 1) {
-            fallback.createConnection(JvmBusType.SESSION_ADDRESS, null, named, null)
-        }
-        verify(exactly = 1) {
-            fallback.createConnection(JvmBusType.REMOTE_SYSTEM, null, null, null)
-        }
+        assertTrue(sessionAddressError.message.orEmpty().contains("Failed to open bus"))
+        assertTrue(remoteSystemError.message.orEmpty().contains("Failed to open bus"))
     }
 }


### PR DESCRIPTION
Fixes #80. Fixes #81.

Two owner-approved JVM behavior fixes from the #66 parity-matrix verification (native = reference). Behavior-only: no public API change — `apiDump` is a no-op.

## #80 — `Connection.methodCallTimeout` now applied (JVM)

- `PureJavaDbusConnection` stored the `Duration` but no call path read it. `PureJavaDbusProxy` now receives a `defaultTimeoutMicros` provider from its connection, and `callMethod(message, timeout)` resolves the effective timeout exactly the way `sd_bus_call` resolves a 0 timeout via `sd_bus_get_method_call_timeout`:
  - explicit per-call timeout always wins;
  - the connection default only fills the unset (`0`/`Duration.ZERO` sentinel) case — `callMethod(message)` (no timeout arg) funnels through the same resolution;
  - if neither is set, the effective timeout stays 0 and the pre-existing default behavior (dbus-java's own reply timeout) is unchanged, mirroring native where an unset (ZERO) `methodCallTimeout` falls back to sd-bus's built-in default.
- All call paths funnel through the two sync `callMethod` overloads (callback-async, suspend, static-dispatch and remote-wire paths), so the default applies uniformly.

**Acceptance test (commonTest, runs on BOTH backends):** `FailurePathParityTest.connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout` — reuses the slow-method fixture pattern: sets `proxyConnection.methodCallTimeout = 100.milliseconds`, calls a 600 ms-slow method WITHOUT a per-call timeout via the raw `callMethod(message)` overload, asserts a timeout-shaped `Error`; then asserts an explicit generous per-call timeout overrides the connection default (call succeeds).

## #81 — throw on unreachable bus instead of silent stub fallback (JVM)

- `PureJavaDbusBackend` no longer takes a fallback backend. When `tryCreateConnection` fails (or the request is unsatisfiable), `createConnection` throws `com.monkopedia.sdbus.Error` with a "Failed to open bus…" message, mirroring native's `openBus` ("Failed to open bus", errno from `sd_bus_open_*`). The exact D-Bus error *name* is not pinned across backends because dbus-java exposes no errno — the `Error` type and the throw are the contract.
- `JvmDbusBackendProvider.backend` is now `PureJavaDbusBackend()` with no implicit stub anywhere.

**Acceptance test (jvmTest):** `JvmUnreachableBusTest` — `createSessionBusConnection(address)` and `createDirectBusConnection(address)` pointed at a nonexistent unix socket path throw `Error` (never return a `:jvm-stub` connection). Plus `PureJavaDbusBackendTest.createConnection_throwsWhenEndpointMissing` for the unsatisfiable-request paths.

### How stub users were migrated

- `StubJvmDbusBackend` **stays** as an explicit internal opt-in for unit tests: tests construct it directly (`StubJvmDbusBackendTest` already does — unchanged) or mock `JvmDbusBackendProvider` (the mockk suites `JvmFactoryMockkTest`/`JvmConnectionMockkTest`/`JvmProxyObjectMockkTest` already do — unchanged). Its KDoc now documents that it is never selected implicitly.
- `PureJavaDbusBackendTest`: constructor lost the fallback param; `createConnection_usesFallbackWhenEndpointMissing` became `createConnection_throwsWhenEndpointMissing`.
- `JvmRealBusIntegrationTest`: the 7 `":jvm-stub"` unique-name skip gates (which used the silent fallback as a "no bus in this environment" signal) are migrated to a `connectOrNull` helper that treats the thrown `Error` as the skip signal. CI behavior is unchanged — `full-tests-x64` runs under `dbus-run-session`, so these tests run for real there.
- `JvmScaffoldTest.createBusConnection_hasStubUniqueName` renamed to `createBusConnection_hasUniqueName` (it asserts against the real bus under CI's `dbus-run-session`).

### BACKENDS.md row updates

- Summary matrix: `Connection.methodCallTimeout` row is now ✅/✅ ("JVM fixed in #80", pinned by the new commonTest); bus-unreachable row is now "✅ throws `Error`" on both ("JVM fixed in #81", stub = explicit internal test opt-in only).
- The two "Known divergence" sections are replaced with parity statements + proven-by test references; "JVM limitations at a glance" items 3/4 removed and recorded as closed historical gaps.

### Verification (all with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk`)

- `./gradlew ktlintFormat` → `./gradlew apiDump` no-op (`git diff -- api/` empty) → `./gradlew ktlintCheck apiCheck` ✅
- `dbus-run-session -- ./gradlew jvmTest linuxX64Test :cross_test:jvmTest :cross_test:linuxX64Test` ✅ (FailurePathParityTest 7/7 on both backends incl. the new test; `JvmUnreachableBusTest` 2/2; `JvmCreateErrorParityTest`, strict-deserialization and dbusmock suites all green — no #63/#78 regressions)
- `./gradlew compileKotlinLinuxX64 :codegen:test :plugin:test :stress_test:compileTestKotlinJvm` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)