### PR TITLE
WIP: Export JVM server objects via dbus-java for cross-process reachability (approach A, partial) (#90)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,10 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.dbus.java.core)
                 runtimeOnly(libs.dbus.java.transport.junixsocket)
+                // Runtime synthesis of typed DBusInterface adapters so JVM-hosted server
+                // objects are reachable cross-process via dbus-java's native object export
+                // (issue #90). New jvmMain runtime dependency on the published -jvm artifact.
+                implementation(libs.byte.buddy)
                 implementation(kotlin("stdlib"))
             }
         }

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -28,11 +28,11 @@ Every row below is pinned by tests on current `main`, not by intention:
 | Error propagation: named D-Bus errors round-trip name + message verbatim | ✅ | ✅ | Incl. foreign (non-sdbus) peers; JVM fixed in #72 |
 | errno → D-Bus error-name mapping for locally created errors | ✅ | ✅ | JVM pinned to native output |
 | Call-after-release fails with `IllegalArgumentException("Connection has already been released")` | ✅ | ✅ | |
-| Properties: `Get`/`Set`/`GetAll`, property delegates (`values()`/`changes()`) — **as a client** | ✅ | ✅ | Client-verified; JVM *serving* properties to an external peer is in-process only — see "Server-side object export" |
+| Properties: `Get`/`Set`/`GetAll`, property delegates (`values()`/`changes()`) — **client + server** | ✅ | ✅ | Client-verified; JVM now also *serves* `Get`/`Set`/`GetAll` to external peers via dbus-java export (#90), busctl-verified cross-process — see "Server-side object export" |
 | `PropertiesChanged` emission incl. getter resolution | ✅ | ✅ | JVM fixed in #28; JVM emits to the real bus, but external reception is not test-verified |
 | Signals: emission, subscription, `signalFlow` | ✅ | ✅ | JVM emission goes to the real bus; subscription/`signalFlow` are cross-process-verified as a client |
-| ObjectManager: `GetManagedObjects`, `InterfacesAdded`/`Removed`, `ObjectManagerProxy` flows — **as a client** | ✅ | ✅ | Client-verified; JVM *serving* `GetManagedObjects` to an external peer is in-process only — see "Server-side object export" |
-| **Serving exported objects to external processes** (incoming method calls, `Properties.Get`/`Set`/`GetAll`, `GetManagedObjects`) | ⚠️ in-process only | ✅ | **JVM gap (#90):** the JVM backend dispatches incoming calls through an in-process table (`JvmStaticDispatch`); an external client (busctl, another process) gets `UnknownObject`. Native is a full server backend — see "Server-side object export" |
+| ObjectManager: `GetManagedObjects`, `InterfacesAdded`/`Removed`, `ObjectManagerProxy` flows — **client + server** | ✅ | ✅ | Client-verified; JVM now also *serves* `GetManagedObjects` to external peers via dbus-java export (#90), busctl-verified — see "Server-side object export" |
+| **Serving exported objects to external processes** (incoming method calls, `Properties.Get`/`Set`/`GetAll`, `GetManagedObjects`) | ✅* common types | ✅ | **#90:** JVM now exports server objects through dbus-java, so external callers (busctl, another process) reach methods, properties and `GetManagedObjects` cross-process (busctl-verified). *Methods whose signatures contain a **struct** or **multiple out-values** are not yet exported (in-process only) — see "Server-side object export" |
 | `UnixFd` type semantics (dup constructor vs `adopt`, `release` closes) | ✅* | ✅ | *JVM dup needs junixsocket native support |
 | Unix FD passing over the wire | ⚠️ untested | ✅ | JVM has the conversion path but no independent-peer test |
 | Connection factories (11 total) | 9 of 11 | 11 of 11 | fd-based factories are native-only |
@@ -72,9 +72,8 @@ of going through the daemon. Results are asserted equivalent by the commonTest s
 such calls do not exercise the wire. Cross-process behavior *as a client* is what the
 `cross_test` dbusmock suites pin.
 
-This in-process table is also, today, the **only** path by which a JVM-hosted object serves
-incoming method/property calls — see "Server-side object export" below for the consequence
-(#90): an *external* process calling a JVM-exported object is not served.
+This in-process table serves same-process JVM clients; external processes are served in
+parallel via dbus-java's object export — see "Server-side object export" below (#90).
 
 ## Timeouts
 
@@ -149,10 +148,10 @@ parity in issue #28 / PR #47.
   historical name, it now *asserts* JVM signal emission and `PropertiesChanged` emission are
   supported — it pins the closure of those former gaps).
 
-> **Serving caveat:** `Properties.Get`/`Set`/`GetAll` *served by a JVM object* are answered
-> from the in-process dispatch table, not over the wire (see "Server-side object export"). An
-> external process performing `Properties.Get` against a JVM-hosted object gets `UnknownObject`
-> (#90). `PropertiesChanged` *emission* does go to the real bus, but external reception is not
+> **Serving note:** `Properties.Get`/`Set`/`GetAll` *served by a JVM object* are reachable
+> cross-process (#90): same-process JVM clients use the in-process dispatch table, while an
+> external process is served via dbus-java export (busctl-verified — see "Server-side object
+> export"). `PropertiesChanged` *emission* goes to the real bus, but external reception is not
 > CI-verified. On native all of these are reachable cross-process.
 
 ## Signals
@@ -177,45 +176,52 @@ consumption, and the `ObjectManagerProxy` reactive state flows behave identicall
   round-trip + proxy flow convergence), and `cross_test/.../DbusmockBluezTest.kt`
   (ObjectManager discovery over the dbusmock `bluez5` template).
 
-> **Serving caveat:** the verified `GetManagedObjects` round-trips above exercise sdbus-kotlin
+> **Serving note:** the verified `GetManagedObjects` round-trips above exercise sdbus-kotlin
 > *as a client* against a foreign emitter, plus JVM in-process own-server. A JVM object
-> *serving* `GetManagedObjects` to an **external** process answers from the in-process registry
-> and is not reachable cross-process (#90); `InterfacesAdded`/`Removed` *emission* does reach
+> *serving* `GetManagedObjects` to an **external** process is now reachable cross-process via
+> dbus-java export (#90, busctl-verified); `InterfacesAdded`/`Removed` *emission* also reaches
 > the bus. On native, serving `GetManagedObjects` cross-process works fully. See "Server-side
 > object export".
 
-## Server-side object export (JVM limitation)
-
-This is the one place the two backends are **not** at parity, and the matrix rows above are
-scoped accordingly.
+## Server-side object export
 
 **Native** is a full server backend: `createObject(path).addVTable(...)` registers the object
 with sd-bus, so methods, `org.freedesktop.DBus.Properties` (`Get`/`Set`/`GetAll`), and
 `ObjectManager.GetManagedObjects` are callable by **any** peer on the bus — busctl, a native
 client, a JVM client, another process — exactly as you'd expect from a D-Bus service.
 
-**JVM** is fully capable as a *client*, and it emits signals (incl. `PropertiesChanged`,
-`InterfacesAdded`/`Removed`) to the real bus via dbus-java's `sendMessage`, so external
-subscribers do receive them. But its server side routes **incoming** method and property calls
-through an in-process dispatch table (`JvmStaticDispatch` / `LocalJvmSignalBus` /
-`LocalManagedObjectsRegistry` in `PureJavaDbusBackend.kt`) rather than registering the object
-with dbus-java's real export mechanism (`DBusConnection.exportObject` / `ExportedObject`).
+**JVM** now also serves exported objects cross-process (#90, approach A). In addition to its
+in-process dispatch table (`JvmStaticDispatch`, used by same-process JVM clients), each exported
+object is registered with dbus-java's real export mechanism (`AbstractConnection.exportObject` /
+`ExportedObject`) via a runtime-synthesized typed `DBusInterface`
+(`SdbusObjectExporter.kt`). For each D-Bus interface the bridge generates, with ByteBuddy, an
+interface whose Java method parameter/return types marshal back to the vtable's exact wire
+signatures, then exports a `java.lang.reflect.Proxy` whose handler converts dbus-java's
+deserialized values into the sdbus value model, routes through the **same** `JvmStaticDispatch`
+handlers the vtable already populates, and converts the reply back. dbus-java owns the wire
+codec, so there is no second serializer to keep in lockstep. A separate process (busctl, another
+client) calling a JVM-hosted object's method, `Properties.Get`/`Set`/`GetAll`, or
+`GetManagedObjects` is now served with real values — verified by `JvmCrossProcessExportTest`,
+which drives a JVM-exported object with `busctl` (a genuinely external process; two connections
+in the *same* JVM would short-circuit through `JvmStaticDispatch` and never exercise the wire).
 
-Consequence (issue #90): a JVM-hosted service claims its bus name, exports, emits, and shuts
-down cleanly, and in-process JVM clients reach it — but a call from a **separate process**
-(busctl, another client) to one of its methods or properties gets `UnknownObject`. The
-exported objects are invisible to external method/property callers on the actual bus.
+Remaining JVM server-side gaps (tracked in #90, in-process only for now; the bridge leaves such
+methods un-exported rather than failing registration):
 
-Why this is not a one-line fix: dbus-java's `exportObject` dispatches incoming calls by
-**reflecting a statically-typed `DBusInterface`** — it deserializes arguments from the wire
-using the Java *method's* declared parameter types, invokes the method reflectively, and
-serializes the reply from the method's return type (`ConnectionMethodInvocation`,
-`ExportedObject`). sdbus-kotlin's vtable is dynamic (signatures + callbacks resolved at
-runtime) and carries its own wire codec. dbus-java exposes no lower-level "raw incoming
-method-call" hook, so bridging the two requires either generating a typed `DBusInterface` per
-vtable at runtime (reconciling dbus-java's marshalling with sdbus-kotlin's codec) or
-intercepting the reader/transport below dbus-java's public API. Both are substantial; the fix
-is tracked in #90.
+- **methods whose signatures contain a struct** (`(...)`) — needs runtime generation of concrete
+  dbus-java `Struct` subclasses (positioned fields + constructor) so dbus-java's reflective
+  marshalling round-trips them. Struct-*valued* properties and `GetManagedObjects` entries are
+  unaffected because they travel inside a `Variant`, which is supported.
+- **methods returning multiple out-values** — needs runtime generation of `Tuple` subtypes for
+  the parameterized return type dbus-java requires.
+- **`g` (signature) arguments** — `Type[]`-typed, not yet bridged.
+
+Background on why this needed a bridge rather than a one-liner: dbus-java's `exportObject`
+dispatches incoming calls by **reflecting a statically-typed `DBusInterface`** — it deserializes
+arguments using the Java *method's* declared parameter types, invokes reflectively, and
+serializes the reply from the return type (`ConnectionMethodInvocation`, `ExportedObject`).
+sdbus-kotlin's vtable is dynamic, so the typed interface has to be synthesized at runtime; that
+synthesis (plus the value bridge) is exactly what `SdbusObjectExporter` provides.
 
 **Until then:** use the **native** backend for any service that must be reachable by external
 D-Bus consumers. The JVM backend is recommended for *client* use and for in-process JVM↔JVM

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktlint = "14.0.1"
 buildconfig = "6.0.9"
 vannik = "0.36.0"
 dbus-java = "5.2.0"
+byte-buddy = "1.18.2"
 mockk = "1.14.9"
 
 [libraries]
@@ -33,6 +34,7 @@ kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-em
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt"}
 dbus-java-core = { module = "com.github.hypfvieh:dbus-java-core", version.ref = "dbus-java" }
 dbus-java-transport-junixsocket = { module = "com.github.hypfvieh:dbus-java-transport-junixsocket", version.ref = "dbus-java" }
+byte-buddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byte-buddy" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [bundles]

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -605,7 +605,7 @@ private fun DBusSignal.toSdbusMessage(connection: AbstractConnection?): Signal =
         .forEach { signal.payload.add(it) }
 }
 
-private fun fromJavaSignalValue(value: Any?): Any? = when (value) {
+internal fun fromJavaSignalValue(value: Any?): Any? = when (value) {
     is UInt16 -> value.toInt().toUShort()
     is UInt32 -> value.toLong().toUInt()
     is UInt64 -> value.value().toString().toULong()
@@ -621,7 +621,7 @@ private fun fromJavaSignalValue(value: Any?): Any? = when (value) {
     else -> value
 }
 
-private fun toJavaSignalValue(value: Any?): Any? = when (value) {
+internal fun toJavaSignalValue(value: Any?): Any? = when (value) {
     is UByte -> value.toByte()
     is UShort -> UInt16(value.toInt())
     is UInt -> UInt32(value.toLong())
@@ -666,7 +666,7 @@ private fun fromJavaVariantValue(value: org.freedesktop.dbus.types.Variant<*>): 
     return Variant().apply { deserializeFrom(message) }
 }
 
-private fun extractVariantPayload(variant: Variant): Message.JvmVariantPayload {
+internal fun extractVariantPayload(variant: Variant): Message.JvmVariantPayload {
     val signature = variant.peekValueType()
         ?: throw createError(-1, "Cannot convert empty variant to JVM D-Bus payload")
     val message = PlainMessage.createPlainMessage()
@@ -678,7 +678,7 @@ private fun extractVariantPayload(variant: Variant): Message.JvmVariantPayload {
     return Message.JvmVariantPayload(signature, value)
 }
 
-private fun toJavaVariantValue(
+internal fun toJavaVariantValue(
     signature: String,
     value: Any?
 ): org.freedesktop.dbus.types.Variant<Any?> = org.freedesktop.dbus.types.Variant(
@@ -688,7 +688,7 @@ private fun toJavaVariantValue(
 
 // Splits a D-Bus signature into its top-level single complete types
 // (e.g. "sa{sv}(is)" -> ["s", "a{sv}", "(is)"]).
-private fun splitTopLevelTypes(signature: String): List<String> {
+internal fun splitTopLevelTypes(signature: String): List<String> {
     fun parseOne(index: Int): Int {
         if (index >= signature.length) return index
         return when (signature[index]) {
@@ -732,12 +732,12 @@ private fun countTopLevelTypes(signature: String?): Int =
 // dbus-java as positional Object[] contents) apart from an array, so structs become
 // Message.JvmStructPayload carrying their exact signature (issue #71). Values whose
 // signature is unavailable fall back to the value-shape-based conversion.
-private fun fromJavaWireValues(values: List<Any?>, signature: String?): List<Any?> {
+internal fun fromJavaWireValues(values: List<Any?>, signature: String?): List<Any?> {
     val types = signature?.let(::splitTopLevelTypes).orEmpty()
     return values.mapIndexed { index, value -> fromJavaWireValue(value, types.getOrNull(index)) }
 }
 
-private fun fromJavaWireValue(value: Any?, signature: String?): Any? {
+internal fun fromJavaWireValue(value: Any?, signature: String?): Any? {
     if (value == null || signature.isNullOrEmpty()) return fromJavaSignalValue(value)
     return when {
         signature.startsWith("(") && signature.endsWith(")") -> {
@@ -772,7 +772,7 @@ private fun fromJavaWireValue(value: Any?, signature: String?): Any? {
     }
 }
 
-private fun wireValueAsList(value: Any?): List<Any?>? = when (value) {
+internal fun wireValueAsList(value: Any?): List<Any?>? = when (value) {
     is List<*> -> value
     is Array<*> -> value.toList()
     is ByteArray -> value.toList()
@@ -782,6 +782,10 @@ private fun wireValueAsList(value: Any?): List<Any?>? = when (value) {
     is BooleanArray -> value.toList()
     is FloatArray -> value.toList()
     is DoubleArray -> value.toList()
+    // dbus-java deserializes a struct argument into a concrete Struct instance whose fields,
+    // in @Position order, are returned by Container.getParameters() (issue #90 cross-process
+    // serve path). Treat it like the positional Object[] a struct otherwise arrives as.
+    is org.freedesktop.dbus.Container -> value.parameters.toList()
     else -> null
 }
 
@@ -885,8 +889,24 @@ private class PureJavaDbusConnection(internal val javaConnection: AbstractConnec
 
     override fun getMethodCallTimeout(): Duration = timeout
 
-    override fun addObjectManager(objectPath: ObjectPath): Resource =
-        LocalObjectManagerRegistry.register(objectPath.value, localUniqueName)
+    override fun addObjectManager(objectPath: ObjectPath): Resource {
+        val registration = LocalObjectManagerRegistry.register(objectPath.value, localUniqueName)
+        // Issue #90: also export an ObjectManager-serving object at this path through dbus-java so
+        // external processes can call org.freedesktop.DBus.ObjectManager.GetManagedObjects on it,
+        // routing back through the same JvmStaticDispatch handler the registration installs.
+        val exporter = SdbusObjectExporter(javaConnection, objectPath.value, localUniqueName)
+        runCatching {
+            exporter.update(
+                interfaces = emptyMap(),
+                serveProperties = false,
+                serveObjectManager = true
+            )
+        }
+        return ActionResource {
+            runCatching { exporter.close() }
+            registration.release()
+        }
+    }
 
     override fun uniqueName(): BusName = BusName(localUniqueName.ifEmpty { ":jvm-direct" })
 
@@ -1413,6 +1433,25 @@ private class PureJavaDbusObject(
     private var propertiesDispatchRegistered = false
     private val dispatchDestination = senderName ?: javaConnection?.uniqueNameOrNull().orEmpty()
 
+    // Issue #90: alongside the in-process JvmStaticDispatch registrations below, register the
+    // object with dbus-java's native object export so external processes can reach it. Only
+    // meaningful for a real (non in-process) connection. The exporter is best-effort and never
+    // affects the in-process path.
+    private val exporter: SdbusObjectExporter? = javaConnection?.let {
+        SdbusObjectExporter(it, objectPath.value, dispatchDestination)
+    }
+    private val exportedMethods =
+        mutableMapOf<String, List<SdbusObjectExporter.ExportedMethodSpec>>()
+    private var objectManagerServed = false
+
+    private fun refreshExport() {
+        exporter?.update(
+            interfaces = exportedMethods.toMap(),
+            serveProperties = propertiesDispatchRegistered,
+            serveObjectManager = objectManagerServed
+        )
+    }
+
     private fun parseInterfaceName(value: Any?): String = when (value) {
         is InterfaceName -> value.value
         is String -> value
@@ -1716,10 +1755,19 @@ private class PureJavaDbusObject(
         }
     }
 
-    override fun addObjectManager(): Resource =
-        LocalObjectManagerRegistry.register(objectPath.value, dispatchDestination).also {
-            registrations += it
+    override fun addObjectManager(): Resource {
+        val registration =
+            LocalObjectManagerRegistry.register(objectPath.value, dispatchDestination)
+        registrations += registration
+        objectManagerServed = true
+        refreshExport()
+        return ActionResource {
+            registration.release()
+            registrations.remove(registration)
+            objectManagerServed = false
+            refreshExport()
         }
+    }
 
     override fun currentlyProcessedMessage(): Message =
         JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
@@ -1793,9 +1841,20 @@ private class PureJavaDbusObject(
             }
         }
         registrations.addAll(resources)
+        exportedMethods[interfaceName.value] = vtable.mapNotNull { item ->
+            val method = item as? MethodVTableItem ?: return@mapNotNull null
+            method.callbackHandler ?: return@mapNotNull null
+            SdbusObjectExporter.ExportedMethodSpec(
+                member = method.name.value,
+                inputSignature = method.inputSignature?.value.orEmpty(),
+                outputSignature = method.outputSignature?.value.orEmpty()
+            )
+        }
+        refreshExport()
         return ActionResource {
             resources.forEach { it.release() }
             registrations.removeAll(resources)
+            exportedMethods.remove(interfaceName.value)
             val current = registeredInterfaces[interfaceName.value] ?: 0
             if (current <= 1) {
                 registeredInterfaces.remove(interfaceName.value)
@@ -1809,6 +1868,7 @@ private class PureJavaDbusObject(
                     propertiesByInterface.remove(interfaceName.value)
                 }
             }
+            refreshExport()
         }
     }
 
@@ -1864,5 +1924,6 @@ private class PureJavaDbusObject(
     override fun release(): Unit = run {
         registrations.forEach { it.release() }
         registrations.clear()
+        exporter?.close()
     }
 }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/SdbusObjectExporter.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/SdbusObjectExporter.kt
@@ -1,0 +1,452 @@
+package com.monkopedia.sdbus.internal.jvmdbus
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.Message
+import com.monkopedia.sdbus.MethodCall
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Variant
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicLong
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.annotation.AnnotationDescription
+import net.bytebuddy.description.modifier.Visibility
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.dynamic.DynamicType
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.annotations.DBusMemberName
+import org.freedesktop.dbus.connections.AbstractConnection
+import org.freedesktop.dbus.exceptions.DBusExecutionException
+import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.interfaces.ObjectManager
+import org.freedesktop.dbus.interfaces.Properties
+import org.freedesktop.dbus.types.Variant as JavaVariant
+
+/**
+ * Issue #90, approach A: makes JVM-hosted server objects reachable cross-process.
+ *
+ * dbus-java only dispatches incoming method/property/ObjectManager calls to objects that were
+ * registered through its native `AbstractConnection.exportObject(path, DBusInterface)` -- a
+ * reflection-driven path that requires a statically typed [DBusInterface] whose Java method
+ * parameter/return types marshal to the right D-Bus signatures. sdbus-kotlin's vtable is dynamic
+ * (signatures + callbacks resolved at runtime), so there is no compile-time interface to export.
+ *
+ * This bridge closes that gap: for each exported object it synthesizes, at runtime via ByteBuddy,
+ * a [DBusInterface] subtype per D-Bus interface whose methods carry parameter/return types that
+ * dbus-java's `Marshalling` turns back into the exact wire signatures the vtable declares, then
+ * exports a [java.lang.reflect.Proxy] implementing those interfaces (plus [Properties] and
+ * [ObjectManager] when the object serves them). Incoming calls land in [SdbusInvocationHandler],
+ * which converts dbus-java's deserialized Java values into the sdbus value model, routes through
+ * the very same in-process [JvmStaticDispatch] table the vtable already populates (so methods,
+ * properties and ObjectManager.GetManagedObjects all reuse the existing, tested handlers), and
+ * converts the reply back. No second dispatch implementation; dbus-java owns the wire codec.
+ *
+ * The bridge is strictly additive and best-effort: it never alters the in-process short-circuit
+ * path, and any interface/method whose signature it cannot yet map (e.g. structs, multi-out
+ * returns, type signatures) is simply left un-exported rather than failing the registration.
+ */
+internal class SdbusObjectExporter(
+    private val connection: AbstractConnection,
+    private val objectPath: String,
+    private val dispatchDestination: String
+) {
+    private var exported = false
+    private var lastSignature: ExportSignature? = null
+
+    private data class ExportSignature(
+        val interfaces: Map<String, List<ExportedMethodSpec>>,
+        val serveProperties: Boolean,
+        val serveObjectManager: Boolean
+    )
+
+    data class ExportedMethodSpec(
+        val member: String,
+        val inputSignature: String,
+        val outputSignature: String
+    )
+
+    /**
+     * Recomputes and (re-)exports the dbus-java object for the current vtable state. Cheap no-op
+     * when nothing relevant changed. Failures are swallowed -- export is an enhancement over the
+     * in-process path, never a precondition for it.
+     */
+    @Synchronized
+    fun update(
+        interfaces: Map<String, List<ExportedMethodSpec>>,
+        serveProperties: Boolean,
+        serveObjectManager: Boolean
+    ) {
+        val signature = ExportSignature(interfaces, serveProperties, serveObjectManager)
+        if (signature == lastSignature && exported) return
+        runCatching { unexportIfNeeded() }
+        if (interfaces.isEmpty() && !serveProperties && !serveObjectManager) {
+            lastSignature = signature
+            return
+        }
+        runCatching {
+            val proxy = buildProxy(interfaces, serveProperties, serveObjectManager)
+            connection.exportObject(objectPath, proxy)
+            exported = true
+            lastSignature = signature
+        }.onFailure {
+            exported = false
+        }
+    }
+
+    @Synchronized
+    fun close() {
+        runCatching { unexportIfNeeded() }
+        lastSignature = null
+    }
+
+    private fun unexportIfNeeded() {
+        if (exported) {
+            connection.unExportObject(objectPath)
+            exported = false
+        }
+    }
+
+    private fun buildProxy(
+        interfaces: Map<String, List<ExportedMethodSpec>>,
+        serveProperties: Boolean,
+        serveObjectManager: Boolean
+    ): DBusInterface {
+        val specsByKey = mutableMapOf<Pair<String, String>, ExportedMethodSpec>()
+        val unloaded = mutableListOf<DynamicType.Unloaded<*>>()
+        val generatedInterfaceNames = mutableListOf<String>()
+
+        interfaces.forEach { (ifaceName, methods) ->
+            val exportable = methods.filter { spec ->
+                runCatching { validateExportable(spec) }.getOrDefault(false)
+            }
+            if (exportable.isEmpty()) return@forEach
+            val generated = generateInterface(ifaceName, exportable)
+            unloaded += generated.unloaded
+            generatedInterfaceNames += generated.className
+            exportable.forEach { spec -> specsByKey[ifaceName to spec.member] = spec }
+        }
+
+        val loader = if (unloaded.isEmpty()) {
+            BRIDGE_CLASS_LOADER
+        } else {
+            val first = unloaded.first()
+            val combined = unloaded.drop(1).fold(first) { acc, next -> acc.include(next) }
+            combined.load(BRIDGE_CLASS_LOADER, ClassLoadingStrategy.Default.WRAPPER)
+                .loaded.classLoader
+        }
+
+        val proxyInterfaces = buildList<Class<*>> {
+            generatedInterfaceNames.forEach { name -> add(Class.forName(name, true, loader)) }
+            if (serveProperties) add(Properties::class.java)
+            if (serveObjectManager) add(ObjectManager::class.java)
+            if (isEmpty()) add(DBusInterface::class.java)
+        }
+
+        val handler = SdbusInvocationHandler(objectPath, dispatchDestination, specsByKey)
+        return Proxy.newProxyInstance(
+            loader,
+            proxyInterfaces.toTypedArray(),
+            handler
+        ) as DBusInterface
+    }
+
+    private data class GeneratedInterface(
+        val className: String,
+        val unloaded: DynamicType.Unloaded<*>
+    )
+
+    private fun generateInterface(
+        ifaceName: String,
+        methods: List<ExportedMethodSpec>
+    ): GeneratedInterface {
+        val className = "${GENERATED_PACKAGE}.SdbusIface\$${NEXT_ID.getAndIncrement()}"
+        var builder: DynamicType.Builder<*> = ByteBuddy()
+            .makeInterface(DBusInterface::class.java)
+            .name(className)
+            .annotateType(
+                AnnotationDescription.Builder.ofType(DBusInterfaceName::class.java)
+                    .define("value", ifaceName)
+                    .build()
+            )
+        methods.forEach { spec ->
+            val paramTypes = splitTopLevelTypes(spec.inputSignature).map(::signatureToGeneric)
+            val outputTypes = splitTopLevelTypes(spec.outputSignature)
+            val returnType: TypeDescription.Generic = when (outputTypes.size) {
+                0 -> TypeDescription.ForLoadedType.of(Void.TYPE).asGenericType()
+                else -> signatureToGeneric(outputTypes.first())
+            }
+            builder = builder
+                .defineMethod(javaMethodName(spec.member), returnType, Visibility.PUBLIC)
+                .withParameters(paramTypes)
+                .withoutCode()
+                .annotateMethod(
+                    AnnotationDescription.Builder.ofType(DBusMemberName::class.java)
+                        .define("value", spec.member)
+                        .build()
+                )
+        }
+        return GeneratedInterface(className, builder.make())
+    }
+
+    // Only export methods whose entire input signature and (single) output signature map to
+    // round-trippable Java types. Structs, multi-out returns and 'g' (signature) args are not
+    // yet supported and leave the method un-exported instead of breaking registration.
+    private fun validateExportable(spec: ExportedMethodSpec): Boolean {
+        val outputs = splitTopLevelTypes(spec.outputSignature)
+        if (outputs.size > 1) return false
+        (splitTopLevelTypes(spec.inputSignature) + outputs).forEach { signatureToGeneric(it) }
+        return true
+    }
+
+    companion object {
+        private const val GENERATED_PACKAGE = "com.monkopedia.sdbus.generated"
+        private val NEXT_ID = AtomicLong(1)
+        private val BRIDGE_CLASS_LOADER: ClassLoader = DBusInterface::class.java.classLoader
+
+        private fun javaMethodName(member: String): String = if (member.isNotEmpty() &&
+            member[0].isLetter() &&
+            member.all { it.isLetterOrDigit() || it == '_' }
+        ) {
+            member
+        } else {
+            "m_${member.hashCode().toUInt()}"
+        }
+    }
+}
+
+/**
+ * Maps a single complete D-Bus type to the Java type whose dbus-java `Marshalling.getDBusType`
+ * inverse produces exactly that signature. Throws [UnsupportedSignatureException] for types not
+ * yet bridged so the caller can skip them.
+ */
+private class UnsupportedSignatureException(signature: String) :
+    RuntimeException("Unsupported D-Bus signature for JVM export: $signature")
+
+private fun signatureToGeneric(signature: String): TypeDescription.Generic = when {
+    signature == "b" -> rawGeneric(Boolean::class.javaObjectType)
+    signature == "y" -> rawGeneric(Byte::class.javaObjectType)
+    signature == "n" -> rawGeneric(Short::class.javaObjectType)
+    signature == "q" -> rawGeneric(org.freedesktop.dbus.types.UInt16::class.java)
+    signature == "i" -> rawGeneric(Int::class.javaObjectType)
+    signature == "u" -> rawGeneric(org.freedesktop.dbus.types.UInt32::class.java)
+    signature == "x" -> rawGeneric(Long::class.javaObjectType)
+    signature == "t" -> rawGeneric(org.freedesktop.dbus.types.UInt64::class.java)
+    signature == "d" -> rawGeneric(Double::class.javaObjectType)
+    signature == "s" -> rawGeneric(String::class.java)
+    signature == "o" -> rawGeneric(DBusPath::class.java)
+    signature == "h" -> rawGeneric(org.freedesktop.dbus.FileDescriptor::class.java)
+    signature == "v" -> rawGeneric(JavaVariant::class.java)
+    signature.startsWith("a{") && signature.endsWith("}") -> {
+        val entry = splitTopLevelTypes(signature.substring(2, signature.length - 1))
+        if (entry.size != 2) throw UnsupportedSignatureException(signature)
+        TypeDescription.Generic.Builder.parameterizedType(
+            TypeDescription.ForLoadedType.of(Map::class.java),
+            listOf(signatureToGeneric(entry[0]), signatureToGeneric(entry[1]))
+        ).build()
+    }
+    signature.startsWith("a") && signature.length > 1 -> {
+        TypeDescription.Generic.Builder.parameterizedType(
+            TypeDescription.ForLoadedType.of(List::class.java),
+            listOf(signatureToGeneric(signature.substring(1)))
+        ).build()
+    }
+    else -> throw UnsupportedSignatureException(signature)
+}
+
+private fun rawGeneric(cls: Class<*>): TypeDescription.Generic =
+    TypeDescription.ForLoadedType.of(cls).asGenericType()
+
+/**
+ * Routes an incoming dbus-java method/property/ObjectManager call (already deserialized into Java
+ * values by dbus-java) into the in-process [JvmStaticDispatch] table the vtable populates, then
+ * converts the reply back into the Java value model dbus-java will marshal onto the wire.
+ */
+private class SdbusInvocationHandler(
+    private val objectPath: String,
+    private val dispatchDestination: String,
+    private val specsByKey: Map<Pair<String, String>, SdbusObjectExporter.ExportedMethodSpec>
+) : InvocationHandler {
+
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any?>?): Any? {
+        val arguments = args?.toList().orEmpty()
+        return when {
+            method.declaringClass == Any::class.java -> handleObjectMethod(proxy, method, arguments)
+            method.name == "getObjectPath" && arguments.isEmpty() -> objectPath
+            method.name == "isRemote" && arguments.isEmpty() -> false
+            method.declaringClass == Properties::class.java -> handleProperties(
+                method.name,
+                arguments
+            )
+            method.declaringClass == ObjectManager::class.java -> handleGetManagedObjects()
+            else -> handleUserMethod(method, arguments)
+        }
+    }
+
+    private fun handleObjectMethod(proxy: Any, method: Method, args: List<Any?>): Any? =
+        when (method.name) {
+            "toString" -> "SdbusExportedObject($objectPath)"
+            "hashCode" -> System.identityHashCode(proxy)
+            "equals" -> proxy === args.firstOrNull()
+            else -> null
+        }
+
+    private fun handleUserMethod(method: Method, args: List<Any?>): Any? {
+        val ifaceName = method.declaringClass.getAnnotation(DBusInterfaceName::class.java)?.value
+            ?: throw DBusExecutionException("Missing interface name for ${method.name}")
+        val member = method.getAnnotation(DBusMemberName::class.java)?.value ?: method.name
+        val spec = specsByKey[ifaceName to member]
+            ?: throw DBusExecutionException("Unknown method $ifaceName.$member")
+        val inputTypes = splitTopLevelTypes(spec.inputSignature)
+        val sdbusArgs = args.mapIndexed { index, value ->
+            fromJavaWireValue(value, inputTypes.getOrNull(index))
+        }
+        val reply = dispatch(ifaceName, member, sdbusArgs)
+        val outputTypes = splitTopLevelTypes(spec.outputSignature)
+        return when (outputTypes.size) {
+            0 -> null
+            else -> sdbusToJava(reply.firstOrNull(), outputTypes.first())
+        }
+    }
+
+    private fun handleProperties(name: String, args: List<Any?>): Any? = when (name) {
+        "Get" -> {
+            val result = invokeDispatch(
+                PROPERTIES_INTERFACE,
+                "Get",
+                listOf(args[0].toString(), args[1].toString())
+            )
+            (result as? Variant)?.let(::sdbusVariantToJava)
+        }
+        "GetAll" -> {
+            val result = invokeDispatch(
+                PROPERTIES_INTERFACE,
+                "GetAll",
+                listOf(args[0].toString())
+            )
+            @Suppress("UNCHECKED_CAST")
+            (result as? Map<PropertyName, Variant>).orEmpty().entries.associate { (key, value) ->
+                key.value to sdbusVariantToJava(value)
+            }
+        }
+        "Set" -> {
+            val newValue = fromJavaSignalValue(args[2])
+            invokeDispatch(
+                PROPERTIES_INTERFACE,
+                "Set",
+                listOf(args[0].toString(), args[1].toString(), newValue)
+            )
+            null
+        }
+        else -> throw DBusExecutionException("Unsupported Properties method $name")
+    }
+
+    private fun handleGetManagedObjects(): Map<DBusPath, Map<String, Map<String, JavaVariant<*>>>> {
+        val result = invokeDispatch(
+            OBJECT_MANAGER_INTERFACE,
+            "GetManagedObjects",
+            emptyList()
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val managed = (result as? Map<ObjectPath, Map<InterfaceName, Map<PropertyName, Variant>>>)
+            .orEmpty()
+        return managed.entries.associate { (path, ifaces) ->
+            DBusPath(path.value) to ifaces.entries.associate { (iface, props) ->
+                iface.value to props.entries.associate { (prop, variant) ->
+                    prop.value to sdbusVariantToJava(variant)
+                }
+            }
+        }
+    }
+
+    // Routes through the same JvmStaticDispatch table the in-process path uses, mirroring
+    // PureJavaDbusProxy.callStaticDispatch's reply extraction so a method's async reply, error
+    // reply or direct return value are all handled identically.
+    private fun dispatch(interfaceName: String, methodName: String, args: List<Any?>): List<Any?> {
+        val result = invokeDispatch(interfaceName, methodName, args)
+        return when (result) {
+            Unit -> emptyList()
+            is JvmStaticDispatch.DispatchResult -> {
+                result.reply.error?.let { throw DBusExecutionException(it.message ?: it.name) }
+                result.reply.payload.toList()
+            }
+            else -> listOf(result)
+        }
+    }
+
+    private fun invokeDispatch(interfaceName: String, methodName: String, args: List<Any?>): Any? {
+        if (!JvmStaticDispatch.hasHandler(
+                objectPath = objectPath,
+                interfaceName = interfaceName,
+                methodName = methodName,
+                args = args,
+                destination = dispatchDestination
+            )
+        ) {
+            throw DBusExecutionException(
+                "No binding for $objectPath:$interfaceName.$methodName/${args.size}"
+            )
+        }
+        val inbound = MethodCall().also {
+            it.metadata = Message.Metadata(
+                interfaceName = interfaceName,
+                memberName = methodName,
+                destination = dispatchDestination,
+                path = objectPath,
+                valid = true,
+                empty = args.isEmpty()
+            )
+            it.payload.addAll(args)
+        }
+        return JvmCurrentMessageContext.withMessage(inbound) {
+            JvmStaticDispatch.invokeOrNull(
+                objectPath = objectPath,
+                interfaceName = interfaceName,
+                methodName = methodName,
+                args = args,
+                destination = dispatchDestination
+            )
+        }
+    }
+
+    companion object {
+        private const val PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+        private const val OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
+    }
+}
+
+private fun sdbusVariantToJava(variant: Variant): JavaVariant<*> {
+    val payload = extractVariantPayload(variant)
+    return toJavaVariantValue(payload.signature, payload.value)
+}
+
+// Signature-driven conversion of an sdbus reply value into the exact Java type dbus-java will
+// marshal for that signature. Reuses toJavaSignalValue for the unambiguous leaf cases and only
+// overrides where the wire signature -- not the value shape -- decides the Java type (object
+// paths, and recursion into containers so element/entry signatures stay authoritative).
+private fun sdbusToJava(value: Any?, signature: String): Any? = when {
+    value == null -> null
+    signature == "o" -> DBusPath(
+        when (value) {
+            is ObjectPath -> value.value
+            else -> value.toString()
+        }
+    )
+    signature.startsWith("a{") && signature.endsWith("}") -> {
+        val entry = splitTopLevelTypes(signature.substring(2, signature.length - 1))
+        val map = value as? Map<*, *> ?: emptyMap<Any?, Any?>()
+        map.entries.associate { (k, v) ->
+            sdbusToJava(k, entry.getOrNull(0).orEmpty()) to
+                sdbusToJava(v, entry.getOrNull(1).orEmpty())
+        }
+    }
+    signature.startsWith("a") && signature.length > 1 -> {
+        val element = signature.substring(1)
+        (wireValueAsList(value) ?: emptyList()).map { sdbusToJava(it, element) }
+    }
+    else -> toJavaSignalValue(value)
+}

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCrossProcessExportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCrossProcessExportTest.kt
@@ -1,0 +1,136 @@
+package com.monkopedia.sdbus
+
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Acceptance test for issue #90 (approach A): an EXTERNAL process must be able to reach a
+ * JVM-hosted server object.
+ *
+ * The proof drives the JVM-exported object with `busctl` -- a genuinely separate process. This
+ * is essential: two sdbus-kotlin connections in the *same* JVM short-circuit through the global
+ * in-process [com.monkopedia.sdbus.internal.jvmdbus.JvmStaticDispatch] table (single-candidate
+ * fallback), so a same-process "cross-connection" call never actually serializes onto the wire
+ * and cannot detect the gap. busctl has no such entry and must go through dbus-java's native
+ * object export, which only serves the object once the approach-A bridge has exported it.
+ *
+ * Before the fix this fails: dbus-java answers external method/property/ObjectManager calls with
+ * `UnknownObject`, so every busctl invocation exits non-zero. After the fix the object is
+ * exported and busctl gets real values.
+ */
+class JvmCrossProcessExportTest {
+
+    private data class BusctlResult(val exitCode: Int, val output: String)
+
+    private fun busctlPath(): String? = listOf("/usr/bin/busctl", "/bin/busctl")
+        .firstOrNull { java.io.File(it).canExecute() }
+
+    private fun runBusctl(address: String, busctl: String, vararg args: String): BusctlResult {
+        val command = listOf(busctl, "--address=$address", *args)
+        val process = ProcessBuilder(command).redirectErrorStream(true).start()
+        val output = ByteArrayOutputStream()
+        val pump = thread(start = true, isDaemon = true) {
+            process.inputStream.use { it.copyTo(output) }
+        }
+        if (!process.waitFor(10, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+        }
+        pump.join(1_000)
+        return BusctlResult(process.exitValue(), output.toString(Charsets.UTF_8))
+    }
+
+    private fun connectOrNull(connect: () -> Connection): Connection? = try {
+        connect()
+    } catch (e: Error) {
+        null
+    }
+
+    @Test
+    fun externalBusctlClientReachesJvmExportedObject() {
+        val address = System.getenv("DBUS_SESSION_BUS_ADDRESS") ?: return
+        val busctl = busctlPath() ?: return
+
+        val suffix = "x${System.nanoTime()}"
+        val service = ServiceName("com.monkopedia.sdbus.export$suffix")
+        val managerPath = ObjectPath("/com/monkopedia/sdbus/export$suffix")
+        val childPath = ObjectPath("${managerPath.value}/child")
+        val iface = InterfaceName("com.monkopedia.sdbus.export.$suffix.Iface")
+        val concat = MethodName("Concat")
+        val valueProp = PropertyName("Value")
+
+        val server = connectOrNull { createSessionBusConnection(service) } ?: return
+        server.startEventLoop()
+        val managerRegistration = server.addObjectManager(managerPath)
+        val obj = createObject(server, childPath)
+        val registration = obj.addVTable(iface) {
+            method(concat) {
+                call { a: String, b: Int -> "$a:$b" }
+            }
+            prop(valueProp) {
+                withGetter { 42 }
+            }
+        }
+
+        try {
+            // 1) External method call on a JVM-hosted object.
+            val call = runBusctl(
+                address,
+                busctl,
+                "call",
+                service.value,
+                childPath.value,
+                iface.value,
+                concat.value,
+                "si",
+                "hello",
+                "7"
+            )
+            assertEquals(0, call.exitCode, "busctl call failed: ${call.output}")
+            assertTrue(
+                call.output.contains("hello:7"),
+                "Unexpected method reply: ${call.output}"
+            )
+
+            // 2) External org.freedesktop.DBus.Properties.Get.
+            val property = runBusctl(
+                address,
+                busctl,
+                "get-property",
+                service.value,
+                childPath.value,
+                iface.value,
+                valueProp.value
+            )
+            assertEquals(0, property.exitCode, "busctl get-property failed: ${property.output}")
+            assertTrue(
+                property.output.contains("42"),
+                "Unexpected property reply: ${property.output}"
+            )
+
+            // 3) External org.freedesktop.DBus.ObjectManager.GetManagedObjects.
+            val managed = runBusctl(
+                address,
+                busctl,
+                "call",
+                service.value,
+                managerPath.value,
+                "org.freedesktop.DBus.ObjectManager",
+                "GetManagedObjects"
+            )
+            assertEquals(0, managed.exitCode, "busctl GetManagedObjects failed: ${managed.output}")
+            assertTrue(
+                managed.output.contains(childPath.value) && managed.output.contains("Value"),
+                "Unexpected GetManagedObjects reply: ${managed.output}"
+            )
+        } finally {
+            registration.release()
+            obj.release()
+            managerRegistration.release()
+            server.release()
+        }
+    }
+}


### PR DESCRIPTION
**Status: PARTIAL / WIP** — a working, tested subset of issue #90 approach A. Does **not** close #90 (struct & multi-out method signatures remain in-process only; see "What remains").

## Problem
dbus-java only dispatches incoming method/property/ObjectManager calls to objects registered through its native `AbstractConnection.exportObject(path, DBusInterface)` — a reflection-driven path requiring a statically-typed `DBusInterface`. sdbus-kotlin's JVM vtable is dynamic, so nothing was registered with dbus-java and external callers got `UnknownObject`. (Signal emission already reached the bus and is untouched.)

## Mechanism (approach A)
New `SdbusObjectExporter` (jvmMain) registers each exported object with dbus-java alongside the existing in-process `JvmStaticDispatch` table:

- For each D-Bus interface, ByteBuddy synthesizes at runtime a `DBusInterface` subtype (annotated `@DBusInterfaceName`) whose methods (annotated `@DBusMemberName`) carry Java parameter/return types that dbus-java's `Marshalling.getDBusType` turns back into the vtable's **exact** wire signatures.
- A `java.lang.reflect.Proxy` implementing those interfaces (plus `Properties`/`ObjectManager` when served) is exported. Its `InvocationHandler` converts dbus-java's deserialized Java values into the sdbus value model, routes through the **same** `JvmStaticDispatch` handlers the vtable already populates, and converts the reply back.
- **dbus-java owns the wire codec** — there is no second serializer to keep in lockstep with the #78 codec. The only conversion is at the Java-value boundary, reusing the already-tested `toJavaSignalValue`/`fromJavaWireValue` helpers from the client path.

The bridge is strictly additive and best-effort: the in-process short-circuit is unchanged, and any method whose signature it cannot yet map is left un-exported rather than failing `addVTable`.

## Signature mapping
D-Bus single-complete-types map to the Java types dbus-java's `getJavaType`/`getDBusType` round-trip identically: `b/y/n/q/i/u/x/t/d → Boolean/Byte/Short/UInt16/Integer/UInt32/Long/UInt64/Double`, `s → String`, `o → DBusPath`, `h → FileDescriptor`, `v → Variant`, `a… → List<…>`, `a{…} → Map<…>` (built as ByteBuddy parameterized types). Object-path replies are emitted as `DBusPath` and containers recurse with their element/entry signatures so the wire signature — not the value shape — drives the Java type.

## New dependency (flag for owner awareness)
`net.bytebuddy:byte-buddy:1.18.2` (~3MB, widely used) added as a **jvmMain `implementation`** dependency — a dependency-graph change to the published `-jvm` artifact. dbus-java-core does not bring a bytecode lib transitively, so this is genuinely new on the main classpath (it was previously only a transitive `testImplementation` of mockk). No public API change; `apiDump` is a no-op.

## Acceptance test (fails-before / passes-after)
`JvmCrossProcessExportTest` drives a JVM-exported object with **busctl** — a genuinely external process. (Two sdbus-kotlin connections in the *same* JVM short-circuit through the global `JvmStaticDispatch` single-candidate fallback and never hit the wire, so they cannot detect the gap; busctl has no such entry and must go through dbus-java export.) It asserts a method call, `Properties.Get`, and `ObjectManager.GetManagedObjects` all return real values.

- **Before** the bridge: every busctl op fails with `… is not an object provided by this process` (`UnknownObject`) — verified by disabling export.
- **After**: all three pass.

## BACKENDS.md
Server-side rows re-flipped to reflect cross-process serve for the common surface (busctl-verified), with the struct/multi-out gaps documented honestly.

## What remains (tracked in #90; in-process only for now)
- Methods whose signatures contain a **struct** `(...)` — needs runtime generation of concrete dbus-java `Struct` subclasses (positioned fields + assigning constructor); dbus-java's `getDBusType(DBusStructType)` does **not** round-trip, so a generated `Struct` class is required. (Struct-*valued* properties / `GetManagedObjects` entries already work — they travel inside a `Variant`.)
- Methods returning **multiple out-values** — needs runtime `Tuple` subtype generation for the parameterized return type dbus-java requires.
- `g` (signature) arguments.

## Verification
`ktlintFormat` → `apiDump` (no-op) → `ktlintCheck apiCheck` clean; `jvmTest`, `linuxX64Test`, `cross_test:jvmTest`, `cross_test:linuxX64Test` all green under `dbus-run-session`; `compileKotlinLinuxX64`, `codegen:test`, `plugin:test` green. Nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)