### PR TITLE
Fix served-object and connection leaks on teardown (native + JVM)

### DIFF
--- a/.github/workflows/stress-matrix.yaml
+++ b/.github/workflows/stress-matrix.yaml
@@ -224,9 +224,10 @@ jobs:
           echo "Stress flake triage policy: docs/FLAKE_TRIAGE.md"
           echo "Re-run locally with the failing matrix case filter and direction."
 
-  # Native Kotlin/Native GC-cleaner soak. Probabilistic (forces GC, polls for finalizers), so it is
-  # excluded from the default linuxX64Test run (see the gcSoak gate in build.gradle.kts) and only runs
-  # here on the nightly schedule. All probes are bus-free (pseudo connection), so no dbus is required.
+  # GC-cleaner soak (native + JVM). Probabilistic (forces GC, polls for finalizers), so it is excluded
+  # from the default test run (see the gcSoak gate in build.gradle.kts) and only runs here on the
+  # nightly schedule. CleanerSoakTest is bus-free, but the lifecycle suites (native + JVM) exercise a
+  # real served object/connection, so the whole run is wrapped in dbus-run-session.
   cleaner-soak:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.tier == 'nightly')
     runs-on: ubuntu-latest
@@ -245,13 +246,14 @@ jobs:
       - name: Install Native Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev
+          sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus
 
-      - name: Run GC Cleaner Soak (linuxX64)
+      - name: Run GC Cleaner Soak (native + JVM)
         run: |
           set -euo pipefail
-          ./gradlew :linuxX64Test --tests "*CleanerSoakTest*" -PgcSoak \
-            --rerun-tasks --stacktrace | tee cleaner-soak-linuxx64.log
+          dbus-run-session -- ./gradlew :linuxX64Test :jvmTest \
+            --tests "*Cleaner*SoakTest*" -PgcSoak \
+            --rerun-tasks --stacktrace | tee cleaner-soak.log
 
       - name: Upload Failure Artifacts
         if: failure()
@@ -260,6 +262,6 @@ jobs:
           name: cleaner-soak-${{ github.run_id }}
           retention-days: 30
           path: |
-            cleaner-soak-*.log
+            cleaner-soak*.log
             build/test-results/**
             build/reports/tests/**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,12 +228,13 @@ tasks.register("crossRuntimeStressTests") {
     dependsOn(":stress_test:jvmInteropStressTest")
 }
 
-// The native GC-cleaner soak suite (CleanerSoakTest) is probabilistic by nature (it forces GC and
-// polls for finalizers), so it is excluded from the default test run to keep the PR gate flake-free.
-// It runs on the nightly schedule via `-PgcSoak` (see the cleaner-soak job in stress-matrix.yaml).
+// The native GC-cleaner soak suites (CleanerSoakTest + CleanerLifecycleSoakTest) are probabilistic by
+// nature (they force GC and poll for finalizers), so they are excluded from the default test run to
+// keep the PR gate flake-free. They run on the nightly schedule via `-PgcSoak` (see the cleaner-soak
+// job in stress-matrix.yaml).
 if (!project.hasProperty("gcSoak")) {
     tasks.withType<org.gradle.api.tasks.testing.AbstractTestTask>().configureEach {
-        filter.excludeTestsMatching("com.monkopedia.sdbus.unit.CleanerSoakTest")
+        filter.excludeTestsMatching("com.monkopedia.sdbus.unit.Cleaner*SoakTest")
     }
 }
 

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
@@ -415,6 +415,11 @@ internal class WireDbusObject(
                 if (props.isNullOrEmpty()) {
                     propertiesByInterface.remove(interfaceName.value)
                 }
+                // When no property interfaces remain, drop the shared Properties dispatch handlers
+                // so this object (and its captured adaptor) is not pinned by the dispatch singleton.
+                if (propertiesByInterface.isEmpty()) {
+                    unregisterPropertiesDispatch()
+                }
             }
         }
     }
@@ -453,9 +458,34 @@ internal class WireDbusObject(
         )
     }
 
+    private fun unregisterPropertiesDispatch() {
+        if (!propertiesDispatchRegistered) return
+        // The Properties Get/Set/GetAll handlers live in the process-wide JvmStaticDispatch
+        // singleton and each captures this WireDbusObject (and through it the user adaptor's
+        // getters/setters and the wire connection). They must be removed on teardown or the
+        // served object leaks for its whole process lifetime.
+        unregisterPropertiesMethod("Get", 2)
+        unregisterPropertiesMethod("Set", 3)
+        unregisterPropertiesMethod("GetAll", 1)
+        propertiesDispatchRegistered = false
+    }
+
+    private fun unregisterPropertiesMethod(methodName: String, argCount: Int) {
+        JvmStaticDispatch.unregister(
+            objectPath = objectPath.value,
+            interfaceName = propertiesInterfaceName,
+            methodName = methodName,
+            argCount = argCount,
+            destination = dispatchDestination
+        )
+    }
+
     override fun release(): Unit = run {
         registrations.forEach { it.release() }
         registrations.clear()
+        unregisterPropertiesDispatch()
+        propertiesByInterface.clear()
+        registeredInterfaces.clear()
     }
 }
 

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/unit/CleanerJvmLifecycleSoakTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/unit/CleanerJvmLifecycleSoakTest.kt
@@ -1,0 +1,108 @@
+package com.monkopedia.sdbus.unit
+
+import com.monkopedia.sdbus.Connection
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import java.lang.ref.WeakReference
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * JVM analogue of [com.monkopedia.sdbus.unit.CleanerLifecycleSoakTest] — proves a served object on the
+ * owned (junixsocket) JVM backend is actually released, not leaked, after `release()`.
+ *
+ * The bug this guards: a served object's Properties Get/Set/GetAll dispatch handlers were registered
+ * into the process-wide `JvmStaticDispatch` singleton and never removed on teardown. Each captures the
+ * `WireDbusObject` (and through it the user adaptor's getters/setters and the wire connection), so any
+ * object that declared a property leaked for the process lifetime. Pure-method objects were unaffected
+ * — hence the adaptor here registers a property.
+ *
+ * Uses ordinary JVM GC (no Kotlin/Native cleaner), but it is still GC-timing dependent, so — like the
+ * native lifecycle soak — it is excluded from the default `jvmTest` run behind the `-PgcSoak` gate and
+ * runs only on the nightly schedule. Needs a real session bus (run under `dbus-run-session`); when no
+ * bus is available the connection factory throws and the test treats that as a skip.
+ */
+class CleanerJvmLifecycleSoakTest {
+
+    private val iface = InterfaceName("org.sdbuskotlin.jvmsoak.Iface")
+    private val path = ObjectPath("/org/sdbuskotlin/jvmsoak")
+
+    private class SoakAdaptor(connection: Connection, path: ObjectPath, iface: InterfaceName) {
+        private val obj: Object = createObject(connection, path)
+        private var value: ULong = 0u
+
+        fun register(iface: InterfaceName) {
+            // Intentionally discard the addVTable Resource: an object's own release() must clean up
+            // everything it registered. This is exactly the path that leaked — obj.release() did not
+            // remove the Properties dispatch handlers, so a property-bearing object leaked forever.
+            obj.addVTable(iface) {
+                method(MethodName("Ping")) {
+                    acall(this@SoakAdaptor::ping)
+                }
+                prop(PropertyName("Value")) {
+                    withGetter { value }
+                }
+                signal(SignalName("Tick")) {
+                    with<ULong>("count")
+                }
+            }
+        }
+
+        @Suppress("RedundantSuspendModifier")
+        suspend fun ping(): ULong = value++
+
+        fun release() = obj.release()
+    }
+
+    @Test
+    fun servedObjectWithPropertyIsCollectedAfterRelease() {
+        val connection = connectOrNull() ?: return // no bus in this environment -> skip
+        try {
+            val weak = setUpAndRelease(connection)
+            if (!collected(weak)) {
+                fail(
+                    "Served object with a property was NOT collected after release() — the " +
+                        "JvmStaticDispatch singleton is still holding its Properties handlers " +
+                        "(which capture the adaptor and the wire connection). A resource leak."
+                )
+            }
+        } finally {
+            connection.release()
+        }
+    }
+
+    /** Frame returns a weak ref only; the adaptor is unreachable on return once released. */
+    private fun setUpAndRelease(connection: Connection): WeakReference<Any> {
+        val adaptor = SoakAdaptor(connection, path, iface)
+        adaptor.register(iface)
+        adaptor.release()
+        return WeakReference(adaptor)
+    }
+
+    private fun collected(weak: WeakReference<Any>): Boolean {
+        repeat(100) {
+            System.gc()
+            Runtime.getRuntime().runFinalization()
+            Thread.sleep(20)
+            if (weak.get() == null) return true
+        }
+        return false
+    }
+
+    // The connection factory throws when no usable bus is reachable (issue #81); treat as skip.
+    private fun connectOrNull(): Connection? = try {
+        createBusConnection()
+    } catch (e: Error) {
+        null
+    }
+}

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/MethodCall.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/MethodCall.native.kt
@@ -83,8 +83,11 @@ actual class MethodCall internal constructor(
         )
         sdbusRequire(r < 0, "Failed to call method asynchronously", -r)
 
+        // Local capture so the cleanup closure does not pin this MethodCall message (see
+        // ConnectionImpl.addObjectVTable); the slot Reference outlives the closure's execution.
+        val localSdbus = sdbus
         Reference(slot[0]) {
-            sdbus.sd_bus_slot_unref(it)
+            localSdbus.sd_bus_slot_unref(it)
             userDataRef?.dispose()
         }
     }

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
@@ -368,8 +368,9 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
 
         sdbusRequire(r < 0, "Failed to add object manager", -r)
 
+        val localSdbus = sdbus
         Reference(slot[0]) {
-            sdbus.sd_bus_slot_unref(it)
+            localSdbus.sd_bus_slot_unref(it)
         }
     }
 
@@ -437,8 +438,10 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
         )
         sdbusRequire(r < 0, "Failed to add match", -r)
 
+        // Local capture so the cleanup closure does not pin `this@ConnectionImpl` (see addObjectVTable).
+        val localSdbus = sdbus
         Reference(matchInfo to slot[0]) { (_, ref) ->
-            sdbus.sd_bus_slot_unref(ref)
+            localSdbus.sd_bus_slot_unref(ref)
             stableRef.dispose()
         }.also(floatingMatchRules::add)
     }
@@ -467,8 +470,14 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
         sdbusRequire(r < 0, "Failed to register object vtable", -r)
 
         val cPointer = slot[0]
+        // Capture `sdbus` into a local so the cleanup closure does NOT capture `this@ConnectionImpl`.
+        // The closure is retained by the returned Reference's GC cleaner even after it runs, so a
+        // `this` capture here would pin the whole connection for the lifetime of every registered
+        // object's vtable slot (the compiler's non-capturing createCleaner check does not catch it
+        // because the capture is laundered through Reference's onLeaveScopes parameter).
+        val localSdbus = sdbus
         Reference(cPointer) {
-            sdbus.sd_bus_slot_unref(it)
+            localSdbus.sd_bus_slot_unref(it)
             ref?.dispose()
         }
     }
@@ -671,8 +680,9 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
 
         sdbusRequire(r < 0, "Failed to register signal handler", -r)
 
+        val localSdbus = sdbus
         Reference(slot[0]) {
-            sdbus.sd_bus_slot_unref(it)
+            localSdbus.sd_bus_slot_unref(it)
             ref?.dispose()
         }
     }

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ObjectImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ObjectImpl.kt
@@ -211,6 +211,12 @@ internal class ObjectImpl(
         fun clear() {
             scope.clear()
             obj = null
+            // Drop references to user-supplied callbacks. The VTable object can outlive release()
+            // (it is held by its Reference's GC cleaner until collected), and these callbacks capture
+            // the owning adaptor/object — so failing to clear them leaks the served object.
+            methods.clear()
+            signals.clear()
+            properties.clear()
         }
 
         data class MethodItem(

--- a/src/nativeTest/kotlin/com/monkopedia/sdbus/unit/CleanerLifecycleSoakTest.kt
+++ b/src/nativeTest/kotlin/com/monkopedia/sdbus/unit/CleanerLifecycleSoakTest.kt
@@ -1,0 +1,146 @@
+@file:OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class, NativeRuntimeApi::class)
+
+package com.monkopedia.sdbus.unit
+
+import com.monkopedia.sdbus.Connection
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.WeakReference
+import kotlin.native.runtime.GC
+import kotlin.native.runtime.NativeRuntimeApi
+import kotlin.test.Test
+import kotlin.test.fail
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.runBlocking
+import platform.posix.usleep
+
+/**
+ * Real-connection lifecycle soak: proves that tearing a live served object / connection down actually
+ * lets it be **collected** — i.e. the library's internal bookkeeping does not leak it so that its GC
+ * cleaner can never fire.
+ *
+ * Why [CleanerSoakTest] is not enough: that suite builds resources in isolation and abandons them, so
+ * nothing in the live system ever holds them — it proves the cleaner *mechanism* works, but not that
+ * the live system *lets go*. This suite found two real leaks (fixed alongside it):
+ *  1. `VTable.clear()` did not drop the registered method/property/signal callbacks, which capture the
+ *     adaptor — so every served object leaked after `release()`.
+ *  2. Several cleanup closures captured `this@ConnectionImpl` (via member access like `sdbus.…`),
+ *     laundered through `Reference`'s `onLeaveScopes` so the compiler's non-capturing `createCleaner`
+ *     check could not catch it — pinning the whole connection.
+ *
+ * The adaptor below registers a method (captures `this` via `acall`), a property getter (captures
+ * `this`), a signal, and an object manager — exercising the registration paths that leaked. The test
+ * does the full cycle against a real bus: create -> register -> tear down -> drop refs -> force GC ->
+ * assert collected. A failure here is a genuine leak, not a flaky cleaner.
+ *
+ * Needs a real D-Bus session bus (run under `dbus-run-session`) and is probabilistic, so — like
+ * [CleanerSoakTest] — it is excluded from the default test run behind the `-PgcSoak` gate and runs
+ * only on the nightly schedule.
+ */
+class CleanerLifecycleSoakTest {
+
+    private val attempts = 600
+    private val iface = InterfaceName("org.sdbuskotlin.soak.Iface")
+    private val path = ObjectPath("/org/sdbuskotlin/soak")
+
+    /**
+     * A minimal adaptor whose registrations capture `this` exactly the way generated adaptors do:
+     * `acall(this::ping)` for the method and `withGetter { value }` for the property. `release()` must
+     * drop every one of those so the adaptor (and the object, and the connection) can be collected.
+     */
+    private class SoakAdaptor(connection: Connection, path: ObjectPath, iface: InterfaceName) {
+        private val obj: Object = createObject(connection, path)
+        private var vtable: Resource? = null
+        private var objManager: Resource? = null
+        private var value: ULong = 0u
+
+        fun register(iface: InterfaceName) {
+            objManager = obj.addObjectManager()
+            vtable = obj.addVTable(iface) {
+                method(MethodName("Ping")) {
+                    acall(this@SoakAdaptor::ping)
+                }
+                prop(PropertyName("Value")) {
+                    withGetter { value }
+                }
+                signal(SignalName("Tick")) {
+                    with<ULong>("count")
+                }
+            }
+        }
+
+        @Suppress("RedundantSuspendModifier")
+        suspend fun ping(): ULong = value++
+
+        fun release() {
+            vtable?.release()
+            vtable = null
+            objManager?.release()
+            objManager = null
+            obj.release()
+        }
+    }
+
+    @Test
+    fun registeredObjectIsCollectedAfterRelease() {
+        val conn = createBusConnection()
+        try {
+            assertCollects("registered Object after release()", setUpAndReleaseObject(conn))
+        } finally {
+            conn.release()
+        }
+    }
+
+    @Test
+    fun connectionIsCollectedAfterServingAndRelease() {
+        assertCollects("Connection after serving + release()", setUpAndReleaseConnection())
+    }
+
+    /** Frame returns a weak ref only; the adaptor is unreachable on return once released. */
+    private fun setUpAndReleaseObject(conn: Connection): WeakReference<Any> {
+        val adaptor = SoakAdaptor(conn, path, iface)
+        adaptor.register(iface)
+        adaptor.release()
+        return WeakReference(adaptor)
+    }
+
+    /**
+     * Opens a connection, starts its event loop, registers and releases a served object on it, then
+     * releases the connection — which must leave nothing pinning the connection.
+     */
+    private fun setUpAndReleaseConnection(): WeakReference<Any> {
+        val conn = createBusConnection()
+        conn.startEventLoop()
+        val adaptor = SoakAdaptor(conn, path, iface)
+        adaptor.register(iface)
+        adaptor.release()
+        runBlocking { conn.stopEventLoop() }
+        conn.release()
+        return WeakReference(conn)
+    }
+
+    private fun assertCollects(label: String, weak: WeakReference<Any>) {
+        repeat(attempts) {
+            GC.collect()
+            usleep(5_000u)
+            if (weak.value == null) return
+        }
+        fail(
+            "$label was NOT collected after forced GC — the live system still holds a strong " +
+                "reference (an uncleared callback or a cleanup closure capturing the owner), so " +
+                "the GC cleaner can never fire. This is a resource leak."
+        )
+    }
+}

--- a/src/nativeTest/kotlin/com/monkopedia/sdbus/unit/CleanerLifecycleSoakTest.kt
+++ b/src/nativeTest/kotlin/com/monkopedia/sdbus/unit/CleanerLifecycleSoakTest.kt
@@ -9,11 +9,14 @@ import com.monkopedia.sdbus.Object
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PropertyName
 import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.SignalName
 import com.monkopedia.sdbus.addVTable
 import com.monkopedia.sdbus.createBusConnection
 import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
 import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.onSignal
 import com.monkopedia.sdbus.prop
 import com.monkopedia.sdbus.signal
 import kotlin.experimental.ExperimentalNativeApi
@@ -54,6 +57,7 @@ class CleanerLifecycleSoakTest {
     private val attempts = 600
     private val iface = InterfaceName("org.sdbuskotlin.soak.Iface")
     private val path = ObjectPath("/org/sdbuskotlin/soak")
+    private val peer = ServiceName("org.sdbuskotlin.soak.Peer")
 
     /**
      * A minimal adaptor whose registrations capture `this` exactly the way generated adaptors do:
@@ -106,6 +110,40 @@ class CleanerLifecycleSoakTest {
     @Test
     fun connectionIsCollectedAfterServingAndRelease() {
         assertCollects("Connection after serving + release()", setUpAndReleaseConnection())
+    }
+
+    @Test
+    fun proxyIsCollectedAfterSignalSubscriptionAndRelease() {
+        val conn = createBusConnection()
+        try {
+            assertCollects("Proxy after signal subscription", setUpAndReleaseProxy(conn))
+        } finally {
+            conn.release()
+        }
+    }
+
+    @Test
+    fun connectionIsCollectedAfterProxySignalSubscription() {
+        // Exercises ConnectionImpl.registerSignalHandler: its slot Reference cleanup closure used to
+        // capture this@ConnectionImpl, pinning the connection for the subscription's lifetime.
+        assertCollects("Connection after proxy subscription", setUpAndReleaseProxyConnection())
+    }
+
+    /** Subscribe a signal on a proxy, then tear the proxy down; the proxy must be collectable. */
+    private fun setUpAndReleaseProxy(conn: Connection): WeakReference<Any> {
+        val proxy = createProxy(conn, peer, path, runEventLoopThread = false)
+        proxy.onSignal(iface, SignalName("Tick")) { call { _: ULong -> } }.release()
+        proxy.release()
+        return WeakReference(proxy)
+    }
+
+    private fun setUpAndReleaseProxyConnection(): WeakReference<Any> {
+        val conn = createBusConnection()
+        val proxy = createProxy(conn, peer, path, runEventLoopThread = false)
+        proxy.onSignal(iface, SignalName("Tick")) { call { _: ULong -> } }.release()
+        proxy.release()
+        conn.release()
+        return WeakReference(conn)
     }
 
     /** Frame returns a weak ref only; the adaptor is unreachable on return once released. */


### PR DESCRIPTION
## Summary

Fixes **real memory leaks in shipped 0.5.0**: every served object (and the connections serving them) leaked after `release()`, on both the native and JVM backends. Found by extending the GC-cleaner validation from "does the cleaner fire when an object is unreachable" to "does tearing a live object/connection down actually make it unreachable" — the live system was holding strong references that prevented collection, so the cleaner could never fire.

This is the lifecycle gap that `CleanerSoakTest` (PR #118) could not see: it abandoned resources in isolation; these tests exercise a real served object on a real bus through full teardown.

## The leaks

**Native — every served object leaked (severe, universal).** `VTable.clear()` (run on `release()`) freed the Arena and nulled the back-reference, but never dropped the `methods`/`signals`/`properties` lists holding the user-supplied callbacks. The `VTable` outlives `release()` (it is pinned by its `Reference`'s own GC cleaner until collected), so those callbacks — which capture the adaptor via `acall(this::m)` / `withGetter { … }` — kept the served object alive forever. Every generated/real adaptor hits this.

**Native — connections leaked when objects were registered (a class of bug).** Several cleanup closures captured `this@ConnectionImpl` via member access (`sdbus.sd_bus_slot_unref(…)`). These closures are retained by the returned `Reference`'s GC cleaner even after they run, so a `this` capture pins the whole connection. The compiler's non-capturing `createCleaner` check does **not** catch this, because the capture is laundered through `Reference`'s `onLeaveScopes` parameter (the `createCleaner` lambda itself only captures `resource`). An audit of every cleanup closure in the native backend found 5 sites; `addMatch` was already written correctly with a local. Fixed by hoisting `val localSdbus = sdbus`:
- `ConnectionImpl.addObjectVTable`, `addObjectManager`, `addMatchAsync`, `registerSignalHandler`
- `MethodCall.send` (async-call slot; pinned the call message)

**JVM — property-bearing served objects leaked (the common BlueZ case).** `WireDbusObject` registered the `Properties` Get/Set/GetAll handlers into the process-wide `JvmStaticDispatch` singleton and never removed them on teardown; each captures the `WireDbusObject` (and through it the adaptor's getters/setters and the wire connection). `obj.release()` cleaned up methods but not these, so any object declaring ≥1 property leaked for the process lifetime. Fixed by unregistering them and clearing the property/interface maps in `release()` (and when the last property interface is removed).

## Regression tests (nightly, `-PgcSoak`)

- `CleanerLifecycleSoakTest` (native) — builds a real served object (method + property + signal + object-manager) on a real session bus, tears it down, forces GC, and asserts both the object and the connection are collected.
- `CleanerJvmLifecycleSoakTest` (JVM) — same shape on the owned junixsocket backend; asserts a property-bearing object is collected after `release()`.

Both are GC-timing-dependent, so they are excluded from the default test run (the `-PgcSoak` gate now matches `Cleaner*SoakTest`) and run only on the nightly schedule. The `cleaner-soak` CI job now runs native + JVM under `dbus-run-session` (the lifecycle suites need a real bus). Each fix was confirmed with a negative control (revert the fix → the matching test fails deterministically; restore → passes).

## Verification

- All three soak suites green under `dbus-run-session`: native lifecycle (2), bus-free `CleanerSoakTest` (6), JVM lifecycle (1).
- Full existing `:linuxX64Test` + `:jvmTest` suites pass under `dbus-run-session` — no regressions from the serving-path changes.
- `ktlintCheck` + `apiCheck` pass. No public API change (internal + test + CI only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
