### PR TITLE
Stamp CHANGELOG 0.5.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to sdbus-kotlin are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - unreleased
+## [0.5.0] - 2026-06-13
 
 0.5.0 is the **1.0 API-freeze** release. It does two big things:
 


### PR DESCRIPTION
Finalize the CHANGELOG `[0.5.0]` header date now that 0.5.0 is released (was the `unreleased` placeholder). Docs-only.

Fixes the one post-release loose end.
