### PR TITLE
Phase 5 (#93): SCM_RIGHTS unix-fd passing over the owned connection

### DIFF
--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
@@ -20,6 +20,12 @@
  */
 package com.monkopedia.sdbus.integration
 
+import java.io.FileDescriptor
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+
 /**
  * Struct marshalling to/from remote peers is supported since the issue #71 fix (structs are
  * decomposed into wire-shaped values via JvmValueCodec on the way to/from dbus-java).
@@ -27,20 +33,114 @@ package com.monkopedia.sdbus.integration
 internal actual val peerStructMarshallingSupported: Boolean = true
 
 /**
- * The JVM has no portable way to surface a freshly created pipe as a raw integer file
- * descriptor from test code (java.io.FileDescriptor's int field is sealed behind JPMS),
- * so the unix-fd sub-case is exercised on the native backend only and skipped here.
+ * Closes #83: with the owned-connection (wire) JVM backend, raw fds round-trip natively via
+ * junixsocket SCM_RIGHTS, so the cross-process unix-fd case runs against a real dbusmock peer. We
+ * surface a real pipe through junixsocket's native primitives (the same path the library uses for
+ * UnixFd, reached reflectively so no `--add-opens` is needed for java.base/java.io).
+ *
+ * Only enabled on the wire backend. The legacy dbus-java backend converts fds through
+ * `org.freedesktop.dbus.FileDescriptor`, which reflects into `java.io.FileDescriptor`'s private
+ * `fd` field and so needs JPMS `--add-opens`; that path is being retired (epic #93 phase 6), so the
+ * sub-case stays skipped there rather than newly requiring add-opens for the old backend.
  */
-internal actual fun createTestPipe(): Pair<Int, Int>? = null
+internal actual fun createTestPipe(): Pair<Int, Int>? {
+    if (!wireBackendEnabled) return null
+    return JunixFdBridge.createPipePair()
+}
 
-internal actual fun writeToFd(fd: Int, data: ByteArray): Boolean =
-    throw UnsupportedOperationException("raw fds are not accessible on the JVM test backend")
+internal actual fun writeToFd(fd: Int, data: ByteArray): Boolean {
+    // Write through a duplicate so the caller's original descriptor stays open.
+    val dup = JunixFdBridge.duplicate(fd)
+    return FileOutputStream(JunixFdBridge.descriptorFor(dup)).use {
+        it.write(data)
+        it.flush()
+        true
+    }
+}
 
-internal actual fun readFromFd(fd: Int, maxBytes: Int): ByteArray? =
-    throw UnsupportedOperationException("raw fds are not accessible on the JVM test backend")
+internal actual fun readFromFd(fd: Int, maxBytes: Int): ByteArray? {
+    val dup = JunixFdBridge.duplicate(fd)
+    return FileInputStream(JunixFdBridge.descriptorFor(dup)).use { stream ->
+        val buffer = ByteArray(maxBytes)
+        val read = stream.read(buffer)
+        if (read < 0) ByteArray(0) else buffer.copyOf(read)
+    }
+}
 
 internal actual fun closeTestFd(fd: Int) {
-    // No raw fds are ever created on the JVM backend; nothing to close.
+    JunixFdBridge.close(fd)
+}
+
+private val wireBackendEnabled: Boolean by lazy {
+    System.getProperty("sdbus.jvm.wire")?.equals("true", ignoreCase = true)
+        ?: System.getenv("SDBUS_JVM_WIRE")?.equals("true", ignoreCase = true)
+        ?: false
+}
+
+/**
+ * Minimal reflective bridge onto junixsocket's `NativeUnixSocket` native primitives (pipe / dup /
+ * close / fd<->FileDescriptor), used only by JVM cross_test fd plumbing. junixsocket is on the test
+ * runtime classpath via the dbus-java junixsocket transport.
+ */
+private object JunixFdBridge {
+    private val initFd: Method
+    private val getFd: Method
+    private val closeFd: Method
+    private val duplicateFd: Method
+    private val initPipe: Method
+
+    init {
+        val type = Class.forName("org.newsclub.net.unix.NativeUnixSocket")
+        type.getDeclaredMethod("ensureSupported").apply { isAccessible = true }.invoke(null)
+        initFd = type.getDeclaredMethod(
+            "initFD",
+            FileDescriptor::class.java,
+            Int::class.javaPrimitiveType!!
+        ).apply { isAccessible = true }
+        getFd = type.getDeclaredMethod("getFD", FileDescriptor::class.java)
+            .apply { isAccessible = true }
+        closeFd = type.getDeclaredMethod("close", FileDescriptor::class.java)
+            .apply { isAccessible = true }
+        duplicateFd = type.getDeclaredMethod(
+            "duplicate",
+            FileDescriptor::class.java,
+            FileDescriptor::class.java
+        ).apply { isAccessible = true }
+        initPipe = type.getDeclaredMethod(
+            "initPipe",
+            FileDescriptor::class.java,
+            FileDescriptor::class.java,
+            Boolean::class.javaPrimitiveType!!
+        ).apply { isAccessible = true }
+    }
+
+    fun createPipePair(): Pair<Int, Int>? = runCatching {
+        val read = FileDescriptor()
+        val write = FileDescriptor()
+        invoke(initPipe, read, write, false)
+        fdOf(read) to fdOf(write)
+    }.getOrNull()
+
+    fun descriptorFor(fd: Int): FileDescriptor = FileDescriptor().also { invoke(initFd, it, fd) }
+
+    fun duplicate(fd: Int): Int {
+        val target = FileDescriptor()
+        val result = invoke(duplicateFd, descriptorFor(fd), target) as? FileDescriptor ?: target
+        return fdOf(result)
+    }
+
+    fun close(fd: Int) {
+        runCatching { invoke(closeFd, descriptorFor(fd)) }
+    }
+
+    private fun fdOf(descriptor: FileDescriptor): Int =
+        (invoke(getFd, descriptor) as Number).toInt()
+
+    private fun invoke(method: Method, vararg args: Any?): Any? = try {
+        method.invoke(null, *args)
+    } catch (e: InvocationTargetException) {
+        throw e.targetException ?: e
+    }
 }
 
 /**

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Types.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Types.jvm.kt
@@ -105,6 +105,33 @@ internal object JvmUnixFdSupport {
             .recoverCatching { support.createFallbackPair() }
             .getOrNull()
     }
+
+    /**
+     * Wraps the raw integer [fd] in a [FileDescriptor] suitable for handing to junixsocket's
+     * `setOutboundFileDescriptors` (SCM_RIGHTS send). The kernel dup-on-send leaves [fd] owned by
+     * the caller; this descriptor is a throwaway wrapper that is never closed here.
+     */
+    fun descriptorForFd(fd: Int): FileDescriptor {
+        val support = nativeSupport
+            ?: throw createError(-1, "Unix-fd passing requires junixsocket native support")
+        return support.descriptorForFd(fd)
+    }
+
+    /**
+     * Adopts a [FileDescriptor] received via junixsocket's `getReceivedFileDescriptors`
+     * (SCM_RIGHTS receive), returning a raw fd that the caller owns outright (wrap it in
+     * [UnixFd.adopt]).
+     *
+     * The received descriptor is duplicated so the returned fd is fully independent, then the
+     * junixsocket-owned original is closed: that removes it from junixsocket's internal
+     * received-fd table (junixsocket attaches a close-callback to each received descriptor), so it
+     * is neither leaked until socket close nor double-closed. The result is a clean single owner.
+     */
+    fun adoptReceivedDescriptor(descriptor: FileDescriptor): Int {
+        val support = nativeSupport
+            ?: throw createError(-1, "Unix-fd passing requires junixsocket native support")
+        return support.adoptReceivedDescriptor(descriptor)
+    }
 }
 
 private class NativeUnixSocketSupport private constructor(
@@ -127,6 +154,22 @@ private class NativeUnixSocketSupport private constructor(
 
     fun close(fd: Int) {
         invokeStatic(close, descriptorFromFd(fd))
+    }
+
+    /** Builds a [FileDescriptor] wrapping the raw integer [fd] (for outbound SCM_RIGHTS sends). */
+    fun descriptorForFd(fd: Int): FileDescriptor = descriptorFromFd(fd)
+
+    /**
+     * Duplicates the int behind a received [descriptor] (so the caller owns an independent fd),
+     * then closes the original junixsocket-owned descriptor object — closing the *object* fires the
+     * close-callback junixsocket attached to it, evicting it from the received-fd table. Returns the
+     * duplicated fd.
+     */
+    fun adoptReceivedDescriptor(descriptor: FileDescriptor): Int {
+        val sourceFd = extractFd(descriptor)
+        val duplicated = duplicate(sourceFd)
+        runCatching { invokeStatic(close, descriptor) }
+        return duplicated
     }
 
     fun createPipePair(): Pair<Int, Int> {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -20,11 +20,15 @@
  */
 package com.monkopedia.sdbus.internal.jvmdbus
 
+import com.monkopedia.sdbus.JvmUnixFdSupport
+import com.monkopedia.sdbus.Message
+import com.monkopedia.sdbus.UnixFd
 import java.io.BufferedInputStream
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.EOFException
 import java.io.File
+import java.io.FileDescriptor
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -166,12 +170,17 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
 
     // --- reader thread --------------------------------------------------------------------------
 
+    // FIFO of file descriptors received via SCM_RIGHTS, accessed only on the reader thread.
+    // junixsocket delivers passed fds out-of-band alongside the message bytes; we drain them after
+    // each frame and hand each message its declared UNIX_FDS count in arrival order.
+    private val receivedFdQueue = ArrayDeque<FileDescriptor>()
+
     private fun startReader() {
         running = true
         readerThread = thread(start = true, isDaemon = true, name = "sdbus-jvm-wire-reader") {
             try {
                 while (running) {
-                    dispatch(WireMessageCodec.read(input))
+                    dispatch(resolveReceivedFds(WireMessageCodec.read(input)))
                 }
             } catch (_: IOException) {
                 // Expected on close() (socket closed) or peer disconnect.
@@ -215,9 +224,76 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
     private fun nextSerial(): Int = serialCounter.incrementAndGet()
 
     private fun writeMessage(message: WireMessage) {
-        synchronized(writeLock) {
-            WireMessageCodec.write(output, message)
+        // Collect any UnixFds in the body (depth-first, body order) and replace each with its
+        // 0-based index into the attached fd array; the `h` wire value is that index, the actual
+        // fds travel out-of-band via SCM_RIGHTS.
+        val fds = mutableListOf<Int>()
+        val outgoing = if (message.body.isEmpty()) {
+            message
+        } else {
+            val body = message.body.map { collectOutboundFds(it, fds) }
+            if (fds.isEmpty()) message else message.copy(body = body, unixFds = fds.size)
         }
+        synchronized(writeLock) {
+            if (fds.isEmpty()) {
+                WireMessageCodec.write(output, outgoing)
+                return
+            }
+            if (!unixFdNegotiated) {
+                throw IOException(
+                    "Cannot send ${fds.size} file descriptor(s): UNIX_FD passing was not negotiated"
+                )
+            }
+            // Attach the fds to THIS message's bytes: setOutboundFileDescriptors arms the next
+            // write on the socket, which we perform immediately under the write lock so the kernel
+            // delivers the ancillary fds together with the framed message (D-Bus associates passed
+            // fds with the message carrying UNIX_FDS).
+            val descriptors = Array(fds.size) { JvmUnixFdSupport.descriptorForFd(fds[it]) }
+            socket.setOutboundFileDescriptors(*descriptors)
+            try {
+                WireMessageCodec.write(output, outgoing)
+            } finally {
+                // junixsocket consumes pending outbound fds on the send; clear defensively so a
+                // later fd-less write can never re-attach them.
+                if (socket.hasOutboundFileDescriptors()) {
+                    runCatching { socket.setOutboundFileDescriptors() }
+                }
+            }
+        }
+    }
+
+    /**
+     * Resolves the UNIX_FDS of a freshly read [message]: drains the fds junixsocket received
+     * alongside it, then rewrites the `h` indices in the decoded body to [UnixFd]s wrapping the
+     * corresponding received descriptors. A message with no UNIX_FDS is returned unchanged.
+     */
+    private fun resolveReceivedFds(message: WireMessage): WireMessage {
+        val count = message.unixFds ?: return message
+        if (count <= 0) return message
+        drainReceivedFds()
+        if (receivedFdQueue.size < count) {
+            throw DBusMarshallingException(
+                "Message declared $count unix fds but only ${receivedFdQueue.size} were received"
+            )
+        }
+        val fds = ArrayList<UnixFd>(count)
+        repeat(count) {
+            fds.add(
+                UnixFd.adopt(
+                    JvmUnixFdSupport.adoptReceivedDescriptor(receivedFdQueue.removeFirst())
+                )
+            )
+        }
+        val types = message.signature?.let { DBusSignatureParser.parse(it) }.orEmpty()
+        val body = message.body.mapIndexed { index, value ->
+            resolveInboundFds(types.getOrNull(index), value, fds)
+        }
+        return message.copy(body = body)
+    }
+
+    private fun drainReceivedFds() {
+        val received = socket.receivedFileDescriptors ?: return
+        for (descriptor in received) receivedFdQueue.addLast(descriptor)
     }
 
     private data class PendingCall(val serial: Int, val future: CompletableFuture<WireMessage>)
@@ -432,6 +508,9 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
         private const val TIMEOUT_ERROR_NAME = "org.freedesktop.DBus.Error.Timeout"
         private const val DEFAULT_SYSTEM_BUS_ADDRESS = "unix:path=/var/run/dbus/system_bus_socket"
 
+        // 4 KiB comfortably holds the cmsg for the kernel's SCM_MAX_FD (253) descriptors per recv.
+        private const val ANCILLARY_RECEIVE_BUFFER_BYTES = 4096
+
         /** Connects to the session bus (`DBUS_SESSION_BUS_ADDRESS`) and completes Hello. */
         fun connectSession(): DBusWireConnection {
             val address = System.getenv("DBUS_SESSION_BUS_ADDRESS")
@@ -450,6 +529,10 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
             val socketAddress = parseAddress(address)
             val socket = AFUNIXSocket.newInstance()
             socket.connect(socketAddress)
+            // Size the ancillary buffer so SCM_RIGHTS descriptors passed with a message are
+            // captured by the receiving recv() (D-Bus relays passed fds through the daemon). Sized
+            // for the kernel's per-message SCM_MAX_FD ceiling with comfortable slack.
+            runCatching { socket.ensureAncillaryReceiveBufferSize(ANCILLARY_RECEIVE_BUFFER_BYTES) }
             val connection = DBusWireConnection(socket)
             try {
                 connection.performSasl()
@@ -495,6 +578,94 @@ internal class DBusWireConnection private constructor(private val socket: AFUNIX
 
         private fun encodeHex(bytes: ByteArray): String = buildString(bytes.size * 2) {
             for (b in bytes) append("%02x".format(b.toInt() and 0xff))
+        }
+    }
+}
+
+/**
+ * Walks an outgoing body value, appending the raw fd of every [UnixFd] to [fds] (depth-first, in
+ * body order) and replacing each with its 0-based index into that array. The marshaller then writes
+ * the index as the `h` (UNIX_FD) value while the real fds ride along via SCM_RIGHTS. Containers
+ * (structs, variants, arrays, dicts) recurse so fds nested anywhere in the body are handled.
+ */
+private fun collectOutboundFds(value: Any?, fds: MutableList<Int>): Any? = when (value) {
+    is UnixFd -> {
+        fds.add(value.fd)
+        fds.size - 1
+    }
+
+    is Message.JvmStructPayload ->
+        Message.JvmStructPayload(value.signature, value.fields.map { collectOutboundFds(it, fds) })
+
+    is Message.JvmVariantPayload ->
+        Message.JvmVariantPayload(value.signature, collectOutboundFds(value.value, fds))
+
+    is Map<*, *> ->
+        value.entries.associate { (k, v) ->
+            collectOutboundFds(k, fds) to collectOutboundFds(v, fds)
+        }
+
+    is List<*> -> value.map { collectOutboundFds(it, fds) }
+    is Array<*> -> value.map { collectOutboundFds(it, fds) }
+    else -> value
+}
+
+/**
+ * Signature-driven rewrite of a decoded incoming [value]: at every `h` position the demarshalled
+ * index is replaced with `fds[index]` (the received descriptor wrapped as a [UnixFd]). The wire
+ * value of an `h` is just an index, indistinguishable by type from an `i`, so the declared [type]
+ * is required to find them; containers recurse using their own embedded signatures.
+ */
+private fun resolveInboundFds(type: DBusType?, value: Any?, fds: List<UnixFd>): Any? = when (type) {
+    null -> value
+    is DBusType.Basic -> if (type.type == 'h') {
+        val index = (value as? Number)?.toInt()
+            ?: throw DBusMarshallingException("Expected an fd index for 'h', got $value")
+        fds.getOrNull(index)
+            ?: throw DBusMarshallingException(
+                "Unix fd index $index out of range (${fds.size} received)"
+            )
+    } else {
+        value
+    }
+
+    is DBusType.ArrayType -> when (val element = type.element) {
+        is DBusType.DictEntryType -> (value as? Map<*, *>)?.entries?.associate { (k, v) ->
+            resolveInboundFds(element.key, k, fds) to resolveInboundFds(element.value, v, fds)
+        } ?: value
+
+        else -> (value as? List<*>)?.map { resolveInboundFds(element, it, fds) } ?: value
+    }
+
+    is DBusType.StructType -> {
+        val payload = value as? Message.JvmStructPayload
+        if (payload == null) {
+            value
+        } else {
+            Message.JvmStructPayload(
+                payload.signature,
+                payload.fields.mapIndexed { i, field ->
+                    resolveInboundFds(type.fields.getOrNull(i), field, fds)
+                }
+            )
+        }
+    }
+
+    is DBusType.DictEntryType -> value // reached only via ArrayType above
+    DBusType.VariantType -> {
+        val payload = value as? Message.JvmVariantPayload
+        if (payload == null) {
+            value
+        } else {
+            val innerTypes = DBusSignatureParser.parse(payload.signature)
+            Message.JvmVariantPayload(
+                payload.signature,
+                if (innerTypes.size == 1) {
+                    resolveInboundFds(innerTypes.first(), payload.value, fds)
+                } else {
+                    payload.value
+                }
+            )
         }
     }
 }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
@@ -1,5 +1,9 @@
 package com.monkopedia.sdbus.internal.jvmdbus
 
+import com.monkopedia.sdbus.JvmUnixFdSupport
+import com.monkopedia.sdbus.UnixFd
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -121,6 +125,121 @@ class DBusWireConnectionTest {
         } finally {
             subscription.close()
             connection.close()
+        }
+    }
+
+    /**
+     * Real SCM_RIGHTS round-trip closing #83: a UnixFd is sent from one owned connection to another
+     * as a method-call argument; the fd genuinely traverses the dbus daemon (which relays passed
+     * fds via SCM_RIGHTS, dup-ing them into a separate process and back), so the descriptor the
+     * server receives is a LIVE duplicate of the original pipe read-end -- proven by reading, from
+     * the received fd, the exact bytes written into the original write-end before the call.
+     */
+    @Test
+    fun unixFd_roundTripsAcrossConnections_throughDaemon_asLiveDuplicate() = runBlocking {
+        if (!JvmUnixFdSupport.supportsFdDuplicationSemantics) return@runBlocking
+        val server = connectOrNull() ?: return@runBlocking
+        val client = connectOrNull() ?: run {
+            server.close()
+            return@runBlocking
+        }
+        if (!server.unixFdNegotiated || !client.unixFdNegotiated) {
+            client.close()
+            server.close()
+            return@runBlocking
+        }
+        val pipe = JvmUnixFdSupport.createPipePair() ?: run {
+            client.close()
+            server.close()
+            return@runBlocking
+        }
+        val (readFd, writeFd) = pipe
+        val busName = "com.monkopedia.sdbus.wire.fdtest.s${System.nanoTime()}"
+        val path = "/com/monkopedia/sdbus/wire/fdtest"
+        val iface = "com.monkopedia.sdbus.wire.FdTest"
+        val payload = "live-dup-through-scm-rights"
+        val receivedBytes = CompletableDeferred<String>()
+
+        server.setIncomingCallHandler { message ->
+            try {
+                if (message.member == "SendFd" && message.interfaceName == iface) {
+                    val received = message.body.firstOrNull() as? UnixFd
+                    if (received == null) {
+                        receivedBytes.completeExceptionally(
+                            AssertionError("server did not receive a UnixFd; body=${message.body}")
+                        )
+                    } else {
+                        receivedBytes.complete(readFromFd(received.fd, 128))
+                        server.send(
+                            WireMessage(
+                                type = WireMessageType.METHOD_RETURN,
+                                replySerial = message.serial,
+                                destination = message.sender,
+                                signature = "b",
+                                body = listOf(true)
+                            )
+                        )
+                        received.release()
+                    }
+                }
+            } catch (t: Throwable) {
+                receivedBytes.completeExceptionally(t)
+            }
+        }
+
+        try {
+            assertEquals(1, server.requestName(busName), "server should own $busName")
+            // Buffer the known bytes in the pipe before sending the read-end, so the server can
+            // read them straight out of the received duplicate.
+            writeToFd(writeFd, payload)
+            val sent = UnixFd(readFd) // duplicates; we retain ownership of readFd
+            try {
+                val reply = withTimeout(5_000) {
+                    client.call(
+                        WireMessage(
+                            type = WireMessageType.METHOD_CALL,
+                            destination = busName,
+                            path = path,
+                            interfaceName = iface,
+                            member = "SendFd",
+                            signature = "h",
+                            body = listOf(sent)
+                        )
+                    )
+                }
+                assertEquals("b", reply.signature)
+                assertEquals(true, reply.body.first(), "server should acknowledge the fd")
+                assertEquals(
+                    payload,
+                    withTimeout(5_000) { receivedBytes.await() },
+                    "the received fd must be a live duplicate of the pipe read-end"
+                )
+            } finally {
+                sent.release()
+            }
+        } finally {
+            JvmUnixFdSupport.closeFd(readFd)
+            JvmUnixFdSupport.closeFd(writeFd)
+            client.close()
+            server.close()
+        }
+    }
+
+    // Writes [text] to a duplicate of [fd] so the original descriptor is left intact for the caller.
+    private fun writeToFd(fd: Int, text: String) {
+        val dup = JvmUnixFdSupport.checkedDup(fd)
+        FileOutputStream(JvmUnixFdSupport.descriptorForFd(dup)).use {
+            it.write(text.toByteArray(Charsets.UTF_8))
+        }
+    }
+
+    // Reads up to [max] bytes from a duplicate of [fd], leaving the original descriptor intact.
+    private fun readFromFd(fd: Int, max: Int): String {
+        val dup = JvmUnixFdSupport.checkedDup(fd)
+        return FileInputStream(JvmUnixFdSupport.descriptorForFd(dup)).use { stream ->
+            val buffer = ByteArray(max)
+            val read = stream.read(buffer)
+            String(buffer, 0, read.coerceAtLeast(0), Charsets.UTF_8)
         }
     }
 


### PR DESCRIPTION
## Phase 5 of epic #93 — SCM_RIGHTS unix-fd passing over the owned connection

Wires file-descriptor passing through the self-owned junixsocket D-Bus connection so UnixFds round-trip natively (no dbus-java) — in method-call args, method replies, and signals alike. Closes the #83 JVM fd wire-test gap.

### Send / receive mechanism (SCM_RIGHTS)
- Outgoing (DBusWireConnection.writeMessage): a depth-first, body-order walk collects every UnixFd in the body and replaces each with its 0-based index into the attachment array. Under the existing writeLock the raw fds are attached via junixsocket setOutboundFileDescriptors immediately before the framed write, so the kernel delivers them with this message's bytes (D-Bus associates passed fds with the message carrying UNIX_FDS). Pending outbound fds are cleared defensively after the send.
- Incoming: the connect path sizes the ancillary receive buffer (ensureAncillaryReceiveBufferSize). After each frame the reader drains junixsocket's received descriptors into a FIFO; a message declaring UNIX_FDS takes that many in arrival order.

### UNIX_FDS header + index semantics
- The h type stays marshalled as a uint32 index (unchanged); the header UNIX_FDS field (code 9) is set to the fd count on send and read on receive. Outgoing: each h body value is the 0-based index, in attachment order, into the fd array. Incoming: a signature-driven walk rewrites each h index N to the Nth received descriptor (containers — structs / variants / arrays / dicts — recurse, since an h index is type-indistinguishable from an i and needs the declared signature to locate).

### Bridge + fd ownership
- Outbound ints become throwaway FileDescriptors via junixsocket NativeUnixSocket.initFD; the kernel dup-on-send leaves our fd open.
- Received descriptors are duplicated so the resulting UnixFd owns an independent fd, then the junixsocket-owned original is closed — closing the object fires junixsocket's attached close-callback, evicting it from the received-fd table — so received fds are neither leaked until socket close nor double-closed. The UnixFd is the sole owner and closes its fd on release/GC.

### Cross-process round-trip test (closes #83)
- DBusWireConnectionTest.unixFd_roundTripsAcrossConnections_throughDaemon_asLiveDuplicate: a UnixFd is sent from one owned connection to another as a method-call arg. The fd genuinely traverses the dbus daemon (which relays passed fds via SCM_RIGHTS, dup-ing them into a separate process and back). Proven a LIVE duplicate: bytes written into the original pipe write-end are read back from the received fd.
- cross_test DbusmockTypeMatrixTest.unixFd_passesThroughForeignPeer_whereSupported: previously SKIPPED on JVM for JPMS reasons; now un-gated on the wire backend by surfacing real pipes through junixsocket's native primitives. The fd crosses to an independent dbusmock peer process and back, and the echoed fd is verified to be a live dup (write through original / read from received). This runs in CI wire-client-parity-x64.

### JPMS flags
None required. The fd <-> FileDescriptor bridge uses junixsocket's native methods (initFD/getFD/duplicate/close), not reflection into java.base/java.io, so no `--add-opens` was needed and none was added. The legacy dbus-java fd path (which would need add-opens) is left skipped on JVM rather than newly requiring flags for the backend being retired in phase 6.

### Verification
- ktlintFormat, ktlintCheck, apiCheck — apiCheck is a no-op (all changes are internal: new helpers on internal JvmUnixFdSupport, internal DBusWireConnection; UnixFd public surface unchanged). compileKotlinLinuxX64 green.
- Full parity, both toggle states (peer engaged, DBUSMOCK_PYTHON set): `:jvmTest` + `:cross_test:jvmTest` green with `-Dsdbus.jvm.wire=true` (wire ON, incl. both new fd round-trip tests executing — not skipped) AND without the toggle (wire OFF / dbus-java regression).

Fixes #83.
Refs #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
