### PR TITLE
Phase 4 (#93): serve incoming method calls / properties / introspect over the owned connection

### DIFF
--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireServeExternalTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireServeExternalTest.kt
@@ -1,0 +1,234 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.prop
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Proves an object exported by a JVM sdbus-kotlin service on the OWNED wire backend is reachable by
+ * a genuinely EXTERNAL process — `busctl` (epic #93 phase 4, closes #90). busctl speaks the real
+ * D-Bus wire protocol over its own socket, so it cannot be short-circuited by the in-process
+ * JvmStaticDispatch the #90 investigation warned about: only true over-the-wire serving makes these
+ * pass.
+ *
+ *  - wire backend BEFORE this phase: the read loop ignored incoming METHOD_CALLs, so busctl got
+ *    `UnknownObject` (or timed out) and every assertion here FAILED;
+ *  - wire backend AFTER this phase: the calls are routed to the vtable handlers and replied over the
+ *    wire, so busctl gets correct results.
+ *
+ * Gated to the owned-wire backend (`-Dsdbus.jvm.wire=true`, exercised by CI's
+ * `wire-client-parity-x64` job): the dbus-java backend serves exported objects in-process only
+ * (the documented #90 limitation), so the test skips cleanly there rather than asserting a known
+ * gap. Also skips when no session bus or no `busctl` is available.
+ */
+class WireServeExternalTest {
+
+    @Test
+    fun externalBusctl_reachesServedObject() = runBlocking {
+        val sessionBus = System.getenv("DBUS_SESSION_BUS_ADDRESS")
+        if (sessionBus == null) {
+            println("[WireServeExternalTest] SKIP: no DBUS_SESSION_BUS_ADDRESS.")
+            return@runBlocking
+        }
+        if (!System.getProperty("sdbus.jvm.wire").equals("true", ignoreCase = true)) {
+            println(
+                "[WireServeExternalTest] SKIP: owned-wire backend not enabled (sdbus.jvm.wire)."
+            )
+            return@runBlocking
+        }
+        val busctl = findExecutable("busctl")
+        if (busctl == null) {
+            println("[WireServeExternalTest] SKIP: busctl not on PATH.")
+            return@runBlocking
+        }
+
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.serve$id")
+        val managerPath = ObjectPath("/com/monkopedia/sdbus/serve$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/serve$id/obj")
+        val iface = InterfaceName("com.monkopedia.sdbus.serve$id.Interface")
+
+        var prefix = "Hello"
+
+        val connection = createBusConnection(service)
+        connection.startEventLoop()
+        val managerRegistration = connection.addObjectManager(managerPath)
+        val obj = createObject(connection, path)
+        val registration = obj.addVTable(iface) {
+            // Sync handler.
+            method(MethodName("Add")) {
+                inputParamNames = listOf("a", "b")
+                outputParamNames = listOf("sum")
+                call { a: Int, b: Int -> a + b }
+            }
+            // Async (acall) handler — completes off the caller's thread.
+            method(MethodName("Concat")) {
+                inputParamNames = listOf("a", "b")
+                outputParamNames = listOf("joined")
+                acall { a: String, b: String -> a + b }
+            }
+            prop(PropertyName("Prefix")) {
+                withGetter { prefix }
+                withSetter<String> { prefix = it }
+            }
+        }
+
+        fun busctl(vararg args: String): Pair<Int, String> {
+            val process = ProcessBuilder(
+                listOf(busctl.absolutePath, "--address=$sessionBus") + args
+            ).redirectErrorStream(true).start()
+            val output = process.inputStream.bufferedReader().readText()
+            if (!process.waitFor(20, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                error("busctl ${args.joinToString(" ")} timed out\n$output")
+            }
+            return process.exitValue() to output
+        }
+
+        try {
+            // 1. Method call (sync handler): Add(2, 3) -> 5.
+            val (addCode, addOut) = busctl(
+                "call",
+                service.value,
+                path.value,
+                iface.value,
+                "Add",
+                "ii",
+                "2",
+                "3"
+            )
+            assertEquals(
+                0,
+                addCode,
+                "busctl call Add failed (UnknownObject before phase 4?): $addOut"
+            )
+            assertTrue("5" in addOut, "Add reply missing expected sum: $addOut")
+
+            // 2. Method call (async acall handler): Concat("foo", "bar") -> "foobar".
+            val (concatCode, concatOut) = busctl(
+                "call",
+                service.value,
+                path.value,
+                iface.value,
+                "Concat",
+                "ss",
+                "foo",
+                "bar"
+            )
+            assertEquals(0, concatCode, "busctl call Concat failed: $concatOut")
+            assertTrue("foobar" in concatOut, "Concat reply missing expected value: $concatOut")
+
+            // 3. Properties.Get -> initial "Hello".
+            val (getCode, getOut) = busctl(
+                "get-property",
+                service.value,
+                path.value,
+                iface.value,
+                "Prefix"
+            )
+            assertEquals(0, getCode, "busctl get-property failed: $getOut")
+            assertTrue("Hello" in getOut, "Get(Prefix) missing initial value: $getOut")
+
+            // 4. Properties.Set -> "World", then Get reflects it.
+            val (setCode, setOut) = busctl(
+                "set-property",
+                service.value,
+                path.value,
+                iface.value,
+                "Prefix",
+                "s",
+                "World"
+            )
+            assertEquals(0, setCode, "busctl set-property failed: $setOut")
+            assertEquals("World", prefix, "setter did not run over the wire")
+            val (getOut2Code, getOut2) = busctl(
+                "get-property",
+                service.value,
+                path.value,
+                iface.value,
+                "Prefix"
+            )
+            assertEquals(0, getOut2Code, "busctl get-property (post-set) failed: $getOut2")
+            assertTrue("World" in getOut2, "Get(Prefix) did not reflect Set: $getOut2")
+
+            // 5. Properties.GetAll over the wire.
+            val (getAllCode, getAllOut) = busctl(
+                "call",
+                service.value,
+                path.value,
+                "org.freedesktop.DBus.Properties",
+                "GetAll",
+                "s",
+                iface.value
+            )
+            assertEquals(0, getAllCode, "busctl GetAll failed: $getAllOut")
+            assertTrue("Prefix" in getAllOut, "GetAll missing Prefix: $getAllOut")
+
+            // 6. Introspect the served object.
+            val (introCode, introOut) = busctl("introspect", service.value, path.value)
+            assertEquals(0, introCode, "busctl introspect failed: $introOut")
+            assertTrue(iface.value in introOut, "Introspect missing our interface: $introOut")
+            assertTrue("Add" in introOut, "Introspect missing Add method: $introOut")
+            assertTrue("Prefix" in introOut, "Introspect missing Prefix property: $introOut")
+
+            // 7. ObjectManager.GetManagedObjects on the manager path lists the child object.
+            val (gmoCode, gmoOut) = busctl(
+                "call",
+                service.value,
+                managerPath.value,
+                "org.freedesktop.DBus.ObjectManager",
+                "GetManagedObjects"
+            )
+            assertEquals(0, gmoCode, "busctl GetManagedObjects failed: $gmoOut")
+            assertTrue(path.value in gmoOut, "GetManagedObjects missing the child object: $gmoOut")
+            assertTrue(iface.value in gmoOut, "GetManagedObjects missing our interface: $gmoOut")
+        } finally {
+            registration.release()
+            obj.release()
+            managerRegistration.release()
+            connection.stopEventLoop()
+            connection.release()
+        }
+    }
+
+    private fun findExecutable(name: String): File? {
+        val path = System.getenv("PATH") ?: return null
+        return path.split(File.pathSeparator)
+            .map { File(it, name) }
+            .firstOrNull { it.canExecute() }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
@@ -92,6 +93,18 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
     private val serialCounter = AtomicInteger(0)
     private val pending = ConcurrentHashMap<Int, CompletableFuture<WireMessage>>()
     private val signalListeners = CopyOnWriteArrayList<(WireMessage) -> Unit>()
+
+    // Incoming METHOD_CALL handler (epic #93 phase 4: serving). When set, every incoming method
+    // call is handed to it on a worker thread so a slow/async handler never stalls the reader.
+    @Volatile
+    private var incomingCallHandler: ((WireMessage) -> Unit)? = null
+
+    // Worker pool for serving incoming calls. Off the reader thread so handler execution (and any
+    // nested call a handler makes back on this same connection) cannot block reads or deadlock the
+    // reader: the reader only enqueues, then keeps reading and completing pending-call futures.
+    private val serveExecutor = Executors.newCachedThreadPool { runnable ->
+        thread(start = false, isDaemon = true, name = "sdbus-jvm-wire-serve") { runnable.run() }
+    }
 
     @Volatile
     private var uniqueNameValue: String? = null
@@ -181,7 +194,12 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
                 signalListeners.forEach { listener -> runCatching { listener(message) } }
 
             WireMessageType.METHOD_CALL -> {
-                // Phase 4: serving incoming calls. Ignored for now.
+                val handler = incomingCallHandler ?: return
+                // Hand off to a worker so the reader thread keeps draining the socket; a handler
+                // may itself call back on this connection and await a reply the reader delivers.
+                runCatching {
+                    serveExecutor.execute { runCatching { handler(message) } }
+                }
             }
         }
     }
@@ -285,6 +303,15 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
         return SignalSubscription { signalListeners.remove(listener) }
     }
 
+    /**
+     * Installs the handler that serves incoming METHOD_CALL messages (epic #93 phase 4). The
+     * handler runs on a worker thread (never the reader) and is responsible for sending any reply
+     * via [send]. At most one handler is installed per connection.
+     */
+    fun setIncomingCallHandler(handler: (WireMessage) -> Unit) {
+        incomingCallHandler = handler
+    }
+
     // --- bus bootstrap & standard calls ---------------------------------------------------------
 
     private fun hello() {
@@ -386,6 +413,7 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
 
     override fun close() {
         running = false
+        runCatching { serveExecutor.shutdownNow() }
         runCatching { socket.close() }
         readerThread?.let { reader ->
             if (reader !== Thread.currentThread()) {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/PureJavaDbusBackend.kt
@@ -1764,10 +1764,23 @@ internal class PureJavaDbusObject(
         }
     }
 
-    override fun addObjectManager(): Resource =
-        LocalObjectManagerRegistry.register(objectPath.value, dispatchDestination).also {
-            registrations += it
+    override fun addObjectManager(): Resource {
+        val local = LocalObjectManagerRegistry.register(objectPath.value, dispatchDestination)
+        registrations += local
+        // Wire backend: also advertise ObjectManager for over-the-wire introspection/serving.
+        val wireResource = if (wireSignalEmitter != null) {
+            WireServeRegistry.registerObjectManager(dispatchDestination, objectPath.value)
+                .also { registrations += it }
+        } else {
+            null
         }
+        return ActionResource {
+            local.release()
+            wireResource?.release()
+            registrations.remove(local)
+            wireResource?.let { registrations.remove(it) }
+        }
+    }
 
     override fun currentlyProcessedMessage(): Message =
         JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
@@ -1794,6 +1807,17 @@ internal class PureJavaDbusObject(
             interfaceName = interfaceName.value
         ) {
             snapshotInterfaceProperties(interfaceName.value)
+        }
+        // Wire backend (epic #93 phase 4): capture the vtable metadata so the owned connection can
+        // route, introspect and serve this object to EXTERNAL callers over the bus, not just
+        // in-process. The dbus-java/stub paths (wireSignalEmitter == null) don't need this.
+        if (wireSignalEmitter != null) {
+            resources += WireServeRegistry.registerVTable(
+                destination = dispatchDestination,
+                path = objectPath.value,
+                interfaceName = interfaceName.value,
+                vtable = vtable
+            )
         }
         resources += vtable.mapNotNull { item ->
             val method = item as? MethodVTableItem ?: return@mapNotNull null

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -163,6 +163,12 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
 
     init {
         LocalJvmServiceRegistry.registerLocalUniqueName(localUniqueName)
+        // Serve incoming method calls (epic #93 phase 4 — closes #90): route every METHOD_CALL the
+        // bus delivers to one of our exported objects through the shared dispatch tables and send
+        // the reply. Runs on the connection's serve worker, never the reader thread.
+        wire.setIncomingCallHandler { message ->
+            WireServe.handleIncomingCall(wire, localUniqueName, message)
+        }
     }
 
     override fun startEventLoop(): Unit = Unit
@@ -701,7 +707,7 @@ private fun microsToMillis(micros: ULong): Long =
  * (e.g. [ObjectPath]/[Signature] as strings, [UnixFd] as its int). The reply path needs NO
  * conversion: the demarshaller already produces decoder-compatible values.
  */
-private fun toWireBodyValue(value: Any?): Any? = when (value) {
+internal fun toWireBodyValue(value: Any?): Any? = when (value) {
     is Variant -> variantToPayload(value)
     // The string-like strong-name value classes arrive boxed in the payload (e.g. the
     // InterfaceName/PropertyName args of a Properties.Get call), since serialize() adds the raw
@@ -710,6 +716,8 @@ private fun toWireBodyValue(value: Any?): Any? = when (value) {
     // Signature and UnixFd pass through: the marshaller coerces those itself.)
     is BusName -> value.value
     is InterfaceName -> value.value
+    // MemberName covers its PropertyName/SignalName/MethodName typealiases (e.g. GetAll's
+    // PropertyName map keys), which must unwrap to their String for the marshaller's `s` handling.
     is MemberName -> value.value
     is Message.JvmVariantPayload ->
         Message.JvmVariantPayload(value.signature, toWireBodyValue(value.value))
@@ -748,7 +756,7 @@ private fun variantToPayload(variant: Variant): Message.JvmVariantPayload {
  * the reply body is NOT decoder-compatible (variants ClassCastException, `o` trips signature
  * enforcement); the demarshaller alone is signature-agnostic about these distinctions.
  */
-private fun fromWireReplyValues(body: List<Any?>, signature: String?): List<Any?> {
+internal fun fromWireReplyValues(body: List<Any?>, signature: String?): List<Any?> {
     val types = signature?.let(::splitTopLevelTypes).orEmpty()
     return body.mapIndexed { index, value -> fromWireReplyValue(value, types.getOrNull(index)) }
 }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
@@ -1,0 +1,564 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.internal.jvmdbus
+
+import com.monkopedia.sdbus.ActionResource
+import com.monkopedia.sdbus.Message
+import com.monkopedia.sdbus.MethodCall
+import com.monkopedia.sdbus.MethodVTableItem
+import com.monkopedia.sdbus.PropertyVTableItem
+import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.SignalVTableItem
+import com.monkopedia.sdbus.VTableItem
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Serves incoming D-Bus METHOD_CALL messages for objects exported on the self-owned wire
+ * connection (epic #93 phase 4 — the core of #90). This is the piece that makes a JVM-exported
+ * object reachable by EXTERNAL processes (busctl, dbus-send, another connection) over the bus, not
+ * just in-process.
+ *
+ * Routing reuses the SAME registries the in-process client path uses:
+ *  - regular methods, `org.freedesktop.DBus.Properties` Get/Set/GetAll and
+ *    `org.freedesktop.DBus.ObjectManager` GetManagedObjects all resolve through [JvmStaticDispatch]
+ *    (the handlers PureJavaDbusObject registers in addVTable), so an object exported via addVTable
+ *    is reachable both in-process AND over the wire from the one registration;
+ *  - `org.freedesktop.DBus.Introspectable` Introspect generates interface XML from the vtable
+ *    metadata captured in [WireServeRegistry];
+ *  - `org.freedesktop.DBus.Peer` Ping / GetMachineId are answered directly.
+ *
+ * Threading: [handleIncomingCall] runs on [DBusWireConnection]'s serve worker (never the reader),
+ * so a slow/async handler — or one that calls back on this same connection — cannot stall I/O.
+ */
+internal object WireServe {
+    const val PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+    const val OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
+    const val INTROSPECTABLE_INTERFACE = "org.freedesktop.DBus.Introspectable"
+    const val PEER_INTERFACE = "org.freedesktop.DBus.Peer"
+
+    private const val ERROR_UNKNOWN_OBJECT = "org.freedesktop.DBus.Error.UnknownObject"
+    private const val ERROR_UNKNOWN_INTERFACE = "org.freedesktop.DBus.Error.UnknownInterface"
+    private const val ERROR_UNKNOWN_METHOD = "org.freedesktop.DBus.Error.UnknownMethod"
+    private const val ERROR_FAILED = "org.freedesktop.DBus.Error.Failed"
+
+    private val standardInterfaces = setOf(
+        PROPERTIES_INTERFACE,
+        OBJECT_MANAGER_INTERFACE,
+        INTROSPECTABLE_INTERFACE,
+        PEER_INTERFACE
+    )
+
+    private val machineId: String by lazy {
+        sequenceOf("/etc/machine-id", "/var/lib/dbus/machine-id")
+            .mapNotNull { runCatching { Files.readString(Paths.get(it)).trim() }.getOrNull() }
+            .firstOrNull { it.isNotEmpty() }
+            ?: "0".repeat(32)
+    }
+
+    /**
+     * Serves [message] (addressed to one of [localUniqueName]'s exported objects) and sends the
+     * reply on [wire]. Never throws to the caller: a handler exception becomes a D-Bus ERROR reply
+     * so it cannot kill the reader/worker. Honors NO_REPLY_EXPECTED (no reply is sent).
+     */
+    fun handleIncomingCall(
+        wire: DBusWireConnection,
+        localUniqueName: String,
+        message: WireMessage
+    ) {
+        val reply = runCatching { serve(localUniqueName, message) }.getOrElse { throwable ->
+            errorReply(message, ERROR_FAILED, throwable.message ?: "Internal serving error")
+        }
+        if (message.flags and WireMessageFlags.NO_REPLY_EXPECTED != 0) return
+        runCatching { wire.send(reply) }
+    }
+
+    private fun serve(localUniqueName: String, message: WireMessage): WireMessage {
+        val member = message.member
+            ?: return errorReply(message, ERROR_UNKNOWN_METHOD, "Missing member name")
+        val iface = message.interfaceName
+        return try {
+            when (iface) {
+                PEER_INTERFACE -> servePeer(message, member)
+                INTROSPECTABLE_INTERFACE -> serveIntrospect(localUniqueName, message, member)
+                else -> serveDispatch(localUniqueName, message, iface, member)
+            }
+        } catch (e: com.monkopedia.sdbus.Error) {
+            errorReply(message, e.name, e.errorMessage)
+        } catch (e: Throwable) {
+            errorReply(message, ERROR_FAILED, e.message ?: "Handler failed")
+        }
+    }
+
+    private fun servePeer(message: WireMessage, member: String): WireMessage = when (member) {
+        "Ping" -> methodReturn(message, signature = null, values = emptyList())
+        "GetMachineId" -> methodReturn(message, signature = "s", values = listOf(machineId))
+        else -> errorReply(
+            message,
+            ERROR_UNKNOWN_METHOD,
+            "Unknown Peer method $member"
+        )
+    }
+
+    private fun serveIntrospect(
+        localUniqueName: String,
+        message: WireMessage,
+        member: String
+    ): WireMessage {
+        if (member != "Introspect") {
+            return errorReply(
+                message,
+                ERROR_UNKNOWN_METHOD,
+                "Unknown Introspectable method $member"
+            )
+        }
+        val path = message.path
+            ?: return errorReply(message, ERROR_UNKNOWN_OBJECT, "Missing object path")
+        val interfaces = WireServeRegistry.interfacesFor(localUniqueName, path)
+        val children = WireServeRegistry.childNodeNames(localUniqueName, path)
+        if (interfaces.isEmpty() && children.isEmpty()) {
+            return errorReply(message, ERROR_UNKNOWN_OBJECT, "Unknown object $path")
+        }
+        val xml = introspectionXml(interfaces, children)
+        return methodReturn(message, signature = "s", values = listOf(xml))
+    }
+
+    private fun serveDispatch(
+        localUniqueName: String,
+        message: WireMessage,
+        iface: String?,
+        member: String
+    ): WireMessage {
+        val path = message.path
+            ?: return errorReply(message, ERROR_UNKNOWN_OBJECT, "Missing object path")
+        val interfaceName = iface.orEmpty()
+        val args = fromWireReplyValues(message.body, message.signature)
+
+        if (!JvmStaticDispatch.hasHandler(path, interfaceName, member, args, localUniqueName)) {
+            return classifyMissing(localUniqueName, message, iface, member)
+        }
+
+        val inbound = MethodCall().also {
+            it.metadata = Message.Metadata(
+                interfaceName = iface,
+                memberName = member,
+                sender = message.sender,
+                destination = message.destination,
+                path = path,
+                valid = true,
+                empty = args.isEmpty()
+            )
+            it.payload.addAll(args)
+        }
+        val result = JvmCurrentMessageContext.withMessage(inbound) {
+            JvmStaticDispatch.invokeOrNull(
+                objectPath = path,
+                interfaceName = interfaceName,
+                methodName = member,
+                args = args,
+                destination = localUniqueName
+            )
+        }
+        return replyFor(message, iface, member, result)
+    }
+
+    private fun replyFor(
+        message: WireMessage,
+        iface: String?,
+        member: String,
+        result: Any?
+    ): WireMessage = when {
+        iface == PROPERTIES_INTERFACE && member == "Get" ->
+            methodReturn(message, "v", listOf(toWireBodyValue(result)))
+
+        iface == PROPERTIES_INTERFACE && member == "GetAll" ->
+            methodReturn(message, "a{sv}", listOf(toWireBodyValue(result)))
+
+        iface == PROPERTIES_INTERFACE && member == "Set" ->
+            methodReturn(message, null, emptyList())
+
+        iface == OBJECT_MANAGER_INTERFACE && member == "GetManagedObjects" ->
+            methodReturn(message, "a{oa{sa{sv}}}", listOf(toWireBodyValue(result)))
+
+        result is JvmStaticDispatch.DispatchResult -> {
+            result.reply.error?.let { throw it }
+            val signature = result.reply.declaredBodySignature.toString().ifEmpty { null }
+            methodReturn(message, signature, result.reply.payload.map(::toWireBodyValue))
+        }
+
+        // A hasNoReply method (or any void result): reply with an empty body.
+        else -> methodReturn(message, null, emptyList())
+    }
+
+    private fun classifyMissing(
+        localUniqueName: String,
+        message: WireMessage,
+        iface: String?,
+        member: String
+    ): WireMessage {
+        val path = message.path.orEmpty()
+        val interfaces = WireServeRegistry.interfacesFor(localUniqueName, path)
+        val servesPath = interfaces.isNotEmpty() ||
+            WireServeRegistry.childNodeNames(localUniqueName, path).isNotEmpty()
+        return when {
+            !servesPath -> errorReply(message, ERROR_UNKNOWN_OBJECT, "Unknown object $path")
+            iface != null && iface !in standardInterfaces && iface !in interfaces.keys ->
+                errorReply(message, ERROR_UNKNOWN_INTERFACE, "Unknown interface $iface on $path")
+            else -> errorReply(
+                message,
+                ERROR_UNKNOWN_METHOD,
+                "Unknown method ${iface.orEmpty()}.$member on $path"
+            )
+        }
+    }
+
+    private fun methodReturn(
+        call: WireMessage,
+        signature: String?,
+        values: List<Any?>
+    ): WireMessage = WireMessage(
+        type = WireMessageType.METHOD_RETURN,
+        replySerial = call.serial,
+        destination = call.sender,
+        signature = signature?.takeUnless { it.isEmpty() },
+        body = if (signature.isNullOrEmpty()) emptyList() else values
+    )
+
+    private fun errorReply(call: WireMessage, name: String, errorMessage: String): WireMessage =
+        WireMessage(
+            type = WireMessageType.ERROR,
+            errorName = name,
+            replySerial = call.serial,
+            destination = call.sender,
+            signature = "s",
+            body = listOf(errorMessage)
+        )
+
+    // --- introspection XML ----------------------------------------------------------------------
+
+    private fun introspectionXml(
+        interfaces: Map<String, WireServeRegistry.InterfaceMeta>,
+        children: List<String>
+    ): String = buildString {
+        append(
+            "<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\"\n" +
+                " \"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
+        )
+        append("<node>\n")
+        // Standard interfaces sd-bus always exposes for an exported object.
+        append(STANDARD_INTROSPECTION)
+        if (interfaces.values.any { it.objectManager }) append(OBJECT_MANAGER_INTROSPECTION)
+        interfaces.toSortedMap().forEach { (name, meta) -> appendInterface(name, meta) }
+        children.sorted().forEach { append("  <node name=\"$it\"/>\n") }
+        append("</node>\n")
+    }
+
+    private fun StringBuilder.appendInterface(name: String, meta: WireServeRegistry.InterfaceMeta) {
+        append("  <interface name=\"").append(name).append("\">\n")
+        meta.methods.values.sortedBy { it.name }.forEach { method ->
+            append("    <method name=\"").append(method.name).append("\">\n")
+            splitTypes(method.inputSignature).forEachIndexed { i, type ->
+                appendArg(type, method.inputNames.getOrNull(i), "in")
+            }
+            splitTypes(method.outputSignature).forEachIndexed { i, type ->
+                appendArg(type, method.outputNames.getOrNull(i), "out")
+            }
+            if (method.deprecated) append(DEPRECATED_ANNOTATION)
+            append("    </method>\n")
+        }
+        meta.signals.values.sortedBy { it.name }.forEach { signal ->
+            append("    <signal name=\"").append(signal.name).append("\">\n")
+            splitTypes(signal.signature).forEachIndexed { i, type ->
+                appendArg(type, signal.paramNames.getOrNull(i), null)
+            }
+            if (signal.deprecated) append(DEPRECATED_ANNOTATION)
+            append("    </signal>\n")
+        }
+        meta.properties.values.sortedBy { it.name }.forEach { property ->
+            val access = when {
+                property.readable && property.writable -> "readwrite"
+                property.writable -> "write"
+                else -> "read"
+            }
+            append("    <property name=\"").append(property.name)
+                .append("\" type=\"").append(property.signature)
+                .append("\" access=\"").append(access).append("\"")
+            if (property.deprecated) {
+                append(">\n").append("      ").append(DEPRECATED_ANNOTATION.trim()).append("\n")
+                    .append("    </property>\n")
+            } else {
+                append("/>\n")
+            }
+        }
+        append("  </interface>\n")
+    }
+
+    // Splits a signature into its top-level complete types (e.g. "ia{sv}" -> [i, a{sv}]); empty
+    // signature -> empty list. Local to avoid colliding with the file-private helpers elsewhere.
+    private fun splitTypes(signature: String): List<String> {
+        if (signature.isEmpty()) return emptyList()
+        fun parseOne(index: Int): Int {
+            if (index >= signature.length) return index
+            return when (signature[index]) {
+                'a' -> parseOne(index + 1)
+                '(' -> {
+                    var i = index + 1
+                    while (i < signature.length && signature[i] != ')') i = parseOne(i)
+                    (i + 1).coerceAtMost(signature.length)
+                }
+                '{' -> {
+                    var i = index + 1
+                    while (i < signature.length && signature[i] != '}') i = parseOne(i)
+                    (i + 1).coerceAtMost(signature.length)
+                }
+                else -> index + 1
+            }
+        }
+        val types = mutableListOf<String>()
+        var index = 0
+        while (index < signature.length) {
+            val next = parseOne(index)
+            if (next <= index) break
+            types += signature.substring(index, next)
+            index = next
+        }
+        return types
+    }
+
+    private fun StringBuilder.appendArg(type: String, name: String?, direction: String?) {
+        append("      <arg type=\"").append(type).append("\"")
+        if (!name.isNullOrEmpty()) append(" name=\"").append(name).append("\"")
+        if (direction != null) append(" direction=\"").append(direction).append("\"")
+        append("/>\n")
+    }
+
+    private val DEPRECATED_ANNOTATION =
+        "      <annotation name=\"org.freedesktop.DBus.Deprecated\" value=\"true\"/>\n"
+
+    private val STANDARD_INTROSPECTION =
+        "  <interface name=\"org.freedesktop.DBus.Peer\">\n" +
+            "    <method name=\"Ping\"/>\n" +
+            "    <method name=\"GetMachineId\">\n" +
+            "      <arg type=\"s\" name=\"machine_uuid\" direction=\"out\"/>\n" +
+            "    </method>\n" +
+            "  </interface>\n" +
+            "  <interface name=\"org.freedesktop.DBus.Introspectable\">\n" +
+            "    <method name=\"Introspect\">\n" +
+            "      <arg type=\"s\" name=\"xml_data\" direction=\"out\"/>\n" +
+            "    </method>\n" +
+            "  </interface>\n" +
+            "  <interface name=\"org.freedesktop.DBus.Properties\">\n" +
+            "    <method name=\"Get\">\n" +
+            "      <arg type=\"s\" name=\"interface_name\" direction=\"in\"/>\n" +
+            "      <arg type=\"s\" name=\"property_name\" direction=\"in\"/>\n" +
+            "      <arg type=\"v\" name=\"value\" direction=\"out\"/>\n" +
+            "    </method>\n" +
+            "    <method name=\"Set\">\n" +
+            "      <arg type=\"s\" name=\"interface_name\" direction=\"in\"/>\n" +
+            "      <arg type=\"s\" name=\"property_name\" direction=\"in\"/>\n" +
+            "      <arg type=\"v\" name=\"value\" direction=\"in\"/>\n" +
+            "    </method>\n" +
+            "    <method name=\"GetAll\">\n" +
+            "      <arg type=\"s\" name=\"interface_name\" direction=\"in\"/>\n" +
+            "      <arg type=\"a{sv}\" name=\"properties\" direction=\"out\"/>\n" +
+            "    </method>\n" +
+            "    <signal name=\"PropertiesChanged\">\n" +
+            "      <arg type=\"s\" name=\"interface_name\"/>\n" +
+            "      <arg type=\"a{sv}\" name=\"changed_properties\"/>\n" +
+            "      <arg type=\"as\" name=\"invalidated_properties\"/>\n" +
+            "    </signal>\n" +
+            "  </interface>\n"
+
+    private val OBJECT_MANAGER_INTROSPECTION =
+        "  <interface name=\"org.freedesktop.DBus.ObjectManager\">\n" +
+            "    <method name=\"GetManagedObjects\">\n" +
+            "      <arg type=\"a{oa{sa{sv}}}\" name=\"objpath_interfaces_and_properties\" " +
+            "direction=\"out\"/>\n" +
+            "    </method>\n" +
+            "    <signal name=\"InterfacesAdded\">\n" +
+            "      <arg type=\"o\" name=\"object_path\"/>\n" +
+            "      <arg type=\"a{sa{sv}}\" name=\"interfaces_and_properties\"/>\n" +
+            "    </signal>\n" +
+            "    <signal name=\"InterfacesRemoved\">\n" +
+            "      <arg type=\"o\" name=\"object_path\"/>\n" +
+            "      <arg type=\"as\" name=\"interfaces\"/>\n" +
+            "    </signal>\n" +
+            "  </interface>\n"
+}
+
+/**
+ * Per-(connection unique name, object path) metadata for objects exported on the wire backend,
+ * captured from the vtable so [WireServe] can route/introspect them. Keyed by the same destination
+ * (the owning connection's unique name) the in-process [JvmStaticDispatch] handlers use.
+ */
+internal object WireServeRegistry {
+    data class MethodMeta(
+        val name: String,
+        val inputSignature: String,
+        val outputSignature: String,
+        val inputNames: List<String>,
+        val outputNames: List<String>,
+        val deprecated: Boolean
+    )
+
+    data class PropertyMeta(
+        val name: String,
+        val signature: String,
+        val readable: Boolean,
+        val writable: Boolean,
+        val deprecated: Boolean
+    )
+
+    data class SignalMeta(
+        val name: String,
+        val signature: String,
+        val paramNames: List<String>,
+        val deprecated: Boolean
+    )
+
+    data class InterfaceMeta(
+        val methods: Map<String, MethodMeta>,
+        val properties: Map<String, PropertyMeta>,
+        val signals: Map<String, SignalMeta>,
+        val objectManager: Boolean = false
+    )
+
+    private data class ObjectKey(val destination: String, val path: String)
+    private data class Entry(var refCount: Int, val meta: InterfaceMeta)
+
+    private val objects = mutableMapOf<ObjectKey, MutableMap<String, Entry>>()
+
+    /** Captures the [vtable] metadata for [interfaceName] at ([destination], [path]). */
+    fun registerVTable(
+        destination: String,
+        path: String,
+        interfaceName: String,
+        vtable: List<VTableItem>
+    ): Resource {
+        val meta = buildMeta(vtable)
+        val key = ObjectKey(destination, path)
+        synchronized(this) {
+            val perObject = objects.getOrPut(key) { mutableMapOf() }
+            val existing = perObject[interfaceName]
+            if (existing != null) {
+                existing.refCount++
+            } else {
+                perObject[interfaceName] = Entry(1, meta)
+            }
+        }
+        return ActionResource {
+            synchronized(this) {
+                val perObject = objects[key] ?: return@ActionResource
+                val entry = perObject[interfaceName] ?: return@ActionResource
+                if (entry.refCount <= 1) {
+                    perObject.remove(interfaceName)
+                    if (perObject.isEmpty()) objects.remove(key)
+                } else {
+                    entry.refCount--
+                }
+            }
+        }
+    }
+
+    /** Marks ([destination], [path]) as exposing the ObjectManager interface (for introspection). */
+    fun registerObjectManager(destination: String, path: String): Resource {
+        val key = ObjectKey(destination, path)
+        val name = WireServe.OBJECT_MANAGER_INTERFACE
+        synchronized(this) {
+            val perObject = objects.getOrPut(key) { mutableMapOf() }
+            val existing = perObject[name]
+            if (existing != null) {
+                existing.refCount++
+            } else {
+                perObject[name] = Entry(1, InterfaceMeta(emptyMap(), emptyMap(), emptyMap(), true))
+            }
+        }
+        return ActionResource {
+            synchronized(this) {
+                val perObject = objects[key] ?: return@ActionResource
+                val entry = perObject[name] ?: return@ActionResource
+                if (entry.refCount <= 1) {
+                    perObject.remove(name)
+                    if (perObject.isEmpty()) objects.remove(key)
+                } else {
+                    entry.refCount--
+                }
+            }
+        }
+    }
+
+    fun interfacesFor(destination: String, path: String): Map<String, InterfaceMeta> =
+        synchronized(this) {
+            objects[ObjectKey(destination, path)]
+                ?.mapValues { it.value.meta }
+                ?.toMap()
+                .orEmpty()
+        }
+
+    /** Immediate child node segment names of [path] among this destination's exported paths. */
+    fun childNodeNames(destination: String, path: String): List<String> = synchronized(this) {
+        val prefix = if (path == "/") "/" else "$path/"
+        objects.keys.asSequence()
+            .filter { it.destination == destination && it.path != path }
+            .mapNotNull { key ->
+                if (!key.path.startsWith(prefix)) return@mapNotNull null
+                key.path.substring(prefix.length).substringBefore('/').ifEmpty { null }
+            }
+            .distinct()
+            .toList()
+    }
+
+    private fun buildMeta(vtable: List<VTableItem>): InterfaceMeta {
+        val methods = mutableMapOf<String, MethodMeta>()
+        val properties = mutableMapOf<String, PropertyMeta>()
+        val signals = mutableMapOf<String, SignalMeta>()
+        vtable.forEach { item ->
+            when (item) {
+                is MethodVTableItem -> methods[item.name.value] = MethodMeta(
+                    name = item.name.value,
+                    inputSignature = item.inputSignature?.value.orEmpty(),
+                    outputSignature = item.outputSignature?.value.orEmpty(),
+                    inputNames = item.inputParamNames,
+                    outputNames = item.outputParamNames,
+                    deprecated = item.isDeprecated
+                )
+
+                is PropertyVTableItem -> properties[item.name.value] = PropertyMeta(
+                    name = item.name.value,
+                    signature = item.signature?.value.orEmpty(),
+                    readable = item.getter != null,
+                    writable = item.setter != null,
+                    deprecated = item.isDeprecated
+                )
+
+                is SignalVTableItem -> signals[item.name.value] = SignalMeta(
+                    name = item.name.value,
+                    signature = item.signature.value,
+                    paramNames = item.paramNames,
+                    deprecated = item.isDeprecated
+                )
+
+                else -> Unit
+            }
+        }
+        return InterfaceMeta(methods, properties, signals)
+    }
+}


### PR DESCRIPTION
## Phase 4 of epic #93 — serve incoming method calls over the owned connection (closes #90)

External processes can now call methods on, get/set properties of, and introspect objects exported by a JVM sdbus-kotlin service running on the owned-wire backend. The read loop previously received but ignored incoming METHOD_CALLs (a phase-2 placeholder); it now routes them and replies over the wire.

### Dispatch design + threading model
- **DBusWireConnection** gains a per-connection incoming-call handler plus a cached worker pool. The reader thread only enqueues each METHOD_CALL and keeps draining the socket; handler execution (which may block up to the async-reply timeout) runs on a worker. This means a slow/async handler — or one that itself calls back on the same connection and awaits a reply the reader delivers — cannot stall I/O or deadlock the reader. The worker pool is shut down on close().
- **WireServe** routes each call through the SAME registries the in-process client path uses. Regular methods, Properties Get/Set/GetAll and ObjectManager GetManagedObjects all resolve through `JvmStaticDispatch` (the handlers `PureJavaDbusObject.addVTable` already registers), so a single addVTable registration serves both in-process AND over the wire. Call args are deserialized signature-driven through the existing wire-to-decoder bridge; return values are marshalled using the reply's declared body signature (regular methods, which handles degrouped multi-out correctly) or the known standard-interface signature, and sent as a METHOD_RETURN with the correct reply-serial and destination=caller.

### Standard interfaces served
- `org.freedesktop.DBus.Properties` — Get / Set / GetAll routed to the vtable getter/setter callbacks (reuses the #89-correct getter serialization).
- `org.freedesktop.DBus.ObjectManager` — GetManagedObjects via the existing managed-objects machinery, marshalled over the wire.
- `org.freedesktop.DBus.Introspectable` — Introspect, with XML generated from vtable metadata captured in a new internal `WireServeRegistry` (methods with in/out args + names, properties with access, signals, deprecation), including child `<node>` entries and the standard interfaces sd-bus always exposes.
- `org.freedesktop.DBus.Peer` — Ping / GetMachineId.

### Errors
Unknown path → `UnknownObject`; unknown interface/member → `UnknownInterface` / `UnknownMethod`; a thrown sdbus `Error` is marshalled into an ERROR reply preserving its name and message. A handler exception is caught and turned into an ERROR reply — it never kills the worker or the reader thread. `NO_REPLY_EXPECTED` is honored (no reply sent).

### Name ownership
Unchanged from phase 2: `createConnection(name=...)` calls RequestName, so external callers can address us by the well-known name (Hello already gives the unique name). The serving dispatch keys on the connection's unique name, matching the dispatch destination `PureJavaDbusObject` registers under.

### External-caller acceptance test
`cross_test/.../WireServeExternalTest` drives **busctl** as a genuinely external process (its own socket / wire protocol — cannot be short-circuited by the in-process JvmStaticDispatch the #90 investigation warned about) against a JVM-exported object on the wire backend. It asserts:
- method return for a **sync** handler (`Add(ii)->i`) and an **async** `acall` handler (`Concat(ss)->s`);
- Properties **Get** / **Set** (verifying the setter ran) / **GetAll**;
- **Introspect** (interface, method, property present);
- ObjectManager **GetManagedObjects** (child object + interface present).

It is gated to the owned-wire backend (`-Dsdbus.jvm.wire=true`), i.e. CI's `wire-client-parity-x64` job; the dbus-java backend serves exported objects in-process only (the documented #90 limitation), so the test skips cleanly there. Verified **fails-before** this phase (busctl reports `Connection timed out` → assertion fails) and **passes-after** (all assertions green). No hang was found (the worker-off-reader design was correct on the first run; every gradle run was wrapped in `timeout`).

### Verification
- `ktlintFormat` → `apiDump` (**no-op**, all new code is internal) → `ktlintCheck apiCheck` → `compileKotlinLinuxX64`: all green.
- Full `:jvmTest :cross_test:jvmTest` **wire-ON** (`-Dsdbus.jvm.wire=true`) green incl. the new external-serving test; dbusmock suites ran with real time (not fake-green).
- Full suite **wire-OFF** green (serve test skips cleanly).
- Parity confirmed across **dbusmock 0.38.1** and CI's **0.31.1**.

Fixes #90.
Refs #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
