### PR TITLE
Make createRemoteSystemBusConnection native-only (#82)

### DIFF
--- a/api/sdbus-kotlin.api
+++ b/api/sdbus-kotlin.api
@@ -66,7 +66,6 @@ public final class com/monkopedia/sdbus/Connection_jvmKt {
 	public static final fun createBusConnection-em-jQOc (Ljava/lang/String;)Lcom/monkopedia/sdbus/Connection;
 	public static final fun createDirectBusConnection (Lcom/monkopedia/sdbus/UnixFd;)Lcom/monkopedia/sdbus/Connection;
 	public static final fun createDirectBusConnection (Ljava/lang/String;)Lcom/monkopedia/sdbus/Connection;
-	public static final fun createRemoteSystemBusConnection (Ljava/lang/String;)Lcom/monkopedia/sdbus/Connection;
 	public static final fun createServerBusConnection (Lcom/monkopedia/sdbus/UnixFd;)Lcom/monkopedia/sdbus/Connection;
 	public static final fun createSessionBusConnection ()Lcom/monkopedia/sdbus/Connection;
 	public static final fun createSessionBusConnection (Ljava/lang/String;)Lcom/monkopedia/sdbus/Connection;

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -188,14 +188,16 @@ Backend differences:
 
 ## Connection factories
 
-There are 11 `create*Connection` entry points (`src/commonMain/.../Connection.kt`):
+There are 11 `create*Connection` entry points — 10 declared in the common API
+(`src/commonMain/.../Connection.kt`) plus one declared only in the native source set
+(`src/nativeMain/.../Connection.native.kt`):
 
 | Factory | JVM | Native |
 | --- | --- | --- |
 | `createBusConnection()` / `(name)` | ✅ | ✅ |
 | `createSystemBusConnection()` / `(name)` | ✅ | ✅ |
 | `createSessionBusConnection()` / `(name)` / `(address)` | ✅ | ✅ |
-| `createRemoteSystemBusConnection(host)` | ⚠️ | ✅ |
+| `createRemoteSystemBusConnection(host)` | ❌ native-only (not declared) | ✅ |
 | `createDirectBusConnection(address)` | ✅ | ✅ |
 | `createDirectBusConnection(fd: UnixFd)` | ❌ native-only | ✅ |
 | `createServerBusConnection(fd: UnixFd)` | ❌ native-only | ✅ |
@@ -205,10 +207,12 @@ There are 11 `create*Connection` entry points (`src/commonMain/.../Connection.kt
   JVM-compiled code is a **compile-time error**; if invoked anyway (e.g. reflectively), the
   JVM backend throws (`PureJavaDbusBackend.createConnection` rejects `DIRECT_FD`/`SERVER_FD`).
   On native they adopt the descriptor as documented in their KDoc.
-- `createRemoteSystemBusConnection(host)` exists on both, but the argument is interpreted
-  differently: native uses sd-bus's ssh transport (`sd_bus_open_system_remote`, takes a
-  hostname), while the JVM backend passes the string as a dbus-java bus *address* (e.g.
-  `tcp:host=…,port=…`). Neither path is covered by CI tests; do not assume portability.
+- `createRemoteSystemBusConnection(host)` is **native-only and not declared in the common
+  or JVM API** (it lives in `src/nativeMain/.../Connection.native.kt`). It opens the system
+  bus of a remote host over ssh via sd-bus (`sd_bus_open_system_remote`, which spawns
+  `ssh … systemd-stdio-bridge`); dbus-java has no equivalent transport, and the former JVM
+  declaration wrongly treated the host as a dbus-java bus *address*, so it was removed
+  (#82). To connect to a TCP-exposed bus on JVM, use the address-based factories instead.
 
 **Known divergence — bus-unreachable behavior:** when opening the bus fails (e.g. no
 `DBUS_SESSION_BUS_ADDRESS`), the native backend throws `com.monkopedia.sdbus.Error`. The JVM
@@ -264,8 +268,8 @@ on native. `currentlyProcessedMessage` is valid inside handlers on both backends
    CI-verified against an independent peer.
 3. **`Connection.methodCallTimeout` is not applied** to calls — use per-call timeouts.
 4. **Silent stub fallback when the bus is unreachable** instead of throwing.
-5. **`createRemoteSystemBusConnection(host)` interprets its argument differently** (bus
-   address, not ssh host).
+5. **No remote-system-bus-over-ssh**: `createRemoteSystemBusConnection(host)` is
+   native-only and not declared in the JVM API (#82).
 6. Historical gaps — object-side signal emission and `PropertiesChanged` emission — are
    closed and pinned by `JvmSignalPropertyUnsupportedTest`; struct marshalling, foreign error
    names, and grouped replies are closed (#71/#72/#74) and pinned by the un-gated

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
@@ -255,16 +255,6 @@ expect fun createSessionBusConnection(name: ServiceName): Connection
 expect fun createSessionBusConnection(address: String): Connection
 
 /**
- * Creates/opens D-Bus system connection on a remote host using ssh
- *
- * @param host Name of the host to connect
- * @return [Connection] instance
- *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
- */
-expect fun createRemoteSystemBusConnection(host: String): Connection
-
-/**
  * Opens direct D-Bus connection at a custom address
  *
  * @param address ";"-separated list of addresses of bus brokers to try to connect to

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Connection.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Connection.jvm.kt
@@ -89,10 +89,6 @@ actual fun createSessionBusConnection(address: String): Connection = JvmConnecti
     )
 )
 
-actual fun createRemoteSystemBusConnection(host: String): Connection = JvmConnection(
-    JvmDbusBackendProvider.backend.createConnection(JvmBusType.REMOTE_SYSTEM, host, null, null)
-)
-
 actual fun createDirectBusConnection(address: String): Connection = JvmConnection(
     JvmDbusBackendProvider.backend.createConnection(
         JvmBusType.DIRECT_ADDRESS,

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
@@ -30,7 +30,6 @@ internal enum class JvmBusType {
     SYSTEM,
     SESSION,
     SESSION_ADDRESS,
-    REMOTE_SYSTEM,
     DIRECT_ADDRESS,
     DIRECT_FD,
     SERVER_FD

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -134,11 +134,6 @@ internal class PureJavaDbusBackend(private val fallbackBackend: JvmDbusBackend) 
             JvmBusType.SESSION_ADDRESS ->
                 endpoint?.let(DBusConnectionBuilder::forAddress)?.withShared(false)?.build()
             JvmBusType.DIRECT_ADDRESS -> endpoint?.let(DirectConnectionBuilder::forAddress)?.build()
-            JvmBusType.REMOTE_SYSTEM -> endpoint?.let { value ->
-                DBusConnectionBuilder.forType(DBusConnection.DBusBusType.SYSTEM, value)
-                    .withShared(false)
-                    .build()
-            }
             JvmBusType.DIRECT_FD,
             JvmBusType.SERVER_FD -> null
         }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmFactoryMockkTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmFactoryMockkTest.kt
@@ -47,7 +47,6 @@ class JvmFactoryMockkTest {
             createSessionBusConnection()
             createSessionBusConnection(serviceName)
             createSessionBusConnection("unix:path=/tmp/session")
-            createRemoteSystemBusConnection("example-host")
             createDirectBusConnection("unix:path=/tmp/direct")
             createDirectBusConnection(UnixFd.adopt(42))
             createServerBusConnection(UnixFd.adopt(99))
@@ -77,9 +76,6 @@ class JvmFactoryMockkTest {
                     null,
                     null
                 )
-            }
-            verify(exactly = 1) {
-                backend.createConnection(JvmBusType.REMOTE_SYSTEM, "example-host", null, null)
             }
             verify(exactly = 1) {
                 backend.createConnection(

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackendTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackendTest.kt
@@ -67,28 +67,28 @@ class PureJavaDbusBackendTest {
         val fallback = mockk<JvmDbusBackend>()
         val backend = PureJavaDbusBackend(fallback)
         val sessionAddressConnection = mockk<JvmDbusConnection>()
-        val remoteSystemConnection = mockk<JvmDbusConnection>()
+        val directAddressConnection = mockk<JvmDbusConnection>()
         val named = ServiceName("org.example.Named")
 
         every {
             fallback.createConnection(JvmBusType.SESSION_ADDRESS, null, named, null)
         } returns sessionAddressConnection
         every {
-            fallback.createConnection(JvmBusType.REMOTE_SYSTEM, null, null, null)
-        } returns remoteSystemConnection
+            fallback.createConnection(JvmBusType.DIRECT_ADDRESS, null, null, null)
+        } returns directAddressConnection
 
         val sessionAddressResult =
             backend.createConnection(JvmBusType.SESSION_ADDRESS, null, named, null)
-        val remoteSystemResult =
-            backend.createConnection(JvmBusType.REMOTE_SYSTEM, null, null, null)
+        val directAddressResult =
+            backend.createConnection(JvmBusType.DIRECT_ADDRESS, null, null, null)
 
         assertEquals(sessionAddressConnection, sessionAddressResult)
-        assertEquals(remoteSystemConnection, remoteSystemResult)
+        assertEquals(directAddressConnection, directAddressResult)
         verify(exactly = 1) {
             fallback.createConnection(JvmBusType.SESSION_ADDRESS, null, named, null)
         }
         verify(exactly = 1) {
-            fallback.createConnection(JvmBusType.REMOTE_SYSTEM, null, null, null)
+            fallback.createConnection(JvmBusType.DIRECT_ADDRESS, null, null, null)
         }
     }
 }

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Connection.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Connection.native.kt
@@ -56,8 +56,19 @@ actual fun createSessionBusConnection(name: ServiceName): Connection =
 actual fun createSessionBusConnection(address: String): Connection =
     sessionConnection(SdBus(), address)
 
-actual fun createRemoteSystemBusConnection(host: String): Connection =
-    remoteConnection(SdBus(), host)
+/**
+ * Creates/opens D-Bus system connection on a remote host using ssh
+ *
+ * Native-only API. The underlying sd-bus library tunnels the connection over ssh
+ * (`sd_bus_open_system_remote`); there is no JVM equivalent, so this function is
+ * not declared in the common API.
+ *
+ * @param host Name of the host to connect
+ * @return [Connection] instance
+ *
+ * @throws [com.monkopedia.sdbus.Error] in case of failure
+ */
+fun createRemoteSystemBusConnection(host: String): Connection = remoteConnection(SdBus(), host)
 
 actual fun createDirectBusConnection(address: String): Connection =
     privateConnection(SdBus(), address)


### PR DESCRIPTION
Implements the owner decision on #82 (0.5.0 gate): an API only feasible on one platform should not be declared in commonMain.

## Feasibility verification (step 1 of the decision)

Native's semantic is sd-bus's remote-system-bus-over-ssh: `sd_bus_open_system_remote(host)` spawns `ssh -xT <host> systemd-stdio-bridge` and speaks D-Bus over the bridge's stdio. Investigated whether dbus-java 5.2.0 (the JVM backend, `com.github.hypfvieh:dbus-java-core` + `dbus-java-transport-junixsocket`) has any equivalent:

- Extracted and inspected `dbus-java-core-5.2.0.jar`: **no** `ssh`, `unixexec`, or `stdio-bridge` support anywhere in the jar; `DBusConnection.DBusBusType` offers only `SYSTEM`/`SESSION`.
- Transports are pluggable via the `org.freedesktop.dbus.spi.transport.ITransportProvider` ServiceLoader SPI; the published dbus-java transport modules are unix-socket variants (jnr/native/junixsocket) and TCP — none implement an ssh transport, and this project ships only junixsocket.
- dbus-java's TCP bus-address connection is a *different* operation (already covered by the address-based factories), not a remote system bus over ssh.

Conclusion: the capability is native-only in substance → outcome (2) from the decision.

## Changes

- **commonMain** (`src/commonMain/.../Connection.kt`): `expect fun createRemoteSystemBusConnection(host)` removed.
- **nativeMain** (`src/nativeMain/.../Connection.native.kt`): now a plain (non-`actual`) `fun` with the KDoc moved over and a native-only note. Behavior unchanged on native.
- **jvmMain**: the actual (which wrongly passed the ssh host to dbus-java as a bus *address*) is removed, along with the now-dead `JvmBusType.REMOTE_SYSTEM` enum value and its `PureJavaDbusBackend` case.
- **Tests**: dropped the factory-delegation line/verify from `JvmFactoryMockkTest`; `PureJavaDbusBackendTest.createConnection_usesFallbackWhenEndpointMissing` now uses `DIRECT_ADDRESS` (same null-endpoint fallback path) instead of `REMOTE_SYSTEM`.
- **API dumps** (`apiDump`): `api/sdbus-kotlin.api` loses the one JVM symbol; `api/sdbus-kotlin.klib.api` is **unchanged** (the function remains for both native targets).
- **docs/BACKENDS.md**: factory matrix row → `❌ native-only (not declared)`, the divergence bullet rewritten to document the removal, limitations item 5 updated. README does not mention the function (checked).

Note: PR #85 also touches the BACKENDS.md "JVM limitations" list (items 3/4 and the bus-unreachable section); this PR only touches the #82-specific lines, but a trivial merge conflict in that area is possible depending on merge order.

**BREAKING CHANGE**: `createRemoteSystemBusConnection` removed from common/JVM API (was misdeclared — JVM treated the ssh host as a bus address); now declared native-only. Deliberate, owner-approved pre-freeze API change.

## Verification

- `./gradlew ktlintCheck apiCheck` — pass (with regenerated dumps)
- `dbus-run-session -- env JAVA_HOME=... ./gradlew jvmTest linuxX64Test` — pass
- `./gradlew compileKotlinLinuxX64 :codegen:test :plugin:test` — pass

Fixes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)