### PR TITLE
Phase 3b (#93): emit signals over the wire on the owned connection

### DIFF
--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireSignalEmissionExternalTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireSignalEmissionExternalTest.kt
@@ -1,0 +1,131 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.signal
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Proves that a signal our object emits actually traverses the BUS and reaches an INDEPENDENT
+ * out-of-process observer (epic #93 phase 3b) — the piece that was deliberately deferred from
+ * phase 3. The observer is `dbus-monitor` (a separate process), so in-process delivery cannot mask
+ * the result:
+ *  - wire backend BEFORE this phase: emission was in-process only, so `dbus-monitor` never sees the
+ *    signal and this test FAILS (the poll loop times out);
+ *  - wire backend AFTER this phase: emission goes over the wire, so `dbus-monitor` captures it;
+ *  - dbus-java backend: always emitted over the real wire, so it captures it too.
+ *
+ * JVM-only (cross_test `jvmTest`) because the owned-connection backend is JVM-only and toggle-gated;
+ * the native backend's over-the-wire emission is already covered elsewhere. Skips cleanly when no
+ * session bus or no `dbus-monitor` is available.
+ */
+class WireSignalEmissionExternalTest {
+
+    @Test
+    fun emittedSignal_reachesExternalDbusMonitor() = runBlocking {
+        val sessionBus = System.getenv("DBUS_SESSION_BUS_ADDRESS")
+        if (sessionBus == null) {
+            println("[WireSignalEmissionExternalTest] SKIP: no DBUS_SESSION_BUS_ADDRESS.")
+            return@runBlocking
+        }
+        val dbusMonitor = findExecutable("dbus-monitor")
+        if (dbusMonitor == null) {
+            println("[WireSignalEmissionExternalTest] SKIP: dbus-monitor not on PATH.")
+            return@runBlocking
+        }
+
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.wireemit$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/wireemit$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.wireemit$id.Interface")
+        val member = SignalName("Pinged")
+        // A unique marker that only appears in the captured output if THIS signal's payload arrived
+        // over the bus, not just a same-named message from some other source.
+        val marker = 0x5d_b0_0000.toInt() or (id and 0xffff)
+
+        val output = File.createTempFile("wireemit-monitor", ".txt").apply { deleteOnExit() }
+        val monitor = ProcessBuilder(
+            dbusMonitor.absolutePath,
+            "--session",
+            "type='signal',interface='${iface.value}',member='${member.value}'"
+        ).redirectErrorStream(true)
+            .redirectOutput(output)
+            .start()
+
+        val connection = createBusConnection(service)
+        val obj = createObject(connection, path)
+        val registration = obj.addVTable(iface) {
+            signal(member) {
+                with<Int>("value")
+            }
+        }
+        connection.startEventLoop()
+
+        try {
+            // dbus-monitor installs its match asynchronously after launch; emit repeatedly until the
+            // observer captures the marker (proving end-to-end bus delivery) or we time out. Bounded
+            // so a missing emission FAILS fast rather than hanging.
+            val deadline = System.currentTimeMillis() + 15_000
+            var observed = false
+            while (System.currentTimeMillis() < deadline) {
+                obj.emitSignal(iface, member) { call(marker) }
+                Thread.sleep(250)
+                if (output.readText().contains(marker.toString())) {
+                    observed = true
+                    break
+                }
+            }
+            assertTrue(
+                observed,
+                "external dbus-monitor never received the over-the-wire signal " +
+                    "${iface.value}.${member.value} (marker=$marker)\n--- captured ---\n" +
+                    output.readText()
+            )
+        } finally {
+            registration.release()
+            obj.release()
+            connection.stopEventLoop()
+            connection.release()
+            monitor.destroy()
+            if (!monitor.waitFor(5, TimeUnit.SECONDS)) monitor.destroyForcibly()
+        }
+    }
+
+    private fun findExecutable(name: String): File? {
+        val path = System.getenv("PATH") ?: return null
+        return path.split(File.pathSeparator)
+            .map { File(it, name) }
+            .firstOrNull { it.canExecute() }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -1392,11 +1392,56 @@ private fun addGenericSigHandler(
     return method.invoke(connection, matchRule, callback) as AutoCloseable
 }
 
+/**
+ * Sends a signal OVER THE WIRE on a self-owned connection (epic #93 phase 3b). Supplied to
+ * [PureJavaDbusObject] by the wire backend in place of in-process [LocalJvmSignalBus] delivery, so
+ * an object served on the owned connection emits a real D-Bus SIGNAL that the bus routes to every
+ * subscriber — external processes AND same-JVM connections (each of which has its own socket +
+ * `AddMatch`). The sender header is left unset: the bus stamps the authoritative sender (our unique
+ * name) and attaches the sender's credentials, which is what lets a receiver resolve them.
+ */
+internal fun interface WireSignalEmitter {
+    fun emitSignalOverWire(
+        path: String,
+        interfaceName: String,
+        member: String,
+        signature: String?,
+        payload: List<Any?>
+    )
+}
+
 internal class PureJavaDbusObject(
     private val objectPath: ObjectPath,
     private val javaConnection: AbstractConnection?,
-    private val senderName: String?
+    private val senderName: String?,
+    // When non-null (the wire backend), signals this object emits go over the wire instead of
+    // through the in-process [LocalJvmSignalBus]. The two are mutually exclusive on a given
+    // backend: dbus-java sends through its own connection (javaConnection != null); the wire
+    // backend has javaConnection == null and routes here; the in-process stub path keeps using
+    // [LocalJvmSignalBus]. This keeps signal delivery uniform with the native backend (always over
+    // the wire) for the owned connection. See WireDbusBackend.createObject.
+    private val wireSignalEmitter: WireSignalEmitter? = null
 ) : JvmDbusObject {
+
+    // Routes a signal whose owning connection is NOT dbus-java (javaConnection == null): over the
+    // wire when the wire backend supplied an emitter, otherwise through the in-process bus (the
+    // stub/no-connection path). The wire path needs the marshalling [signature]; the in-process
+    // path ignores it.
+    private fun emitLocalOrWire(
+        sender: String?,
+        path: String,
+        interfaceName: String,
+        member: String,
+        signature: String?,
+        payload: List<Any?>
+    ) {
+        val emitter = wireSignalEmitter
+        if (emitter != null) {
+            emitter.emitSignalOverWire(path, interfaceName, member, signature, payload)
+        } else {
+            LocalJvmSignalBus.emit(sender, path, interfaceName, member, payload)
+        }
+    }
     private val registrations = mutableListOf<Resource>()
     private val registeredInterfaces = mutableMapOf<String, Int>()
     private val asyncReplyTimeoutMs = 10_000L
@@ -1600,11 +1645,12 @@ internal class PureJavaDbusObject(
         val payload = listOf(interfaceName, changedProperties, invalidatedProperties)
         val realConnection = javaConnection
         if (realConnection == null) {
-            LocalJvmSignalBus.emit(
+            emitLocalOrWire(
                 sender = sender,
                 path = objectPath.value,
                 interfaceName = propertiesInterfaceName,
                 member = propertiesChangedMemberName,
+                signature = propertiesChangedSignature,
                 payload = payload
             )
             return
@@ -1650,11 +1696,12 @@ internal class PureJavaDbusObject(
         )
         val realConnection = javaConnection
         if (realConnection == null) {
-            LocalJvmSignalBus.emit(
+            emitLocalOrWire(
                 sender = sender,
                 path = signalPath,
                 interfaceName = objectManagerInterfaceName,
                 member = interfacesAddedMemberName,
+                signature = interfacesAddedSignature,
                 payload = payload
             )
             return
@@ -1689,11 +1736,12 @@ internal class PureJavaDbusObject(
         val payload = listOf(objectPath, interfaces)
         val realConnection = javaConnection
         if (realConnection == null) {
-            LocalJvmSignalBus.emit(
+            emitLocalOrWire(
                 sender = sender,
                 path = signalPath,
                 interfaceName = objectManagerInterfaceName,
                 member = interfacesRemovedMemberName,
+                signature = interfacesRemovedSignature,
                 payload = payload
             )
             return
@@ -1841,7 +1889,14 @@ internal class PureJavaDbusObject(
         val sender = message.sender?.value ?: senderName ?: javaConnection?.uniqueNameOrNull()
         val realConnection = javaConnection
         if (realConnection == null) {
-            LocalJvmSignalBus.emit(sender, path, interfaceName, signalName, message.payload)
+            emitLocalOrWire(
+                sender = sender,
+                path = path,
+                interfaceName = interfaceName,
+                member = signalName,
+                signature = signature,
+                payload = message.payload
+            )
             return
         }
         val rawSignal = runCatching {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -30,23 +30,25 @@ import kotlin.concurrent.thread
 import kotlin.time.Duration
 
 /**
- * JVM backend that routes the CLIENT path through the self-owned D-Bus connection
- * ([DBusWireConnection]) instead of dbus-java (epic #93, phase 3). Selected via the
- * `sdbus.jvm.wire` toggle (see [isJvmWireBackendEnabled]); dbus-java remains the default.
+ * JVM backend that routes the CLIENT path (and signal emission) through the self-owned D-Bus
+ * connection ([DBusWireConnection]) instead of dbus-java (epic #93, phases 3 + 3b). Selected via
+ * the `sdbus.jvm.wire` toggle (see [isJvmWireBackendEnabled]); dbus-java remains the default.
  *
- * Scope this phase is deliberately CLIENT-ONLY, with a consistent same-process/cross-process split:
+ * Scope, with a consistent same-process/cross-process split:
  * - method calls (sync + async) to a REMOTE peer and Properties Get/Set/GetAll go over the wire;
  *   a call to an object served by one of our OWN connections is dispatched in-process through the
  *   shared static-dispatch tables ([JvmStaticDispatch], [LocalObjectManagerRegistry], ...), exactly
  *   as the dbus-java backend short-circuits same-process calls;
- * - signal RECEPTION uses the same split: signals from OTHER processes arrive over the wire
- *   (`AddMatch` + the reader's signal dispatch); signals our own served objects emit in the same
- *   process are delivered through the in-process [LocalJvmMatchBus]. Both are wired by
- *   [installSignalMatch] and are disjoint, so each signal is delivered exactly once;
- * - what stays DEFERRED to a dedicated phase is signal EMISSION over the wire (our object emitting
- *   a signal that a SEPARATE process receives over the bus) and incoming-call serving over the wire
- *   (phase 4). No in-suite test has an external peer receive a signal we emit; the only gated case
- *   is sender-credential resolution on a received signal, which needs real wire emission.
+ * - signal EMISSION goes OVER THE WIRE (phase 3b): an object served on the owned connection emits a
+ *   real D-Bus SIGNAL via [emitWireSignal], so the bus routes it to every subscriber -- external
+ *   processes AND same-JVM connections alike;
+ * - signal RECEPTION is correspondingly wire-only: every subscriber (whether listening to an
+ *   external peer or to one of our own objects) registers `AddMatch` + a reader filter via
+ *   [installSignalMatch] over its own socket, so each signal is delivered exactly once. The
+ *   in-process [LocalJvmSignalBus]/[LocalJvmMatchBus] is NOT used on this backend -- it stays the
+ *   dbus-java backend's same-process mechanism. Sender credentials of a signal from one of our own
+ *   connections are filled from the local process ([withLocalSenderCredentials]);
+ * - what stays DEFERRED is incoming method-call SERVING over the wire (phase 4).
  */
 internal class WireDbusBackend : JvmDbusBackend {
     override fun createConnection(
@@ -93,15 +95,61 @@ internal class WireDbusBackend : JvmDbusBackend {
         return WireDbusProxy(wireConnection, destination, objectPath)
     }
 
-    override fun createObject(connection: Connection, objectPath: ObjectPath): JvmDbusObject =
+    override fun createObject(connection: Connection, objectPath: ObjectPath): JvmDbusObject {
         // Reuse the in-process object machinery with no dbus-java connection: method dispatch and
-        // managed-object/property bookkeeping live in the shared local registries, while signal
-        // emission falls back to the in-process bus (wire emission is deferred -- epic #93).
-        PureJavaDbusObject(
+        // managed-object/property bookkeeping live in the shared local registries. Signal EMISSION,
+        // however, goes OVER THE WIRE (epic #93 phase 3b): we hand PureJavaDbusObject a
+        // WireSignalEmitter bound to this connection's socket, so every signal it emits is a real
+        // D-Bus SIGNAL the bus routes to all subscribers (external processes AND same-JVM
+        // connections, each via its own AddMatch) -- uniform with the native backend, and the only
+        // way a receiver can resolve our sender credentials off the bus.
+        val wire = (connection as? JvmConnection)?.backend
+            .let { it as? WireDbusConnection }
+            ?.wireConnection
+        val emitter = wire?.let { wireConnection ->
+            WireSignalEmitter { path, interfaceName, member, signature, payload ->
+                emitWireSignal(wireConnection, path, interfaceName, member, signature, payload)
+            }
+        }
+        return PureJavaDbusObject(
             objectPath,
             null,
-            runCatching { connection.uniqueName.value }.getOrNull()
+            runCatching { connection.uniqueName.value }.getOrNull(),
+            emitter
         )
+    }
+}
+
+/**
+ * Marshals [payload] (converted from the high-level value model via [toWireBodyValue]) against
+ * [signature] and sends it as a broadcast D-Bus SIGNAL on [wire]. The SENDER header is left unset:
+ * the bus daemon stamps the authoritative sender (our unique name) and attaches our credentials.
+ * An empty/blank signature means a no-argument signal (no body).
+ */
+private fun emitWireSignal(
+    wire: DBusWireConnection,
+    path: String,
+    interfaceName: String,
+    member: String,
+    signature: String?,
+    payload: List<Any?>
+) {
+    val effectiveSignature = signature?.takeUnless { it.isEmpty() }
+    val body = if (effectiveSignature == null) emptyList() else payload.map(::toWireBodyValue)
+    runCatching {
+        wire.send(
+            WireMessage(
+                type = WireMessageType.SIGNAL,
+                path = path,
+                interfaceName = interfaceName,
+                member = member,
+                signature = effectiveSignature,
+                body = body
+            )
+        )
+    }.getOrElse {
+        throw createError(-1, "emitSignal failed: ${it.message}")
+    }
 }
 
 internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbusConnection {
@@ -155,7 +203,7 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
     }
 
     override fun addMatch(match: String, callback: MessageHandler): Resource =
-        installSignalMatch(wire, match, parseMatchSpec(match), match, callback)
+        installSignalMatch(wire, match, parseMatchSpec(match), callback)
 
     override fun addMatchAsync(
         match: String,
@@ -486,17 +534,7 @@ internal class WireDbusProxy(
             resolvedOwner = owner
         )
         val rule = buildMatchRule(spec)
-        // In-process emitters (our own served objects) deliver through the shared local bus with
-        // their connection's unique name as the sender; resolve it so the local match lines up.
-        val localMatch = buildMatchRule(
-            MatchSpec(
-                sender = localDispatchOwnerOrNull(),
-                path = objectPath.value,
-                interfaceName = interfaceName.value,
-                member = signalName.value
-            )
-        )
-        return installSignalMatch(realWire, rule, spec, localMatch) { message ->
+        return installSignalMatch(realWire, rule, spec) { message ->
             signalHandler(message as com.monkopedia.sdbus.Signal)
         }
     }
@@ -552,20 +590,17 @@ private fun WireMessage.matches(spec: MatchSpec): Boolean {
     return true
 }
 
-// Installs a signal subscription on two paths so it mirrors the rest of the wire backend's
-// same-process/cross-process split:
-//  - the WIRE ([rule] + [spec] filter) carries signals from OTHER processes (e.g. a dbusmock
-//    peer), exercising the real bus reception path;
-//  - the in-process [LocalJvmMatchBus] ([localMatch]) carries signals our own served objects
-//    emit in the same process, which (like same-process method calls) are dispatched in-process
-//    rather than put on the wire. Cross-PROCESS signal EMISSION over the wire stays deferred
-//    (epic #93, dedicated phase); no in-suite test has an external peer receive a signal WE emit.
-// The two sources are disjoint, so a signal is delivered exactly once.
+// Installs a signal subscription that receives ENTIRELY over the wire (epic #93 phase 3b):
+// [rule] is registered on the bus via AddMatch and [spec] filters the incoming SIGNAL frames the
+// reader delivers. Because the wire backend now emits signals over the wire too (see
+// [emitWireSignal]), this single path covers BOTH cross-process senders (e.g. a dbusmock peer) and
+// our OWN same-JVM served objects: each connection has its own socket + AddMatch, so the bus routes
+// every matching signal to it exactly once. The in-process [LocalJvmSignalBus]/[LocalJvmMatchBus]
+// is no longer used on this backend (it stays the dbus-java backend's same-process mechanism).
 private fun installSignalMatch(
     wire: DBusWireConnection,
     rule: String,
     spec: MatchSpec,
-    localMatch: String,
     callback: MessageHandler
 ): Resource {
     runCatching { wire.addMatch(rule) }.getOrElse {
@@ -582,19 +617,74 @@ private fun installSignalMatch(
                 destination = wireMessage.destination,
                 valid = true,
                 empty = wireMessage.body.isEmpty()
-            )
+            ).withLocalSenderCredentials(wireMessage.sender)
         )
         signal.payload.addAll(fromWireReplyValues(wireMessage.body, wireMessage.signature))
         JvmCurrentMessageContext.withMessage(signal) { callback(signal) }
     }
-    val localResource = LocalJvmMatchBus.register(localMatch, callback)
     val removed = AtomicBoolean(false)
     return com.monkopedia.sdbus.ActionResource {
         if (!removed.compareAndSet(false, true)) return@ActionResource
         runCatching { subscription.close() }
         runCatching { wire.removeMatch(rule) }
-        runCatching { localResource.release() }
     }
+}
+
+// --- sender credentials (received signals) ---------------------------------------------------
+
+private data class WireSenderCredentials(
+    val pid: Int?,
+    val uid: UInt?,
+    val gid: UInt?,
+    val supplementaryGids: List<UInt>?,
+    val selinuxContext: String?
+)
+
+// Credentials of THIS process, used for senders that are one of our own connections (resolved via
+// LocalJvmServiceRegistry). A signal that traversed the bus carries the authoritative sender (the
+// bus stamps it), and for a same-process sender that is this very process -- so reporting the local
+// process credentials is correct and matches the dbus-java backend's local short-circuit
+// (resolveSenderCredentials -> localProcessCredentialsOrNull). Credentials of an EXTERNAL sender
+// would require a GetConnectionCredentials bus call, which cannot run on the reader thread that
+// delivers signals without deadlocking; no test needs it, so it is intentionally left out here.
+private val localProcessWireCredentials: WireSenderCredentials by lazy {
+    val pid = runCatching { ProcessHandle.current().pid().toInt() }.getOrNull()
+    val unix = runCatching { com.sun.security.auth.module.UnixSystem() }.getOrNull()
+    val selinuxContext = runCatching {
+        java.nio.file.Files.readString(java.nio.file.Paths.get("/proc/self/attr/current"))
+            .trim(' ', ' ')
+            .ifEmpty { null }
+    }.getOrNull()
+    WireSenderCredentials(
+        pid = pid,
+        uid = unix?.uid?.toUInt(),
+        gid = unix?.gid?.toUInt(),
+        supplementaryGids = unix?.groups?.map { it.toUInt() },
+        selinuxContext = selinuxContext
+    )
+}
+
+private fun Message.Metadata.withLocalSenderCredentials(sender: String?): Message.Metadata {
+    val senderName = sender?.takeIf { it.isNotBlank() } ?: return this
+    if (LocalJvmServiceRegistry.resolveLocalUniqueName(senderName) == null) return this
+    val creds = localProcessWireCredentials
+    if (creds.pid == null &&
+        creds.uid == null &&
+        creds.gid == null &&
+        creds.supplementaryGids == null &&
+        creds.selinuxContext == null
+    ) {
+        return this
+    }
+    return copy(
+        credsPid = creds.pid,
+        credsUid = creds.uid,
+        credsEuid = creds.uid,
+        credsGid = creds.gid,
+        credsEgid = creds.gid,
+        credsSupplementaryGids = creds.supplementaryGids,
+        selinuxContext = creds.selinuxContext
+    )
 }
 
 // --- value-model <-> marshaller-model bridge -------------------------------------------------

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -232,11 +232,10 @@ class JvmRealBusIntegrationTest {
 
     @Test
     fun signalCallback_resolvesSenderCredentialsFromBus() = runBlocking {
-        // wire signal emission deferred — epic #93 (dedicated phase): our object's signal is
-        // delivered in-process via the local bus, which carries no sender credentials. Resolving
-        // credentials needs the signal to travel over the wire (real wire emission), so this case
-        // is gated until that lands.
-        if (com.monkopedia.sdbus.internal.jvmdbus.isJvmWireBackendEnabled()) return@runBlocking
+        // Exercised on BOTH backends now (epic #93 phase 3b): the wire backend emits the signal over
+        // the wire, so the bus stamps the authoritative sender and the receiver resolves the
+        // sender's credentials (filled from the local process for a same-process sender), just as
+        // the dbus-java backend does.
         val suffix = "c${System.nanoTime()}"
         val service = ServiceName("com.monkopedia.sdbus.jvmreal.$suffix")
         val objectPath = ObjectPath("/com/monkopedia/sdbus/jvmreal$suffix/credentials")


### PR DESCRIPTION
## Phase 3b (#93): emit signals over the wire on the owned connection

Makes an object served on a WIRE-backed (owned) connection emit signals **over the wire** so external processes receive them and the bus stamps the authoritative sender + attaches credentials. This was deliberately deferred from Phase 3 (it had caused a hang + a match collision when entangled earlier); done here in isolation.

### Design decision: WIRE-ONLY on the wire backend

- **Emission.** PureJavaDbusObject (reused by the wire backend with no dbus-java connection) is now handed a WireSignalEmitter bound to the connection's socket. All four emit paths (emitSignal / emitPropertiesChangedSignal / emitInterfacesAdded / emitInterfacesRemoved) build a D-Bus SIGNAL WireMessage (path / interface / member / signature, body marshalled via the existing toWireBodyValue + DBusMarshaller bridge) and send it through DBusWireConnection.send. The SENDER header is left unset so the bus stamps our unique name and our credentials.
- **Reception is correspondingly wire-only.** installSignalMatch no longer also registers an in-process LocalJvmMatchBus subscription, so each signal is delivered exactly once via the subscriber's own socket + AddMatch. Same-JVM two-connection delivery still works because each connection has its own socket + match (verified by CrossModuleSignalIntegrationTest). The in-process LocalJvmSignalBus / LocalJvmMatchBus is now the dbus-java backend's same-process mechanism only. A hybrid (wire + in-process) was rejected: same-JVM subscribers already hold a wire match, so it would double-deliver.
- **Sender credentials.** A signal from one of our own connections has its credentials filled from the local process (withLocalSenderCredentials), matching the dbus-java backend's local short-circuit. Resolving an external sender's credentials would need a GetConnectionCredentials bus call, which cannot run on the reader thread that delivers signals without deadlocking; no test needs it, so it is intentionally left out.

### Acceptance

1. **Un-gated** JvmRealBusIntegrationTest.signalCallback_resolvesSenderCredentialsFromBus: now runs on **both** toggle states and **PASSES wire-ON** (the signal traverses the bus, so sender + credsPid resolve).
2. **External-reception proof** (new): cross_test WireSignalEmissionExternalTest.emittedSignal_reachesExternalDbusMonitor serves an object on an owned connection, runs an **independent out-of-process dbus-monitor** observer, emits a signal, and asserts the observer captured it. **FAILS before** this change (in-process-only emission, the external observer never receives it) and **PASSES after**. JVM-only (the owned backend is JVM-only + toggle-gated); skips cleanly without a session bus / dbus-monitor.
3. CrossModuleSignalIntegrationTest + all dbusmock signal-reception suites still green wire-ON.

### Results

JAVA_HOME=java-21, under dbus-run-session, peer engaged (dbusmock per-test timings 0.5-0.76s — real, not the ~13ms no-op).

- **wire-ON** `:jvmTest :cross_test:jvmTest` — all green on dbusmock **0.38.1** and **0.31.1**, including the un-gated creds test and the new external-reception test.
- **wire-OFF** `:jvmTest :cross_test:jvmTest` — all green on dbusmock **0.38.1** and **0.31.1**.
- **fails-before** for the external test confirmed by temporarily disabling wire emission: dbus-monitor engaged (`became a monitor`) but never received the signal, so the test failed with an AssertionError; restored afterwards.
- `ktlintFormat` / `apiDump` (**NO-OP** — no `api/*.api` change) / `ktlintCheck` / `apiCheck` / `compileKotlinLinuxX64` all green.

Refs #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
