### PR TITLE
Fix generated-adaptor property getter to serialize the value (#89)

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyVTableItem.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyVTableItem.kt
@@ -141,8 +141,10 @@ class PropertyVTableItem @PublishedApi internal constructor(
      */
     inline fun <reified T : Any> with(receiver: KProperty0<T>) {
         signature = Signature(signatureOf<T>().value)
-        getter = {
-            receiver.get()
+        getter = { reply ->
+            // Serialize the property value into the reply, mirroring withGetter; returning the
+            // value from the lambda is not enough — the callback type is (PropertyGetReply) -> Unit.
+            reply.serialize<T>(receiver.get())
         }
         if (receiver is KMutableProperty0) {
             setter = {

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -44,6 +44,11 @@ class CommonApiIntegrationTest {
     @Serializable
     private data class Point(val x: Int, val y: Int)
 
+    // Backs the generated-adaptor `with(::prop)` binding exercised by the #89 regression test.
+    private class PropertyHolder {
+        var value: Int = 0
+    }
+
     private data class FixtureIds(
         val service: ServiceName,
         val path: ObjectPath,
@@ -1241,6 +1246,62 @@ class CommonApiIntegrationTest {
             val allAsync = propertiesProxy.getAllAsync(ids.iface)
             assertTrue(stateProperty in allAsync)
             assertTrue(allAsync[stateProperty]?.let { it.get<Boolean>() } == false)
+        } finally {
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
+    // Regression for #89: the generated-adaptor property binding path. AdaptorGenerator emits
+    // `with(this@Adaptor::<prop>)` for every property, and `with(KProperty0)` used to discard the
+    // value returned by the getter (`getter = { receiver.get() }`) instead of serializing it into
+    // the reply. That produced an empty Properties.Get/GetAll reply on the wire, breaking property
+    // reads for every codegen adaptor on native. This test binds via `with(::prop)` (NOT
+    // withGetter/withSetter) and performs a real remote Get/GetAll, asserting the real value comes
+    // back. It fails on main (empty/wrong value) and passes once the getter serializes.
+    @Test
+    fun propertiesProxy_supportsGetAndGetAllViaKotlinPropertyBinding() = runBlocking {
+        val ids = uniqueFixtureIds("propertiesKProp")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val countProperty = PropertyName("count")
+        val holder = PropertyHolder()
+        holder.value = 42
+        val obj = createObject(serverConnection, ids.path)
+        val registration = obj.addVTable(ids.iface) {
+            prop(countProperty) {
+                with(holder::value)
+            }
+        }
+        serverConnection.startEventLoop()
+        proxyConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path)
+        val propertiesProxy = PropertiesProxy(proxy)
+
+        try {
+            // Remote Properties.Get must return the real backing value, not an empty reply.
+            assertEquals(
+                42,
+                PropertiesProxy.run { propertiesProxy.get<Int>(ids.iface, countProperty) }
+            )
+
+            // GetAll must include the property with its real value.
+            val all = propertiesProxy.getAll(ids.iface)
+            assertTrue(countProperty in all)
+            assertEquals(42, all[countProperty]?.get<Int>())
+
+            // The mutable binding (KMutableProperty0) round-trips a Set back into the property.
+            PropertiesProxy.run {
+                propertiesProxy.set(ids.iface, countProperty, 7)
+            }
+            assertEquals(7, holder.value)
+            assertEquals(
+                7,
+                PropertiesProxy.run { propertiesProxy.get<Int>(ids.iface, countProperty) }
+            )
         } finally {
             registration.release()
             proxy.release()


### PR DESCRIPTION
## The bug

`PropertyVTableItem.with(receiver: KProperty0<T>)` installed a getter that computed the property value and then threw it away:

    getter = { receiver.get() }   // value evaluated, never written

`PropertyGetCallback` is `(msg: PropertyGetReply) -> Unit` — the getter must serialize the value INTO the reply, exactly like `withGetter` does. Since the value was never appended, a remote `org.freedesktop.DBus.Properties.Get` / `GetAll` produced a malformed empty reply; on native sd-bus this drops the connection (`Error.Disconnected: Connection reset by peer`).

`AdaptorGenerator` emits `with(this@<Adaptor>::<prop>)` for every generated property, so this broke property reads for **every codegen-generated service adaptor on native** — the library's primary server-side use case. It hid because prior tests exercised us as a client against mock servers, own-server JVM tests route through `JvmStaticDispatch` (bypassing wire serialization), and nothing did a real remote Get against a native adaptor.

## The fix

Serialize into the reply, mirroring `withGetter`:

    getter = { reply -> reply.serialize<T>(receiver.get()) }

The setter path (`KMutableProperty0`) was already correct and is unchanged. No codegen change (it keeps emitting `with(::prop)`, now correct); golden fixtures unchanged; `apiDump` is a no-op (behavior-only; `api/` diff empty).

## Regression test

Added `propertiesProxy_supportsGetAndGetAllViaKotlinPropertyBinding` to `CommonApiIntegrationTest`. It registers a property via the generated-style `prop { with(::someProp) }` path (NOT `withGetter`), serves it, and has a client `Get`/`GetAll` it asserting the real value returns; it also round-trips a `Set` through the mutable binding.

Confirmed it **FAILS on main without the fix** (`linuxX64Test`: `Error.Disconnected: Connection reset by peer`) and **PASSES with it** — a genuine regression test, not a tautology.

## Verification

- `ktlintCheck`, `apiCheck` — pass; `apiDump` no-op (`git diff -- api/` empty)
- `compileKotlinLinuxX64` — pass
- full `:linuxX64Test` (native — the affected backend) — pass, including the new test
- `:jvmTest :cross_test:jvmTest` with dbusmock — pass (no JVM/wire regression)

Fixes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
