### PR TITLE
Fix cleaner-soak nightly job running the full suite instead of soak tests

### DIFF
--- a/.github/workflows/stress-matrix.yaml
+++ b/.github/workflows/stress-matrix.yaml
@@ -249,10 +249,11 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus
 
       - name: Run GC Cleaner Soak (native + JVM)
+        # `-PgcSoak` makes the build run ONLY the Cleaner*SoakTest suites (see build.gradle.kts); no
+        # `--tests` filter — that is unreliable across two test tasks and ran the full suite in CI.
         run: |
           set -euo pipefail
-          dbus-run-session -- ./gradlew :linuxX64Test :jvmTest \
-            --tests "*Cleaner*SoakTest*" -PgcSoak \
+          dbus-run-session -- ./gradlew :linuxX64Test :jvmTest -PgcSoak \
             --rerun-tasks --stacktrace | tee cleaner-soak.log
 
       - name: Upload Failure Artifacts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,12 +228,17 @@ tasks.register("crossRuntimeStressTests") {
     dependsOn(":stress_test:jvmInteropStressTest")
 }
 
-// The native GC-cleaner soak suites (CleanerSoakTest + CleanerLifecycleSoakTest) are probabilistic by
-// nature (they force GC and poll for finalizers), so they are excluded from the default test run to
-// keep the PR gate flake-free. They run on the nightly schedule via `-PgcSoak` (see the cleaner-soak
-// job in stress-matrix.yaml).
-if (!project.hasProperty("gcSoak")) {
-    tasks.withType<org.gradle.api.tasks.testing.AbstractTestTask>().configureEach {
+// The GC-cleaner soak suites (Cleaner*SoakTest) are probabilistic by nature (they force GC and poll
+// for finalizers), so by default they are EXCLUDED from every test run to keep the PR gate flake-free.
+// Passing `-PgcSoak` inverts this to run ONLY the soak suites (see the cleaner-soak job in
+// stress-matrix.yaml). Driving the selection from this gate — rather than a command-line `--tests`
+// filter — is deliberate: `--tests` across multiple test tasks (`:linuxX64Test :jvmTest`) is applied
+// to only one task and silently runs the other unfiltered, which ran the full integration suite in CI.
+tasks.withType<org.gradle.api.tasks.testing.AbstractTestTask>().configureEach {
+    if (project.hasProperty("gcSoak")) {
+        filter.isFailOnNoMatchingTests = false
+        filter.includeTestsMatching("com.monkopedia.sdbus.unit.Cleaner*SoakTest")
+    } else {
         filter.excludeTestsMatching("com.monkopedia.sdbus.unit.Cleaner*SoakTest")
     }
 }


### PR DESCRIPTION
## What

Fixes the nightly `cleaner-soak` job (added in #118/#119) which turned `main`'s scheduled run red.

## Root cause

The job ran `:linuxX64Test :jvmTest --tests "*Cleaner*SoakTest*"`. **Gradle applies a command-line `--tests` filter to only one of multiple test tasks and runs the others unfiltered** — so `linuxX64Test` ran the *entire* integration suite (280 tests) instead of the ~9 soak tests, while `jvmTest` was filtered correctly (1 test). The full integration suite fails under this job's environment, so the run went red. It looked green locally because the integration tests pass locally regardless of the filter.

## Fix

Drive the soak-test selection from the `-PgcSoak` gate in `build.gradle.kts` rather than a fragile cross-task `--tests` filter:
- default (no `-PgcSoak`): exclude `Cleaner*SoakTest` from every test task — **PR-gate behaviour unchanged**.
- with `-PgcSoak`: include **only** `Cleaner*SoakTest` (and `isFailOnNoMatchingTests = false`).

The CI job now runs `:linuxX64Test :jvmTest -PgcSoak` with no `--tests`, which reliably runs only the soak suites on both tasks.

## Verification (local)

- `-PgcSoak`: runs exactly the 3 Cleaner classes — `CleanerSoakTest` + `CleanerLifecycleSoakTest` (native) and `CleanerJvmLifecycleSoakTest` (JVM), green.
- Default run: full suite (27 JVM classes), `Cleaner*` absent, green.
- `ktlintCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
