### PR TITLE
Native: take the SdBus lock in sd_bus_message_new_method_return (#84)

### DIFF
--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/SdBus.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/SdBus.kt
@@ -57,6 +57,47 @@ import sdbus.sd_bus_message_handler_t
 import sdbus.sd_bus_vtable
 import sdbus.sd_id128_t
 
+/**
+ * Thin wrapper around libsystemd's sd-bus that serializes all bus access through a
+ * per-instance [ReentrantLock].
+ *
+ * ## Locking invariant (#69, #84)
+ *
+ * sd-bus is single-threaded by design: its reference counts (e.g. `bus->n_ref`,
+ * bumped by `sd_bus_ref` from nearly every message/slot operation) are plain
+ * non-atomic increments. sdbus-kotlin runs the connection's event loop on one
+ * thread while user code (proxies, async server handlers on worker dispatchers)
+ * calls into the same bus concurrently, so EVERY libsystemd entry point that can
+ * touch live bus state MUST hold [lock] (`lock.withLock { }`).
+ *
+ * A single unlocked entry point is enough to corrupt the heap: a lost refcount
+ * update undercounts `n_ref`, the bus is freed prematurely at teardown while live
+ * messages still hold logical references, and later unrefs write to freed memory
+ * ("malloc(): unsorted double linked list corrupted" under server-side async load
+ * — the #69 flake, root-caused in #84 to exactly one wrapper missing the lock).
+ *
+ * The lock is reentrant on purpose: message handlers are dispatched by libsystemd
+ * from inside locked `sd_bus_process`, and synchronous handlers create/send their
+ * replies on that same thread, re-entering wrappers like
+ * [sd_bus_message_new_method_return] while the event-loop thread already holds
+ * the lock.
+ *
+ * The only functions allowed to skip the lock are those that provably cannot race
+ * a live event loop:
+ * - bus constructors ([sd_bus_new], the `sd_bus_open*` family): the bus pointer
+ *   is thread-local until the connection is published and the loop starts;
+ * - [sd_bus_flush] standalone: only used during the connection handshake, before
+ *   the bus is shared (the post-send flushes in [sd_bus_send]/[sd_bus_call_async]
+ *   already run under the lock);
+ * - [sd_bus_flush_close_unref]/[sd_bus_close_unref]: teardown destructors that run
+ *   after the event loop has exited;
+ * - [sd_bus_get_current_message]: read-only, only valid on the event-loop thread
+ *   inside a handler callback (which already holds the lock).
+ *
+ * If you add a new wrapper, take the lock unless it falls into one of the
+ * categories above — when in doubt, lock (it is reentrant and cheap compared to a
+ * Feb-2026-style heap-corruption hunt).
+ */
 internal class SdBus : ISdBus {
     private val lock = ReentrantLock()
     private val useAnonymousDirectAuth by lazy {
@@ -142,7 +183,9 @@ internal class SdBus : ISdBus {
     override fun sd_bus_message_new_method_return(
         call: CValuesRef<sd_bus_message>?,
         m: CValuesRef<CPointerVar<sd_bus_message>>?
-    ): Int = sdbus.sd_bus_message_new_method_return(call, m)
+    ): Int = lock.withLock {
+        return sdbus.sd_bus_message_new_method_return(call, m)
+    }
 
     override fun sd_bus_message_new_method_error(
         call: CValuesRef<sd_bus_message>?,


### PR DESCRIPTION
Fixes #84. Root cause of the #69 malloc/SIGABRT-134 CI flake (full analysis in the #69 investigation findings).

## The fix

`SdBus.sd_bus_message_new_method_return()` was the **only** bus-mutating libsystemd wrapper in `src/nativeMain/kotlin/com/monkopedia/sdbus/internal/SdBus.kt` that did not take the per-connection `lock.withLock { }`. Its sole caller is `MethodCall.createReply()` (`MethodCall.native.kt:94`), which server-side async (`acall`) handlers run on `Dispatchers.Default` workers while the event-loop thread is inside locked `sd_bus_process`. The call internally does `sd_bus_ref(bus)` — a plain non-atomic `n_ref++` in libsystemd — so a lost update undercounts the bus refcount → premature `bus_free()` at teardown → later unrefs write freed memory → heap corruption detected at an arbitrary later allocation (which is why CI aborts landed in unrelated tests right after the bulk-parallel async tests).

The change wraps the call in `lock.withLock { }` exactly like every sibling wrapper, and adds a class-level KDoc on `SdBus` documenting the invariant (every libsystemd entry point that can touch live bus state must hold the lock, citing #69/#84) plus the short list of provably-safe exceptions, so the next change to this file doesn't reintroduce the bug class (as happened after e2eeb3e's Feb-2026 sweep).

## Audit of all ISdBus entry points

Independently re-audited every function in `SdBus.kt` (the only production `ISdBus` implementation; the only other implementor is the test-only `SdBusMock`). Result: **`sd_bus_message_new_method_return` was the only unsafe unlocked entry point**, confirming the #69 finding. The remaining unlocked functions cannot race a live event loop:

- **Bus constructors** (`sd_bus_new`, `sd_bus_open`, `sd_bus_open_system`, `sd_bus_open_user`, `sd_bus_open_user_with_address`, `sd_bus_open_direct` ×2, `sd_bus_open_server`, `sd_bus_open_system_remote`): the bus pointer is thread-local until `openBus`/`openPseudoBus` returns and the event loop starts.
- **`sd_bus_flush` (standalone)**: only called from `finishHandshake()` (`ConnectionImpl.kt:170`), before the bus is shared. The post-send flushes inside `sd_bus_send`/`sd_bus_call_async` already run under the lock.
- **`sd_bus_flush_close_unref` / `sd_bus_close_unref`**: bus `Reference` destructors; `ConnectionImpl.release()` tears down the event loop before `bus.release()`.
- **`sd_bus_get_current_message`**: read-only; only called from `currentlyProcessedMessage`, which is only valid on the event-loop thread inside a handler callback (already under the lock held across `sd_bus_process`).

Also re-verified that all bus-touching calls outside `SdBus.kt` (`ConnectionImpl`, `Message.native`, `MethodCall.native`, `Signal.native`, `MethodReply.native`) go through the `ISdBus` field (i.e. the locked wrappers); the remaining direct cinterop calls are message-local serialization (`sd_bus_message_append/read/...`) or pure validators (`sd_bus_*_is_valid`) that don't touch bus state.

## Deadlock analysis

No deadlock is possible from adding the lock:

- The lock is `kotlinx.atomicfu.locks.ReentrantLock` — **reentrant** (owner-thread + reenter count) on Kotlin/Native.
- Sync `call {}` handlers run inside libsystemd's dispatch from `sd_bus_process`, i.e. on the event-loop thread **while it already holds the lock**; their `createReply()` now re-enters the lock on the same thread, which is exactly the pattern the sync **error** path has used all along (`createErrorReply` → already-locked `sd_bus_message_new_method_error`) — proven in production.
- Async handlers call `createReply()` from a worker thread that holds no lock; it simply contends briefly with the event loop. This is the only lock in play on these paths (no ordering hazard), and the subsequent `reply.send()` → locked `sd_bus_send` already does the same.

## Verification

- `./gradlew ktlintFormat` (no changes), `./gradlew apiDump` (no-op — behavior-only change), `./gradlew ktlintCheck apiCheck` green.
- `dbus-run-session -- ./gradlew linuxX64Test jvmTest :cross_test:linuxX64Test` — all green (the bulk-parallel async tests are the stress test).
- **Local soak**: looped `build/bin/linuxX64/debugTest/test.kexe` filtered to `DBusAsyncMethodsTest.* : CommonApiIntegrationTest.*` (34 tests/iteration) under `dbus-run-session` with `MALLOC_CHECK_=3` and randomized `MALLOC_PERTURB_` per iteration: **36/36 iterations passed, 0 failures** (35-iteration loop + 1 timed warm-up). As noted in #84, the race was never reproducible on x64 (window too small under x86-TSO; it fired ~6% of ARM CI runs), so the soak validates nothing-broke; correctness of the fix rests on the restored lock discipline. The real signal is the arm-runtime-tests exit-134 flake disappearing over subsequent CI runs, after which the #69 re-run-on-flake policy can be retired.

No jvmMain or docs/BACKENDS.md changes (deliberately avoided — sibling PR territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)