### PR TITLE
Release 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ introspection XML files, conventionally placed in `src/dbusMain`.
 ```
 plugins {
     ...
-    id("com.monkopedia.sdbus.plugin") version "0.4.5"
+    id("com.monkopedia.sdbus.plugin") version "0.5.0"
 }
 
 sdbus {
@@ -92,7 +92,7 @@ module with implementations for `jvm`, `linuxX64`, and `linuxArm64`. Add the dep
 ```
 val nativeMain by getting {
     dependencies {
-       implementation("com.monkopedia:sdbus-kotlin:0.4.5")
+       implementation("com.monkopedia:sdbus-kotlin:0.5.0")
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.4.5
+version=0.5.0
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/samples/bluez-scan/build.gradle.kts
+++ b/samples/bluez-scan/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization)
                 implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
-                implementation("com.monkopedia:sdbus-kotlin:0.4.5")
+                implementation("com.monkopedia:sdbus-kotlin:0.5.0")
             }
         }
         val nativeTest by getting {

--- a/samples/demo-service/README.md
+++ b/samples/demo-service/README.md
@@ -30,10 +30,10 @@ produce `DemoService1`, `DemoService1Adaptor`, and `DemoService1Proxy` into the 
 This sample is part of the sdbus-kotlin repository and must demonstrate the **current** API
 (post-0.5.0: `startEventLoop`/`stopEventLoop`, `withGetter`/`withSetter`, typed property flows,
 `Duration` timeouts, etc.). That API does **not** exist in the artifact published to Maven Central
-(0.4.5). So, exactly like `bluez-scan`, [`settings.gradle.kts`](settings.gradle.kts) uses a Gradle
+(0.5.0). So, exactly like `bluez-scan`, [`settings.gradle.kts`](settings.gradle.kts) uses a Gradle
 **composite build** (`includeBuild("../..")`). Gradle automatically substitutes the
 `com.monkopedia:sdbus-kotlin` dependency declared in `build.gradle.kts` with the local source tree,
-so the version coordinate there (`0.4.5`) is only a placeholder and the sample always compiles
+so the version coordinate there (`0.5.0`) is only a placeholder and the sample always compiles
 against the library checked out next to it. No `publishToMavenLocal` step is required.
 
 ## Running

--- a/samples/demo-service/build.gradle.kts
+++ b/samples/demo-service/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
                 implementation(kotlin("stdlib"))
                 // Version is a placeholder: the composite build in settings.gradle.kts
                 // substitutes this with the local sdbus-kotlin source tree.
-                implementation("com.monkopedia:sdbus-kotlin:0.4.5")
+                implementation("com.monkopedia:sdbus-kotlin:0.5.0")
             }
         }
     }


### PR DESCRIPTION
## Release 0.5.0 — ready for the owner to cut

Version bump **0.4.5 → 0.5.0** across gradle.properties, the README install snippets, and the sample build coordinates. This supersedes the stale draft #64 (which predated the README rewrite and ~50 commits of work).

### What 0.5.0 contains
- **1.0 ABI freeze** (#57–63): the public API is frozen; see CHANGELOG.md `[0.5.0]` for the full old→new migration guide.
- **JVM backend rewrite** (epic #93): the JVM backend no longer uses dbus-java — it owns its D-Bus connection (junixsocket + a pure-Kotlin marshaller + dispatch), with cross-process serving (#90) and unix-fd passing (#83). The dbus-java runtime dependency is dropped from the published `-jvm` artifact.
- **Independent-peer test coverage** (#70/73/75/76): python-dbusmock suites (type matrix, signals, ObjectManager, Secret Service, BlueZ).
- **Bug fixes**: JVM wire marshalling (#78), JVM timeout/unreachable-bus behavior (#85), native heap-corruption race / the "ARM async flake" (#86), generated-adaptor property getters (#89).
- **Docs**: rewritten README (#77), backend parity matrix (#79/#91), server-side sample (#88), CHANGELOG + dokka overview (#105).

### To cut the release (owner)
1. Merge this PR to main.
2. Create a GitHub release **`v0.5.0`** → `publish.yaml` publishes all coordinates to Maven Central (vanniktech, automaticRelease), and `pages.yaml` deploys the dokka docs.
3. Optionally finalize the CHANGELOG `[0.5.0]` date (currently `unreleased`) — can be done in this PR or a follow-up.

Per policy this is a tier-3 release: it does not auto-merge. CI must be green first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
