### PR TITLE
Fix flaky wire-ON async test: drop racy isPending() assertion (#97)

### DIFF
--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmScaffoldTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmScaffoldTest.kt
@@ -139,7 +139,10 @@ class JvmScaffoldTest {
                 latch.countDown()
             }
 
-            assertTrue(pending.isPending())
+            // NB: do not assert pending.isPending() here — on a fast backend (the owned
+            // wire connection) the reply can arrive and fire the callback before this line
+            // runs, making isPending() legitimately false. See #97. The post-completion
+            // !isPending() assertion below verifies the call resolves.
             assertTrue(latch.await(3, TimeUnit.SECONDS))
             assertEquals(null, errorRef.get())
             assertEquals(7, resultRef.get())


### PR DESCRIPTION
## Summary
Removes the racy `assertTrue(pending.isPending())` at JvmScaffoldTest.kt:142 (test-only). On the owned wire backend a fast reply can fire the callback before that line, so `isPending()` is legitimately false — it flaked `wire-client-parity-x64` on main after #96. The post-completion `!pending.isPending()` check + result assertions still verify the async contract. Replaced with a comment so it is not re-added.

Fixes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
