### PR TITLE
Phase 3 (#93): JVM client path through the owned connection (toggle)

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -88,6 +88,52 @@ jobs:
             stress_test/build/test-results/**
             stress_test/build/reports/tests/**
 
+  wire-client-parity-x64:
+    # Epic #93 phase 3: run the JVM client suites on the self-owned wire connection
+    # (-Dsdbus.jvm.wire=true). A hard job timeout plus an inner `timeout` guard ensure a hung
+    # call/signal fails the job fast instead of stalling (a prior run hung for 21 hours).
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Install Test Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus python3-dbusmock
+
+      - name: Run JVM Client Suites on the Owned Wire Connection
+        run: |
+          set -euo pipefail
+          dbus-run-session -- bash -lc '
+            set -euo pipefail
+            export DBUS_STARTER_BUS_TYPE=session
+            export DBUS_STARTER_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
+            export DBUS_SYSTEM_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
+            timeout 1800 ./gradlew --no-daemon :jvmTest :cross_test:jvmTest \
+              -Dsdbus.jvm.wire=true --stacktrace
+          '
+
+      - name: Upload Failure Reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wire-client-parity-x64-${{ github.run_id }}
+          retention-days: 14
+          path: |
+            build/test-results/**
+            build/reports/tests/**
+            cross_test/build/test-results/**
+            cross_test/build/reports/tests/**
+
   native-build-x64:
     runs-on: ubuntu-24.04
     timeout-minutes: 60

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,6 +139,12 @@ kotlin {
     }
 }
 
+// Phase 3 (#93): forward the owned-connection client toggle to the test JVMs so
+// `-Dsdbus.jvm.wire=true` on the Gradle invocation selects the wire client path under test.
+tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+    System.getProperty("sdbus.jvm.wire")?.let { systemProperty("sdbus.jvm.wire", it) }
+}
+
 fun firstExistingPath(vararg candidates: String): String? =
     candidates.firstOrNull { rootProject.file(it).exists() }
 

--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -42,6 +42,11 @@ val reverseInteropEnabled = providers
     .systemProperty("kdbus.crossRuntimeInterop.reverse.enabled")
     .orElse(providers.gradleProperty("kdbus.crossRuntimeInterop.reverse.enabled"))
 
+// Phase 3 (#93): forward the owned-connection client toggle to cross_test's JVM test JVMs.
+tasks.withType<Test>().configureEach {
+    System.getProperty("sdbus.jvm.wire")?.let { systemProperty("sdbus.jvm.wire", it) }
+}
+
 tasks.register<Test>("jvmInteropTest") {
     group = "verification"
     description = "Runs JVM<->native direct-bus interop smoke tests in cross_test."

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 import kotlinx.coroutines.future.await
@@ -201,11 +202,14 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
         }
     }
 
+    private data class PendingCall(val serial: Int, val future: CompletableFuture<WireMessage>)
+
     /**
      * Sends [request] (a serial is assigned automatically) and returns the registered future that
-     * the reader completes with the matching reply.
+     * the reader completes with the matching reply, plus the serial so callers can evict the
+     * pending entry if they give up waiting (timeout).
      */
-    private fun dispatchCall(request: WireMessage): CompletableFuture<WireMessage> {
+    private fun dispatchCall(request: WireMessage): PendingCall {
         val serial = nextSerial()
         val future = CompletableFuture<WireMessage>()
         pending[serial] = future
@@ -215,19 +219,50 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
             pending.remove(serial)
             future.completeExceptionally(e)
         }
-        return future
+        return PendingCall(serial, future)
     }
 
-    /** Suspends until the reply for [request] arrives; throws [DBusCallException] on a D-Bus error. */
-    suspend fun call(request: WireMessage): WireMessage =
-        dispatchCall(request).await().also(::throwIfError)
+    /**
+     * Suspends until the reply for [request] arrives or [timeoutMillis] elapses; throws
+     * [DBusCallException] on a D-Bus error or on timeout. A timeout bounds the wait so a reply
+     * that never arrives cannot hang the caller indefinitely (epic #93 phase 3).
+     */
+    suspend fun call(
+        request: WireMessage,
+        timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS
+    ): WireMessage {
+        val (serial, future) = dispatchCall(request)
+        val reply = try {
+            future.orTimeout(timeoutMillis, TimeUnit.MILLISECONDS).await()
+        } catch (e: TimeoutException) {
+            pending.remove(serial)
+            throw DBusCallException(
+                TIMEOUT_ERROR_NAME,
+                "Method call timed out after ${timeoutMillis}ms"
+            )
+        }
+        throwIfError(reply)
+        return reply
+    }
 
     /** Blocking variant of [call], for bootstrap before any coroutine context exists. */
     fun callBlocking(
         request: WireMessage,
         timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS
-    ): WireMessage =
-        dispatchCall(request).get(timeoutMillis, TimeUnit.MILLISECONDS).also(::throwIfError)
+    ): WireMessage {
+        val (serial, future) = dispatchCall(request)
+        val reply = try {
+            future.get(timeoutMillis, TimeUnit.MILLISECONDS)
+        } catch (e: TimeoutException) {
+            pending.remove(serial)
+            throw DBusCallException(
+                TIMEOUT_ERROR_NAME,
+                "Method call timed out after ${timeoutMillis}ms"
+            )
+        }
+        throwIfError(reply)
+        return reply
+    }
 
     /** Fire-and-forget send (e.g. a method call with NO_REPLY_EXPECTED, a signal, or a reply). */
     fun send(message: WireMessage): Int {
@@ -313,6 +348,25 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
         )
     }
 
+    /**
+     * Resolves the current unique-name owner of a (possibly well-known) [busName], or null when
+     * the name has no owner. Used to match incoming signals (whose sender is a unique name)
+     * against a subscription expressed by a well-known destination.
+     */
+    fun getNameOwner(busName: String): String? = runCatching {
+        callBlocking(
+            WireMessage(
+                type = WireMessageType.METHOD_CALL,
+                destination = DBUS_SERVICE,
+                path = DBUS_PATH,
+                interfaceName = DBUS_INTERFACE,
+                member = "GetNameOwner",
+                signature = "s",
+                body = listOf(busName)
+            )
+        ).body.firstOrNull() as? String
+    }.getOrNull()
+
     /** Removes a previously installed match [rule]. */
     fun removeMatch(rule: String) {
         callBlocking(
@@ -347,6 +401,7 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
         private const val DBUS_INTERFACE = "org.freedesktop.DBus"
         private const val DEFAULT_TIMEOUT_MILLIS = 30_000L
         private const val JOIN_TIMEOUT_MILLIS = 2_000L
+        private const val TIMEOUT_ERROR_NAME = "org.freedesktop.DBus.Error.Timeout"
         private const val DEFAULT_SYSTEM_BUS_ADDRESS = "unix:path=/var/run/dbus/system_bus_socket"
 
         /** Connects to the session bus (`DBUS_SESSION_BUS_ADDRESS`) and completes Hello. */

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDbusBackend.kt
@@ -111,8 +111,20 @@ internal interface JvmDbusBackend {
     fun createObject(connection: Connection, objectPath: ObjectPath): JvmDbusObject
 }
 
+/**
+ * Whether the JVM client path should run on the self-owned D-Bus connection (epic #93) instead of
+ * dbus-java. Opt-in via `-Dsdbus.jvm.wire=true` or the `SDBUS_JVM_WIRE=true` environment variable;
+ * the default stays dbus-java until the owned path is complete (flipped in a later phase).
+ */
+internal fun isJvmWireBackendEnabled(): Boolean {
+    System.getProperty("sdbus.jvm.wire")?.let { return it.equals("true", ignoreCase = true) }
+    return System.getenv("SDBUS_JVM_WIRE")?.equals("true", ignoreCase = true) == true
+}
+
 internal object JvmDbusBackendProvider {
-    val backend: JvmDbusBackend = PureJavaDbusBackend()
+    val backend: JvmDbusBackend by lazy {
+        if (isJvmWireBackendEnabled()) WireDbusBackend() else PureJavaDbusBackend()
+    }
 }
 
 /**

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -295,7 +295,7 @@ private object LocalManagedObjectsRegistry {
     }
 }
 
-private object LocalObjectManagerRegistry {
+internal object LocalObjectManagerRegistry {
     private data class ManagerKey(val destination: String, val path: String)
 
     private val managerPaths = mutableMapOf<String, Int>()
@@ -354,7 +354,7 @@ private object LocalObjectManagerRegistry {
     }
 }
 
-private object LocalJvmServiceRegistry {
+internal object LocalJvmServiceRegistry {
     private val namesByUnique = mutableMapOf<String, MutableSet<String>>()
 
     fun registerLocalUniqueName(uniqueName: String) {
@@ -1392,7 +1392,7 @@ private fun addGenericSigHandler(
     return method.invoke(connection, matchRule, callback) as AutoCloseable
 }
 
-private class PureJavaDbusObject(
+internal class PureJavaDbusObject(
     private val objectPath: ObjectPath,
     private val javaConnection: AbstractConnection?,
     private val senderName: String?

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -5,6 +5,7 @@ import com.monkopedia.sdbus.BusName
 import com.monkopedia.sdbus.Connection
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.JvmConnection
+import com.monkopedia.sdbus.MemberName
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MessageHandler
 import com.monkopedia.sdbus.MethodCall
@@ -403,7 +404,7 @@ internal class WireDbusProxy(
                 valid = true,
                 empty = reply.body.isEmpty()
             ),
-            reply.body
+            fromWireReplyValues(reply.body, reply.signature)
         )
     }
 
@@ -583,7 +584,7 @@ private fun installSignalMatch(
                 empty = wireMessage.body.isEmpty()
             )
         )
-        signal.payload.addAll(wireMessage.body)
+        signal.payload.addAll(fromWireReplyValues(wireMessage.body, wireMessage.signature))
         JvmCurrentMessageContext.withMessage(signal) { callback(signal) }
     }
     val localResource = LocalJvmMatchBus.register(localMatch, callback)
@@ -612,6 +613,14 @@ private fun microsToMillis(micros: ULong): Long =
  */
 private fun toWireBodyValue(value: Any?): Any? = when (value) {
     is Variant -> variantToPayload(value)
+    // The string-like strong-name value classes arrive boxed in the payload (e.g. the
+    // InterfaceName/PropertyName args of a Properties.Get call), since serialize() adds the raw
+    // arg for a non-struct descriptor. Unwrap them to their String so the marshaller's `s`
+    // handling accepts them, mirroring the dbus-java path's toJavaSignalValue. (ObjectPath,
+    // Signature and UnixFd pass through: the marshaller coerces those itself.)
+    is BusName -> value.value
+    is InterfaceName -> value.value
+    is MemberName -> value.value
     is Message.JvmVariantPayload ->
         Message.JvmVariantPayload(value.signature, toWireBodyValue(value.value))
     is Message.JvmStructPayload ->
@@ -632,6 +641,114 @@ private fun variantToPayload(variant: Variant): Message.JvmVariantPayload {
     val value = message.nextDeserializedValue("variantToPayload")
     message.exitVariant()
     return Message.JvmVariantPayload(signature, toWireBodyValue(value))
+}
+
+// --- reply/signal value-model bridge (wire -> decoder) ---------------------------------------
+
+/**
+ * Converts the demarshaller's wire value model into the canonical decoder-compatible model the
+ * high-level deserializer expects -- the SAME model the dbus-java reply path produces
+ * ([com.monkopedia.sdbus.internal.jvmdbus] fromJavaWireValue): a wire variant
+ * ([Message.JvmVariantPayload]) becomes a high-level [Variant] (the decoder reads variants as
+ * [Variant], never as the raw payload box); an object-path/signature that demarshalled to a bare
+ * String becomes its strong [ObjectPath]/[Signature] type, so signature inference and grouped
+ * multi-out (`(vo)` etc.) detection see the right element type instead of "s"; structs/arrays/
+ * dicts recurse. The reply SIGNATURE header field is authoritative -- it is the only way to know a
+ * String is `o`/`g` or what an element/entry type is -- so it drives the conversion. Without this
+ * the reply body is NOT decoder-compatible (variants ClassCastException, `o` trips signature
+ * enforcement); the demarshaller alone is signature-agnostic about these distinctions.
+ */
+private fun fromWireReplyValues(body: List<Any?>, signature: String?): List<Any?> {
+    val types = signature?.let(::splitTopLevelTypes).orEmpty()
+    return body.mapIndexed { index, value -> fromWireReplyValue(value, types.getOrNull(index)) }
+}
+
+private fun fromWireReplyValue(value: Any?, signature: String?): Any? = when (value) {
+    is Message.JvmVariantPayload -> wireVariant(value)
+    is Message.JvmStructPayload -> {
+        val fieldTypes = splitTopLevelTypes(value.signature.removeSurrounding("(", ")"))
+        Message.JvmStructPayload(
+            value.signature,
+            value.fields.mapIndexed { i, field ->
+                fromWireReplyValue(field, fieldTypes.getOrNull(i))
+            }
+        )
+    }
+
+    is Map<*, *> -> {
+        val (keyType, valueType) = dictEntryTypes(signature)
+        value.entries.associate { (k, v) ->
+            fromWireReplyValue(k, keyType) to fromWireReplyValue(v, valueType)
+        }
+    }
+
+    is List<*> -> {
+        val elementType = signature?.takeIf { it.startsWith("a") }?.substring(1)
+        value.map { fromWireReplyValue(it, elementType) }
+    }
+
+    is String -> when (signature) {
+        "o" -> ObjectPath(value)
+        "g" -> Signature(value)
+        else -> value
+    }
+
+    else -> value
+}
+
+/**
+ * Wraps a demarshalled wire variant in a high-level [Variant], converting its inner value
+ * recursively so a nested variant/object-path is itself decoder-compatible once the variant is
+ * unwrapped via `get()`. Mirrors PureJavaDbusBackend.fromJavaVariantValue.
+ */
+private fun wireVariant(payload: Message.JvmVariantPayload): Variant {
+    val message = PlainMessage.createPlainMessage()
+    message.payload.add(
+        Message.JvmVariantPayload(
+            payload.signature,
+            fromWireReplyValue(payload.value, payload.signature)
+        )
+    )
+    return Variant().apply { deserializeFrom(message) }
+}
+
+/** Key/value element types of a dict signature `a{kv}`, or (null, null) if not a dict. */
+private fun dictEntryTypes(signature: String?): Pair<String?, String?> {
+    if (signature == null || !signature.startsWith("a{") || !signature.endsWith("}")) {
+        return null to null
+    }
+    val parts = splitTopLevelTypes(signature.substring(2, signature.length - 1))
+    return parts.getOrNull(0) to parts.getOrNull(1)
+}
+
+/** Splits a signature into its top-level complete types (e.g. "sa{sv}(is)" -> [s, a{sv}, (is)]). */
+private fun splitTopLevelTypes(signature: String): List<String> {
+    fun parseOne(index: Int): Int {
+        if (index >= signature.length) return index
+        return when (signature[index]) {
+            'a' -> parseOne(index + 1)
+            '(' -> {
+                var i = index + 1
+                while (i < signature.length && signature[i] != ')') i = parseOne(i)
+                (i + 1).coerceAtMost(signature.length)
+            }
+            '{' -> {
+                var i = index + 1
+                while (i < signature.length && signature[i] != '}') i = parseOne(i)
+                (i + 1).coerceAtMost(signature.length)
+            }
+            else -> index + 1
+        }
+    }
+    val types = mutableListOf<String>()
+    var index = 0
+    while (index < signature.length) {
+        val next = parseOne(index)
+        if (next <= index) break
+        types += signature.substring(index, next)
+        index = next
+    }
+    return types
 }
 
 /**

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -1,0 +1,718 @@
+package com.monkopedia.sdbus.internal.jvmdbus
+
+import com.monkopedia.sdbus.AsyncReplyHandler
+import com.monkopedia.sdbus.BusName
+import com.monkopedia.sdbus.Connection
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.JvmConnection
+import com.monkopedia.sdbus.Message
+import com.monkopedia.sdbus.MessageHandler
+import com.monkopedia.sdbus.MethodCall
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.MethodReply
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PendingAsyncCall
+import com.monkopedia.sdbus.PlainMessage
+import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalHandler
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Signature
+import com.monkopedia.sdbus.UnixFd
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.createError
+import com.monkopedia.sdbus.methodReplyFrom
+import com.monkopedia.sdbus.signalFromMetadata
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.time.Duration
+
+/**
+ * JVM backend that routes the CLIENT path through the self-owned D-Bus connection
+ * ([DBusWireConnection]) instead of dbus-java (epic #93, phase 3). Selected via the
+ * `sdbus.jvm.wire` toggle (see [isJvmWireBackendEnabled]); dbus-java remains the default.
+ *
+ * Scope this phase is deliberately CLIENT-ONLY, with a consistent same-process/cross-process split:
+ * - method calls (sync + async) to a REMOTE peer and Properties Get/Set/GetAll go over the wire;
+ *   a call to an object served by one of our OWN connections is dispatched in-process through the
+ *   shared static-dispatch tables ([JvmStaticDispatch], [LocalObjectManagerRegistry], ...), exactly
+ *   as the dbus-java backend short-circuits same-process calls;
+ * - signal RECEPTION uses the same split: signals from OTHER processes arrive over the wire
+ *   (`AddMatch` + the reader's signal dispatch); signals our own served objects emit in the same
+ *   process are delivered through the in-process [LocalJvmMatchBus]. Both are wired by
+ *   [installSignalMatch] and are disjoint, so each signal is delivered exactly once;
+ * - what stays DEFERRED to a dedicated phase is signal EMISSION over the wire (our object emitting
+ *   a signal that a SEPARATE process receives over the bus) and incoming-call serving over the wire
+ *   (phase 4). No in-suite test has an external peer receive a signal we emit; the only gated case
+ *   is sender-credential resolution on a received signal, which needs real wire emission.
+ */
+internal class WireDbusBackend : JvmDbusBackend {
+    override fun createConnection(
+        busType: JvmBusType,
+        endpoint: String?,
+        name: ServiceName?,
+        fd: Int?
+    ): JvmDbusConnection {
+        if (fd != null || busType == JvmBusType.DIRECT_FD || busType == JvmBusType.SERVER_FD) {
+            throw createError(-1, "JVM wire backend does not support fd-based connections")
+        }
+        val wire = runCatching {
+            when (busType) {
+                JvmBusType.DEFAULT, JvmBusType.SESSION -> DBusWireConnection.connectSession()
+                JvmBusType.SYSTEM -> DBusWireConnection.connectSystem()
+                JvmBusType.SESSION_ADDRESS,
+                JvmBusType.DIRECT_ADDRESS ->
+                    endpoint?.let(DBusWireConnection::connect)
+                JvmBusType.DIRECT_FD, JvmBusType.SERVER_FD -> null
+            }
+        }.getOrElse {
+            throw createError(
+                -1,
+                "Failed to open bus${endpoint?.let { e -> " '$e'" }.orEmpty()}: ${it.message}"
+            )
+        }
+            ?: throw createError(
+                -1,
+                "Failed to open bus: unsupported connection request for $busType"
+            )
+        return WireDbusConnection(wire).also { connection ->
+            if (name != null) connection.requestName(name)
+        }
+    }
+
+    override fun createProxy(
+        connection: Connection,
+        destination: ServiceName,
+        objectPath: ObjectPath,
+        runEventLoopThread: Boolean
+    ): JvmDbusProxy {
+        if (runEventLoopThread) connection.startEventLoop()
+        val wireConnection = (connection as? JvmConnection)?.backend as? WireDbusConnection
+        return WireDbusProxy(wireConnection, destination, objectPath)
+    }
+
+    override fun createObject(connection: Connection, objectPath: ObjectPath): JvmDbusObject =
+        // Reuse the in-process object machinery with no dbus-java connection: method dispatch and
+        // managed-object/property bookkeeping live in the shared local registries, while signal
+        // emission falls back to the in-process bus (wire emission is deferred -- epic #93).
+        PureJavaDbusObject(
+            objectPath,
+            null,
+            runCatching { connection.uniqueName.value }.getOrNull()
+        )
+}
+
+internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbusConnection {
+    private val localUniqueName: String = wire.uniqueName.orEmpty()
+    private val released = AtomicBoolean(false)
+    private var timeout: Duration = Duration.ZERO
+
+    val wireConnection: DBusWireConnection get() = wire
+    fun isReleased(): Boolean = released.get()
+    fun defaultTimeoutMicros(): ULong = timeout.inWholeMicroseconds.coerceAtLeast(0L).toULong()
+
+    init {
+        LocalJvmServiceRegistry.registerLocalUniqueName(localUniqueName)
+    }
+
+    override fun startEventLoop(): Unit = Unit
+
+    override suspend fun stopEventLoop(): Unit = Unit
+
+    override fun currentlyProcessedMessage(): Message =
+        JvmCurrentMessageContext.current() ?: PlainMessage.createPlainMessage()
+
+    override fun setMethodCallTimeout(timeout: Duration): Unit = run { this.timeout = timeout }
+
+    override fun getMethodCallTimeout(): Duration = timeout
+
+    override fun addObjectManager(objectPath: ObjectPath): Resource =
+        LocalObjectManagerRegistry.register(objectPath.value, localUniqueName)
+
+    override fun uniqueName(): BusName = BusName(localUniqueName.ifEmpty { ":jvm-wire" })
+
+    override fun requestName(name: ServiceName) {
+        val result = runCatching { wire.requestName(name.value) }.getOrElse {
+            throw createError(-1, "requestName failed: ${it.message}")
+        }
+        // 1 = primary owner, 4 = already owner. Anything else means we did not get the name.
+        if (result != 1 && result != 4) {
+            throw createError(
+                -1,
+                "requestName failed: RequestName returned $result for ${name.value}"
+            )
+        }
+        LocalJvmServiceRegistry.addAlias(localUniqueName, name.value)
+    }
+
+    override fun releaseName(name: ServiceName) {
+        runCatching { wire.releaseName(name.value) }.getOrElse {
+            throw createError(-1, "releaseName failed: ${it.message}")
+        }
+        LocalJvmServiceRegistry.removeAlias(localUniqueName, name.value)
+    }
+
+    override fun addMatch(match: String, callback: MessageHandler): Resource =
+        installSignalMatch(wire, match, parseMatchSpec(match), match, callback)
+
+    override fun addMatchAsync(
+        match: String,
+        callback: MessageHandler,
+        installCallback: MessageHandler
+    ): Resource = addMatch(match, callback).also {
+        installCallback(signalFromMetadata(Message.Metadata(valid = true, empty = true)))
+    }
+
+    override fun release() {
+        if (!released.compareAndSet(false, true)) return
+        LocalJvmServiceRegistry.unregisterLocalUniqueName(localUniqueName)
+        runCatching { wire.close() }
+    }
+}
+
+internal class WireDbusProxy(
+    private val connection: WireDbusConnection?,
+    private val destination: ServiceName,
+    private val objectPath: ObjectPath
+) : JvmDbusProxy {
+    private val wire: DBusWireConnection? get() = connection?.wireConnection
+
+    override fun currentlyProcessedMessage(): Message =
+        JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
+
+    override fun createMethodCall(
+        interfaceName: InterfaceName,
+        methodName: MethodName
+    ): MethodCall = MethodCall().also {
+        it.metadata = Message.Metadata(
+            interfaceName = interfaceName.value,
+            memberName = methodName.value,
+            destination = destination.value,
+            path = objectPath.value,
+            valid = true,
+            empty = true
+        )
+    }
+
+    override fun callMethod(message: MethodCall): MethodReply = callMethod(message, 0uL)
+
+    override fun callMethod(message: MethodCall, timeout: ULong): MethodReply {
+        // Native parity (issue #81): a call after the proxy's connection was released must throw,
+        // never be serviced (e.g. via the in-process dispatch short-circuit). ConnectionImpl guards
+        // every post-release op with require(!released) { "Connection has already been released" }.
+        require(connection?.isReleased() != true) { "Connection has already been released" }
+        val effectiveTimeout =
+            if (timeout == 0uL) connection?.defaultTimeoutMicros() ?: 0uL else timeout
+        val interfaceName = message.interfaceName?.value
+            ?: throw createError(-1, "callMethod failed: missing interface name")
+        val methodName = message.memberName?.value
+            ?: throw createError(-1, "callMethod failed: missing method name")
+        val path = message.path?.value ?: objectPath.value
+
+        // Same-process serving: a call to an object served by any connection in our own process is
+        // dispatched in-process through the shared static-dispatch table (this is not wire serving;
+        // it is the same local dispatch the dbus-java backend uses for same-process calls). The
+        // dispatch key prefers the owning local unique name but falls back to the destination, so
+        // wildcard ("") and single-candidate registrations resolve exactly as dbus-java's do.
+        val localOwner = localDispatchOwnerOrNull()
+        val dispatchDestination = localOwner ?: destination.value
+        if (JvmStaticDispatch.hasHandler(
+                path,
+                interfaceName,
+                methodName,
+                message.payload,
+                dispatchDestination
+            )
+        ) {
+            return if (effectiveTimeout == 0uL) {
+                callLocalDispatch(message, interfaceName, methodName, path, dispatchDestination)
+            } else {
+                callLocalDispatchWithTimeout(
+                    message,
+                    interfaceName,
+                    methodName,
+                    path,
+                    dispatchDestination,
+                    effectiveTimeout
+                )
+            }
+        }
+        if (localOwner != null) {
+            // The destination is one of our own connections but nothing serves this member.
+            // We must NOT put the call on the wire: phase 3 does not serve incoming wire calls
+            // (phase 4), so our own peer would never reply and the caller would hang until
+            // timeout. Fail fast with UnknownMethod, the same outcome dbus-java produces by
+            // auto-replying for an unexported member.
+            throw com.monkopedia.sdbus.Error(
+                "org.freedesktop.DBus.Error.UnknownMethod",
+                "No handler for $path:$interfaceName.$methodName on local destination " +
+                    destination.value
+            )
+        }
+
+        val realWire = wire
+            ?: throw createError(-1, "callMethod failed: connection has no wire transport")
+        return callRemote(realWire, interfaceName, methodName, path, message, effectiveTimeout)
+    }
+
+    private fun localDispatchOwnerOrNull(): String? {
+        val localUnique = connection?.uniqueName()?.value ?: return null
+        val destName = destination.value
+        if (destName == localUnique) return localUnique
+        return LocalJvmServiceRegistry.resolveLocalUniqueName(destName)
+    }
+
+    // Honors a per-call timeout for in-process dispatch (which may block on an async vtable
+    // handler): runs the dispatch on a daemon thread and fails with a timeout error if it does not
+    // complete in time, mirroring the dbus-java backend's callWithTimeout.
+    private fun callLocalDispatchWithTimeout(
+        message: MethodCall,
+        interfaceName: String,
+        methodName: String,
+        path: String,
+        dispatchDestination: String,
+        timeoutMicros: ULong
+    ): MethodReply {
+        val result = java.util.concurrent.atomic.AtomicReference<MethodReply?>()
+        val failure = java.util.concurrent.atomic.AtomicReference<Throwable?>()
+        val done = java.util.concurrent.CountDownLatch(1)
+        thread(start = true, isDaemon = true, name = "sdbus-jvm-wire-local-timeout") {
+            runCatching {
+                callLocalDispatch(message, interfaceName, methodName, path, dispatchDestination)
+            }.onSuccess { result.set(it) }.onFailure { failure.set(it) }
+            done.countDown()
+        }
+        if (!done.await(
+                microsToMillis(timeoutMicros),
+                java.util.concurrent.TimeUnit.MILLISECONDS
+            )
+        ) {
+            throw com.monkopedia.sdbus.Error(
+                "org.freedesktop.DBus.Error.Timeout",
+                "Method call timed out"
+            )
+        }
+        failure.get()?.let { throw it }
+        return result.get() ?: throw createError(-1, "callMethod failed: missing result")
+    }
+
+    private fun callLocalDispatch(
+        message: MethodCall,
+        interfaceName: String,
+        methodName: String,
+        path: String,
+        dispatchDestination: String
+    ): MethodReply {
+        val inboundSender = connection?.uniqueName()?.value
+        val inbound = MethodCall().also {
+            it.metadata = Message.Metadata(
+                interfaceName = interfaceName,
+                memberName = methodName,
+                sender = inboundSender,
+                destination = destination.value,
+                path = path,
+                valid = true,
+                empty = message.payload.isEmpty()
+            )
+            it.payload.addAll(message.payload)
+        }
+        val result = runCatching {
+            JvmCurrentMessageContext.withMessage(inbound) {
+                JvmStaticDispatch.invokeOrNull(
+                    objectPath = path,
+                    interfaceName = interfaceName,
+                    methodName = methodName,
+                    args = message.payload,
+                    destination = dispatchDestination
+                )
+            }
+        }.getOrElse {
+            throw createError(-1, "callMethod failed: ${it.message}")
+        } ?: throw createError(
+            -1,
+            "callMethod failed: no static binding for $path:$interfaceName.$methodName"
+        )
+        val values = when (result) {
+            Unit -> emptyList()
+            is JvmStaticDispatch.DispatchResult -> {
+                result.reply.error?.let { throw it }
+                if (!result.reply.isValid) {
+                    throw createError(-1, "callMethod failed: method returned an invalid reply")
+                }
+                result.reply.payload.toList()
+            }
+            else -> listOf(result)
+        }
+        return methodReplyFrom(
+            Message.Metadata(
+                interfaceName = interfaceName,
+                memberName = methodName,
+                sender = destination.value,
+                path = path,
+                destination = connection?.uniqueName()?.value ?: destination.value,
+                valid = true,
+                empty = values.isEmpty()
+            ),
+            values
+        )
+    }
+
+    private fun callRemote(
+        realWire: DBusWireConnection,
+        interfaceName: String,
+        methodName: String,
+        path: String,
+        message: MethodCall,
+        timeoutMicros: ULong
+    ): MethodReply {
+        val payload = message.payload.toList()
+        val signature = wireBodySignature(payload, message.declaredBodySignature.toString())
+        val request = WireMessage(
+            type = WireMessageType.METHOD_CALL,
+            destination = destination.value.ifEmpty { null },
+            path = path,
+            interfaceName = interfaceName,
+            member = methodName,
+            signature = signature,
+            body = if (signature == null) emptyList() else payload.map(::toWireBodyValue)
+        )
+        val reply = try {
+            if (timeoutMicros == 0uL) {
+                realWire.callBlocking(request)
+            } else {
+                realWire.callBlocking(request, microsToMillis(timeoutMicros))
+            }
+        } catch (e: DBusCallException) {
+            // Preserve the wire ERROR_NAME verbatim, like the native backend copies it straight
+            // into sd_bus_error instead of squeezing it through the errno mapping (issue #72).
+            throw com.monkopedia.sdbus.Error(
+                e.errorName ?: "org.freedesktop.DBus.Error.Failed",
+                e.errorMessage.orEmpty()
+            )
+        } catch (e: IOException) {
+            throw createError(-1, "callMethod failed: ${e.message}")
+        }
+        return methodReplyFrom(
+            Message.Metadata(
+                interfaceName = interfaceName,
+                memberName = methodName,
+                sender = reply.sender ?: destination.value,
+                path = reply.path ?: path,
+                destination = reply.destination,
+                valid = true,
+                empty = reply.body.isEmpty()
+            ),
+            reply.body
+        )
+    }
+
+    override fun callMethodAsync(
+        message: MethodCall,
+        asyncReplyCallback: AsyncReplyHandler
+    ): PendingAsyncCall = callMethodAsync(message, asyncReplyCallback, 0u)
+
+    override fun callMethodAsync(
+        message: MethodCall,
+        asyncReplyCallback: AsyncReplyHandler,
+        timeout: ULong
+    ): PendingAsyncCall {
+        val cancelled = AtomicBoolean(false)
+        val pending = AtomicBoolean(true)
+        val interfaceName = message.interfaceName?.value.orEmpty()
+        val methodName = message.memberName?.value.orEmpty()
+        val path = message.path?.value ?: objectPath.value
+        thread(
+            start = true,
+            isDaemon = true,
+            name = "sdbus-jvm-wire-call-$interfaceName.$methodName"
+        ) {
+            val outcome = runCatching {
+                if (timeout == 0uL) callMethod(message) else callMethod(message, timeout)
+            }
+            pending.set(false)
+            if (cancelled.get()) return@thread
+            outcome.fold(
+                onSuccess = { asyncReplyCallback(it, null) },
+                onFailure = {
+                    val error = it as? com.monkopedia.sdbus.Error
+                        ?: createError(-1, it.message ?: "JVM wire async call failed")
+                    asyncReplyCallback(invalidReply(path, interfaceName, methodName), error)
+                }
+            )
+        }
+        return PendingAsyncCall(
+            cancelAction = { cancelled.set(true) },
+            isPendingAction = { pending.get() }
+        )
+    }
+
+    override suspend fun callMethodAsync(message: MethodCall): MethodReply = callMethod(message)
+
+    override suspend fun callMethodAsync(message: MethodCall, timeout: ULong): MethodReply =
+        if (timeout == 0uL) callMethod(message) else callMethod(message, timeout)
+
+    private fun invalidReply(path: String, interfaceName: String, methodName: String): MethodReply =
+        methodReplyFrom(
+            Message.Metadata(
+                interfaceName = interfaceName,
+                memberName = methodName,
+                sender = destination.value,
+                path = path,
+                valid = false,
+                empty = true
+            ),
+            emptyList()
+        )
+
+    override fun registerSignalHandler(
+        interfaceName: InterfaceName,
+        signalName: SignalName,
+        signalHandler: SignalHandler
+    ): Resource {
+        val realWire = wire ?: throw createError(
+            -1,
+            "registerSignalHandler failed: connection has no wire transport"
+        )
+        val owner = destination.value
+            .takeIf { it.isNotEmpty() && !it.startsWith(":") }
+            ?.let { realWire.getNameOwner(it) }
+        val spec = MatchSpec(
+            sender = destination.value.ifEmpty { null },
+            path = objectPath.value,
+            interfaceName = interfaceName.value,
+            member = signalName.value,
+            resolvedOwner = owner
+        )
+        val rule = buildMatchRule(spec)
+        // In-process emitters (our own served objects) deliver through the shared local bus with
+        // their connection's unique name as the sender; resolve it so the local match lines up.
+        val localMatch = buildMatchRule(
+            MatchSpec(
+                sender = localDispatchOwnerOrNull(),
+                path = objectPath.value,
+                interfaceName = interfaceName.value,
+                member = signalName.value
+            )
+        )
+        return installSignalMatch(realWire, rule, spec, localMatch) { message ->
+            signalHandler(message as com.monkopedia.sdbus.Signal)
+        }
+    }
+
+    override fun release(): Unit = Unit
+}
+
+/** A parsed signal match used to filter incoming SIGNAL messages on the connection. */
+private data class MatchSpec(
+    val sender: String? = null,
+    val path: String? = null,
+    val interfaceName: String? = null,
+    val member: String? = null,
+    val resolvedOwner: String? = null
+)
+
+private fun parseMatchSpec(match: String): MatchSpec {
+    val values = mutableMapOf<String, String>()
+    match.split(",")
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .forEach { token ->
+            val parts = token.split("=", limit = 2)
+            if (parts.size == 2) {
+                values[parts[0].trim()] = parts[1].trim().trim('\'').trim('"')
+            }
+        }
+    return MatchSpec(
+        sender = values["sender"],
+        path = values["path"],
+        interfaceName = values["interface"],
+        member = values["member"]
+    )
+}
+
+private fun buildMatchRule(spec: MatchSpec): String = buildString {
+    append("type='signal'")
+    spec.sender?.let { append(",sender='$it'") }
+    spec.path?.let { append(",path='$it'") }
+    spec.interfaceName?.let { append(",interface='$it'") }
+    spec.member?.let { append(",member='$it'") }
+}
+
+private fun WireMessage.matches(spec: MatchSpec): Boolean {
+    if (spec.path != null && path != spec.path) return false
+    if (spec.interfaceName != null && interfaceName != spec.interfaceName) return false
+    if (spec.member != null && member != spec.member) return false
+    if (spec.sender != null) {
+        val senderOk = sender == spec.sender ||
+            (spec.resolvedOwner != null && sender == spec.resolvedOwner)
+        if (!senderOk) return false
+    }
+    return true
+}
+
+// Installs a signal subscription on two paths so it mirrors the rest of the wire backend's
+// same-process/cross-process split:
+//  - the WIRE ([rule] + [spec] filter) carries signals from OTHER processes (e.g. a dbusmock
+//    peer), exercising the real bus reception path;
+//  - the in-process [LocalJvmMatchBus] ([localMatch]) carries signals our own served objects
+//    emit in the same process, which (like same-process method calls) are dispatched in-process
+//    rather than put on the wire. Cross-PROCESS signal EMISSION over the wire stays deferred
+//    (epic #93, dedicated phase); no in-suite test has an external peer receive a signal WE emit.
+// The two sources are disjoint, so a signal is delivered exactly once.
+private fun installSignalMatch(
+    wire: DBusWireConnection,
+    rule: String,
+    spec: MatchSpec,
+    localMatch: String,
+    callback: MessageHandler
+): Resource {
+    runCatching { wire.addMatch(rule) }.getOrElse {
+        throw createError(-1, "addMatch failed: ${it.message}")
+    }
+    val subscription = wire.onSignal { wireMessage ->
+        if (!wireMessage.matches(spec)) return@onSignal
+        val signal = signalFromMetadata(
+            Message.Metadata(
+                interfaceName = wireMessage.interfaceName,
+                memberName = wireMessage.member,
+                sender = wireMessage.sender,
+                path = wireMessage.path,
+                destination = wireMessage.destination,
+                valid = true,
+                empty = wireMessage.body.isEmpty()
+            )
+        )
+        signal.payload.addAll(wireMessage.body)
+        JvmCurrentMessageContext.withMessage(signal) { callback(signal) }
+    }
+    val localResource = LocalJvmMatchBus.register(localMatch, callback)
+    val removed = AtomicBoolean(false)
+    return com.monkopedia.sdbus.ActionResource {
+        if (!removed.compareAndSet(false, true)) return@ActionResource
+        runCatching { subscription.close() }
+        runCatching { wire.removeMatch(rule) }
+        runCatching { localResource.release() }
+    }
+}
+
+// --- value-model <-> marshaller-model bridge -------------------------------------------------
+
+private fun microsToMillis(micros: ULong): Long =
+    ((micros + 999uL) / 1000uL).toLong().coerceAtLeast(1L)
+
+/**
+ * Converts a value from the high-level sdbus payload model into the model [DBusMarshaller]
+ * consumes. The two models already share their representation (Strings, unsigned boxes,
+ * [Message.JvmStructPayload]/[Message.JvmVariantPayload], [ObjectPath]/[Signature]/[UnixFd],
+ * List/Map); the only normalization needed is turning a high-level [Variant] into a
+ * [Message.JvmVariantPayload], recursively. The marshaller's own coercion handles the rest
+ * (e.g. [ObjectPath]/[Signature] as strings, [UnixFd] as its int). The reply path needs NO
+ * conversion: the demarshaller already produces decoder-compatible values.
+ */
+private fun toWireBodyValue(value: Any?): Any? = when (value) {
+    is Variant -> variantToPayload(value)
+    is Message.JvmVariantPayload ->
+        Message.JvmVariantPayload(value.signature, toWireBodyValue(value.value))
+    is Message.JvmStructPayload ->
+        Message.JvmStructPayload(value.signature, value.fields.map(::toWireBodyValue))
+    is Map<*, *> -> value.entries.associate { (k, v) -> toWireBodyValue(k) to toWireBodyValue(v) }
+    is List<*> -> value.map(::toWireBodyValue)
+    is Array<*> -> value.map(::toWireBodyValue)
+    else -> value
+}
+
+private fun variantToPayload(variant: Variant): Message.JvmVariantPayload {
+    val signature = variant.peekValueType()
+        ?: throw createError(-1, "Cannot marshal an empty variant")
+    val message = PlainMessage.createPlainMessage()
+    variant.serializeTo(message)
+    message.rewind(false)
+    message.enterVariant(signature)
+    val value = message.nextDeserializedValue("variantToPayload")
+    message.exitVariant()
+    return Message.JvmVariantPayload(signature, toWireBodyValue(value))
+}
+
+/**
+ * Wire signature for an outgoing body. Prefer the declared signature accumulated from serializer
+ * descriptors (correct even for empty collections); fall back to value-based inference only when
+ * no usable declared signature is available. Returns null for an empty body.
+ */
+private fun wireBodySignature(payload: List<Any?>, declaredSignature: String?): String? {
+    if (payload.isEmpty()) return null
+    if (!declaredSignature.isNullOrEmpty() &&
+        countTopLevelTypes(declaredSignature) == payload.size
+    ) {
+        return declaredSignature
+    }
+    return payload.joinToString(separator = "") { value ->
+        inferWireElementSignature(value)
+            ?: throw createError(
+                -1,
+                "callMethod failed: unsupported argument type ${value?.let {
+                    it::class.simpleName
+                }}"
+            )
+    }
+}
+
+private fun inferWireElementSignature(value: Any?): String? = when (value) {
+    null -> null
+    is Message.JvmVariantPayload -> "v"
+    is Message.JvmStructPayload -> value.signature
+    is Variant -> "v"
+    is Boolean -> "b"
+    is Byte, is UByte -> "y"
+    is Short -> "n"
+    is UShort -> "q"
+    is Int -> "i"
+    is UInt -> "u"
+    is Long -> "x"
+    is ULong -> "t"
+    is Float, is Double -> "d"
+    is String -> "s"
+    is ObjectPath -> "o"
+    is Signature -> "g"
+    is UnixFd -> "h"
+    is List<*> -> "a" + (value.firstNotNullOfOrNull(::inferWireElementSignature) ?: return "a")
+    is Array<*> -> "a" + (value.firstNotNullOfOrNull(::inferWireElementSignature) ?: return "a")
+    is Map<*, *> -> {
+        val first = value.entries.firstOrNull() ?: return "a{}"
+        val keySig = inferWireElementSignature(first.key) ?: return "a{}"
+        val valueSig = inferWireElementSignature(first.value) ?: return "a{}"
+        "a{$keySig$valueSig}"
+    }
+    else -> null
+}
+
+/** Counts the number of top-level complete types in a signature (e.g. "sa{sv}" -> 2). */
+private fun countTopLevelTypes(signature: String?): Int {
+    if (signature.isNullOrEmpty()) return 0
+    fun parseOne(index: Int): Int {
+        if (index >= signature.length) return index
+        return when (signature[index]) {
+            'a' -> parseOne(index + 1)
+            '(' -> {
+                var i = index + 1
+                while (i < signature.length && signature[i] != ')') i = parseOne(i)
+                (i + 1).coerceAtMost(signature.length)
+            }
+            '{' -> {
+                var i = index + 1
+                while (i < signature.length && signature[i] != '}') i = parseOne(i)
+                (i + 1).coerceAtMost(signature.length)
+            }
+            else -> index + 1
+        }
+    }
+    var count = 0
+    var index = 0
+    while (index < signature.length) {
+        val next = parseOne(index)
+        if (next <= index) break
+        count++
+        index = next
+    }
+    return count
+}

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -232,6 +232,11 @@ class JvmRealBusIntegrationTest {
 
     @Test
     fun signalCallback_resolvesSenderCredentialsFromBus() = runBlocking {
+        // wire signal emission deferred — epic #93 (dedicated phase): our object's signal is
+        // delivered in-process via the local bus, which carries no sender credentials. Resolving
+        // credentials needs the signal to travel over the wire (real wire emission), so this case
+        // is gated until that lands.
+        if (com.monkopedia.sdbus.internal.jvmdbus.isJvmWireBackendEnabled()) return@runBlocking
         val suffix = "c${System.nanoTime()}"
         val service = ServiceName("com.monkopedia.sdbus.jvmreal.$suffix")
         val objectPath = ObjectPath("/com/monkopedia/sdbus/jvmreal$suffix/credentials")

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireMessageCodecTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireMessageCodecTest.kt
@@ -123,6 +123,40 @@ class WireMessageCodecTest {
     }
 
     @Test
+    fun bigEndianFrame_decodesHandCraftedBytes() {
+        // A hand-assembled BIG-ENDIAN ('B') METHOD_RETURN frame (phase 2 follow-up): the codec
+        // only ever writes little-endian, so this is the only coverage of the big-endian decode
+        // path at the framing level. Layout (offsets):
+        //   0: 'B'  1: type=2  2: flags=0  3: version=1
+        //   4..7  body length = 7 (BE)        8..11 serial = 2 (BE)
+        //   12..15 header-array length = 15 (BE)
+        //   16..23 struct (yv): code 5 REPLY_SERIAL, variant "u" = 1
+        //   24..30 struct (yv): code 8 SIGNATURE, variant "g" = "s"
+        //   31     pad to 8-byte boundary
+        //   32..38 body: string "Hi" (BE u32 length 2, 'H','i', NUL)
+        val bytes = intArrayOf(
+            0x42, 0x02, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x07,
+            0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00, 0x00, 0x0F,
+            0x05, 0x01, 0x75, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x01, 0x67, 0x00, 0x01, 0x73, 0x00,
+            0x00,
+            0x00, 0x00, 0x00, 0x02, 0x48, 0x69, 0x00
+        ).map { it.toByte() }.toByteArray()
+
+        val decoded = WireMessageCodec.decode(bytes)
+        val streamed = WireMessageCodec.read(ByteArrayInputStream(bytes))
+        assertEquals(decoded, streamed)
+
+        assertEquals(WireMessageType.METHOD_RETURN, decoded.type)
+        assertEquals(2, decoded.serial)
+        assertEquals(1, decoded.replySerial)
+        assertEquals("s", decoded.signature)
+        assertEquals(listOf<Any?>("Hi"), decoded.body)
+    }
+
+    @Test
     fun emptyBody_roundTrips() {
         val message = WireMessage(
             type = WireMessageType.METHOD_CALL,


### PR DESCRIPTION
## Phase 3 (#93): JVM client path on the owned connection (toggle)

Routes the JVM **client** path through the self-owned D-Bus connection (`DBusWireConnection`,
phases 1+2) behind an opt-in toggle, keeping dbus-java as the default. Signal **emission** over
the wire and **fd-passing** stay deferred to later phases.

### The bridge (value model <-> wire)
- Outgoing `MethodCall`: the sdbus payload value model is already what `DBusMarshaller` consumes
  (unsigned boxes, `ObjectPath`/`Signature`/`UnixFd`, `JvmStructPayload`, List/Map), so the only
  normalization is turning a high-level `Variant` into a `JvmVariantPayload` (recursively). The
  body signature is the declared signature accumulated from serializer descriptors (authoritative
  even for empty collections), with value inference as a fallback. The body is marshalled by
  `DBusMarshaller` — no dbus-java value conversion.
- Reply: the demarshaller already produces decoder-compatible values, so the reply body is used
  directly as the `MethodReply` payload (no conversion).
- Errors: a wire `ERROR` surfaces as sdbus `Error` with the `ERROR_NAME` header preserved verbatim
  (no errno squeeze — issue #72), correct by construction.
- Properties (client): `Get`/`Set`/`GetAll` ride the ordinary method path.

### Same-process vs cross-process split
The backend handles same-process and cross-process consistently:
- **Method calls:** a call to an object served by one of our own connections is dispatched
  in-process through the shared static-dispatch tables (exactly as dbus-java short-circuits
  same-process calls); a call to a genuinely remote peer goes over the wire. A call to a
  locally-owned name with no handler fails fast with `UnknownMethod` (our phase-3 peer does not
  serve incoming wire calls, so it must not be put on the wire — see "hang found + fixed").
- **Signal reception:** signals from other processes (e.g. a dbusmock peer) arrive over the wire
  (`AddMatch` + the reader's dispatch); signals our own objects emit in-process are delivered
  through the in-process `LocalJvmMatchBus`. The two sources are disjoint, so each signal is
  delivered exactly once.
- **Timeouts:** `DBusWireConnection.call`/`callBlocking` honor a timeout and evict the pending
  entry; in-process dispatch with a per-call timeout runs on a bounded daemon thread. A reply that
  never arrives can no longer hang the caller.

### Toggle
`JvmDbusBackendProvider.backend` is now lazy and reads `-Dsdbus.jvm.wire=true` (or env
`SDBUS_JVM_WIRE=true`); default stays dbus-java (flipping the default is phase 6). The Gradle
`Test` tasks forward the property to the test JVMs.

### CI
New `wire-client-parity-x64` job runs `:jvmTest :cross_test:jvmTest` with `-Dsdbus.jvm.wire=true`
inside `dbus-run-session`, with a 45-minute job timeout and an inner `timeout 1800` guard so a
hang fails the job fast.

### Phase-2 follow-up
Added a hand-crafted **big-endian** decode test to `WireMessageCodecTest`.

### Hang found + fixed
Bringing the suite up wire-ON surfaced (and fixed) a real hang: a method call to a name owned by
one of our own connections but with no handler (e.g. after a vtable is released) was put on the
wire to our own peer, which does not serve incoming wire calls in phase 3, so the reply never
arrived. Fixed by failing fast with `UnknownMethod` for locally-owned-no-handler, mirroring the
`UnknownMethod` dbus-java auto-replies in that case. Two related correctness bugs were fixed in the
same pass: in-process dispatch now consults the static-dispatch table for wildcard/single-candidate
registrations (so the connectionless `createProxy` path resolves), and honors the per-call timeout.

### Parity results
- **wire OFF** (regression): `:jvmTest :cross_test:jvmTest` — all green (jvmTest 310, cross_test
  jvmTest 58; 0 failures).
- **wire ON**: `:jvmTest :cross_test:jvmTest -Dsdbus.jvm.wire=true` — jvmTest 310 / cross_test
  jvmTest 58, 0 failures/0 errors, with only the one gated case below (passes via early return).
  The dbusmock peer suites (type matrix, signal reception, ObjectManager, properties, foreign
  errors, Secret Service, BlueZ) pass wire-ON, including struct, grouped-return and foreign-error
  type-matrix sub-cases (which the marshaller handles).

### Gated as deferred (skip when wire-ON, with a clear comment)
- `JvmRealBusIntegrationTest.signalCallback_resolvesSenderCredentialsFromBus`: an in-process signal
  carries no sender credentials; resolving them needs the signal to travel over the wire (real wire
  emission), which is deferred. The unix-fd type-matrix case needs no gate — it already skips on JVM
  (no raw-fd access from JVM test code), so SCM_RIGHTS fd-passing (phase 5) is never exercised.

`./gradlew apiDump` is a no-op (no public API change; only internal additions + visibility widening
of internal-only symbols).

Refs #93.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
