### PR TITLE
Bound the JVM serve worker pool (deadlock-free, compensated)

### DIFF
--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -36,7 +36,9 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
@@ -112,12 +114,18 @@ internal class DBusWireConnection private constructor(
     @Volatile
     private var incomingCallHandler: ((WireMessage) -> Unit)? = null
 
-    // Worker pool for serving incoming calls. Off the reader thread so handler execution (and any
-    // nested call a handler makes back on this same connection) cannot block reads or deadlock the
-    // reader: the reader only enqueues, then keeps reading and completing pending-call futures.
-    private val serveExecutor = Executors.newCachedThreadPool { runnable ->
-        thread(start = false, isDaemon = true, name = "sdbus-jvm-wire-serve") { runnable.run() }
-    }
+    // Bounded, nested-dispatch-safe worker pool for serving incoming calls (issue #101). Off the
+    // reader thread so handler execution (and any nested call a handler makes back on this same
+    // connection) cannot block reads: the reader only enqueues, then keeps reading and completing
+    // pending-call futures. See [ServeWorkerPool] for why a bounded pool here is nonetheless free of
+    // the nested-same-connection-dispatch deadlock that a naive bound would introduce.
+    private val serveWorkers = ServeWorkerPool()
+
+    /** Steady-state worker bound of the serve pool (test/diagnostic visibility only). */
+    internal val serveBound: Int get() = serveWorkers.bound
+
+    /** High-water mark of live serve-worker threads (test/diagnostic visibility only). */
+    internal val serveLargestPoolSize: Int get() = serveWorkers.largestPoolSize
 
     @Volatile
     private var uniqueNameValue: String? = null
@@ -219,7 +227,7 @@ internal class DBusWireConnection private constructor(
                 // Hand off to a worker so the reader thread keeps draining the socket; a handler
                 // may itself call back on this connection and await a reply the reader delivers.
                 runCatching {
-                    serveExecutor.execute { runCatching { handler(message) } }
+                    serveWorkers.execute { runCatching { handler(message) } }
                 }
             }
         }
@@ -357,6 +365,10 @@ internal class DBusWireConnection private constructor(
         timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS
     ): WireMessage {
         val (serial, future) = dispatchCall(request)
+        // If a serve worker is making this (nested same-connection) call it is about to PARK
+        // waiting for a reply the reader delivers; compensate so the queued nested work still has a
+        // runnable worker (see [ServeWorkerPool]). A no-op off the serve pool.
+        val compensating = serveWorkers.beginNestedBlock()
         val reply = try {
             future.orTimeout(timeoutMillis, TimeUnit.MILLISECONDS).await()
         } catch (e: TimeoutException) {
@@ -365,6 +377,8 @@ internal class DBusWireConnection private constructor(
                 TIMEOUT_ERROR_NAME,
                 "Method call timed out after ${timeoutMillis}ms"
             )
+        } finally {
+            if (compensating) serveWorkers.endNestedBlock()
         }
         throwIfError(reply)
         return reply
@@ -376,6 +390,9 @@ internal class DBusWireConnection private constructor(
         timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS
     ): WireMessage {
         val (serial, future) = dispatchCall(request)
+        // A blocking nested call from a serve worker parks the worker until the reader delivers the
+        // reply; compensate so the queued nested work keeps a runnable worker (see [ServeWorkerPool]).
+        val compensating = serveWorkers.beginNestedBlock()
         val reply = try {
             future.get(timeoutMillis, TimeUnit.MILLISECONDS)
         } catch (e: TimeoutException) {
@@ -384,6 +401,8 @@ internal class DBusWireConnection private constructor(
                 TIMEOUT_ERROR_NAME,
                 "Method call timed out after ${timeoutMillis}ms"
             )
+        } finally {
+            if (compensating) serveWorkers.endNestedBlock()
         }
         throwIfError(reply)
         return reply
@@ -537,7 +556,7 @@ internal class DBusWireConnection private constructor(
 
     override fun close() {
         running = false
-        runCatching { serveExecutor.shutdownNow() }
+        runCatching { serveWorkers.shutdownNow() }
         runCatching { socket.close() }
         readerThread?.let { reader ->
             if (reader !== Thread.currentThread()) {
@@ -643,6 +662,131 @@ internal class DBusWireConnection private constructor(
         private fun encodeHex(bytes: ByteArray): String = buildString(bytes.size * 2) {
             for (b in bytes) append("%02x".format(b.toInt() and 0xff))
         }
+    }
+}
+
+/**
+ * Bounded, nested-dispatch-safe worker pool that serves incoming METHOD_CALL messages off the
+ * reader thread (issue #101).
+ *
+ * Why bounded: serving previously used [java.util.concurrent.Executors.newCachedThreadPool], which
+ * creates one thread per concurrently-served call, so a flood of slow or blocking handlers grew the
+ * thread (and stack/memory) count without limit — a resource-exhaustion hazard. This pool keeps a
+ * fixed [bound] of worker threads (a small multiple of the CPU count) and lets surplus calls QUEUE,
+ * so a burst of slow handlers degrades into latency rather than unbounded thread growth.
+ *
+ * Why a naive bound would be WORSE than unbounded — the nested-same-connection-dispatch deadlock: a
+ * served handler may itself make a synchronous call back on THIS connection whose target is also
+ * served here. Concretely handler X (on a worker thread) calls `callBlocking` -> the request goes
+ * out on the wire -> the daemon routes it back to us -> the reader reads it as a METHOD_CALL and
+ * submits handler Y -> Y replies -> the reader completes X's future. So X PARKS on a worker thread
+ * waiting for Y, and Y needs its OWN worker thread. With a fixed bound whose workers are all parked
+ * (e.g. a flood of such handlers), Y can never get a thread and the chain deadlocks forever.
+ * `newCachedThreadPool` avoided this only by always conjuring a spare thread.
+ *
+ * How this stays deadlock-free — ForkJoinPool-style COMPENSATION. The reader is the SOLE submitter
+ * and must never run a handler inline (it has to stay free to read the very replies that unpark
+ * parked workers), so the queue is unbounded and [execute] never blocks or rejects. Live-thread
+ * capacity is governed purely by `corePoolSize` (with an unbounded queue the pool never spawns
+ * threads beyond `corePoolSize`). Whenever a WORKER thread is about to park on a nested
+ * same-connection call it calls [beginNestedBlock], which raises `corePoolSize` by one and
+ * pre-starts a replacement worker; [endNestedBlock] lowers it again. Therefore at every instant
+ *
+ *     live worker threads == bound + (workers currently parked on a nested call),
+ *
+ * i.e. there are always at least [bound] RUNNABLE workers no matter how many are parked. A nested
+ * chain of depth D parks at most D-1 workers, each compensated, so Y (and the rest of the chain)
+ * always finds a thread: the pool is deadlock-free at any nesting depth.
+ *
+ * What stays bounded is exactly the dangerous case: a flood of INDEPENDENT slow handlers never
+ * compensates (they never call back on this connection), so the worker count stays pinned at
+ * [bound] and the excess simply queues. Threads grow ONLY by the number of handlers genuinely
+ * parked on nested dispatch — the irreducible minimum for those to make progress at all (N
+ * concurrently-parked nested handlers cannot be served by fewer than ~N threads without deadlock).
+ * Surplus compensating workers retire once idle (`allowCoreThreadTimeOut`), shrinking the pool back
+ * to [bound] after a nested-dispatch storm subsides.
+ */
+private class ServeWorkerPool {
+    /** Steady-state worker count: ~2x CPUs, clamped so it is neither starved nor wildly large. */
+    val bound: Int =
+        (Runtime.getRuntime().availableProcessors() * 2).coerceIn(MIN_BOUND, MAX_BOUND)
+
+    // Marks threads owned by this pool, so a nested blocking call made from inside a handler can be
+    // detected (it runs on one of these threads) and compensated for; see [beginNestedBlock].
+    private val onWorkerThread = ThreadLocal.withInitial { false }
+    private val threadCounter = AtomicInteger(0)
+
+    // Guards corePoolSize mutations and [parked]; the invariant corePoolSize == bound + parked is
+    // maintained only under this lock so concurrent nested blocks compose correctly.
+    private val poolLock = Any()
+    private var parked = 0
+
+    private val executor = ThreadPoolExecutor(
+        bound,
+        // Unreachable in practice: with the unbounded queue below the pool never grows past
+        // corePoolSize, so the live-thread count is driven entirely by corePoolSize (which
+        // compensation adjusts). A generous ceiling just keeps setCorePoolSize legal.
+        Int.MAX_VALUE,
+        WORKER_KEEPALIVE_SECONDS,
+        TimeUnit.SECONDS,
+        // Unbounded: the reader must never block or reject on submit (it has to keep reading the
+        // replies that unpark parked workers), so surplus calls queue instead.
+        LinkedBlockingQueue(),
+        ThreadFactory { runnable ->
+            thread(
+                start = false,
+                isDaemon = true,
+                name = "sdbus-jvm-wire-serve-${threadCounter.incrementAndGet()}"
+            ) {
+                onWorkerThread.set(true)
+                runnable.run()
+            }
+        }
+    ).apply {
+        // Let compensating (and otherwise idle base) workers retire so the pool returns to [bound]
+        // once a nested-dispatch storm subsides.
+        allowCoreThreadTimeOut(true)
+    }
+
+    val largestPoolSize: Int get() = executor.largestPoolSize
+
+    fun execute(task: () -> Unit) {
+        executor.execute(task)
+    }
+
+    /**
+     * Called by a worker thread immediately before it PARKS on a nested same-connection call: adds
+     * one compensating worker so queued nested work keeps a runnable thread, and returns true (the
+     * caller MUST pair it with [endNestedBlock]). Off the worker pool it is a no-op returning false.
+     */
+    fun beginNestedBlock(): Boolean {
+        if (!onWorkerThread.get()) return false
+        synchronized(poolLock) {
+            parked++
+            executor.corePoolSize = bound + parked
+            // Make a replacement worker live now (even before the nested METHOD_CALL is queued) so
+            // it is ready to pick the nested task up the instant the reader submits it.
+            executor.prestartCoreThread()
+        }
+        return true
+    }
+
+    /** Retires the compensating worker added by a matching [beginNestedBlock]. */
+    fun endNestedBlock() {
+        synchronized(poolLock) {
+            parked--
+            executor.corePoolSize = bound + parked
+        }
+    }
+
+    fun shutdownNow() {
+        executor.shutdownNow()
+    }
+
+    private companion object {
+        private const val MIN_BOUND = 4
+        private const val MAX_BOUND = 64
+        private const val WORKER_KEEPALIVE_SECONDS = 30L
     }
 }
 

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -705,6 +705,14 @@ internal class DBusWireConnection private constructor(
  * concurrently-parked nested handlers cannot be served by fewer than ~N threads without deadlock).
  * Surplus compensating workers retire once idle (`allowCoreThreadTimeOut`), shrinking the pool back
  * to [bound] after a nested-dispatch storm subsides.
+ *
+ * SCOPE / CONSTRAINT on serve handlers: compensation only covers a worker that blocks *on its own
+ * thread* inside [call]/[callBlocking] (where [beginNestedBlock] runs). A serve handler that instead
+ * (a) offloads its nested same-connection call to a DIFFERENT thread/dispatcher (e.g.
+ * `withContext(Dispatchers.IO) { connection.call(...) }`) while keeping the worker parked, or
+ * (b) blocks on a non-same-connection dependency (a shared lock, another handler's result), is NOT
+ * compensated and can starve the bounded pool. Serve handlers must perform any nested same-connection
+ * call synchronously on the worker thread, and must not block the worker on unrelated work.
  */
 private class ServeWorkerPool {
     /** Steady-state worker count: ~2x CPUs, clamped so it is neither starved nor wildly large. */

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
@@ -11,6 +11,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
@@ -240,6 +243,161 @@ class DBusWireConnectionTest {
             val buffer = ByteArray(max)
             val read = stream.read(buffer)
             String(buffer, 0, read.coerceAtLeast(0), Charsets.UTF_8)
+        }
+    }
+
+    /**
+     * Regression for issue #101 (bounded serve pool must not deadlock on nested same-connection
+     * dispatch). A served "Outer" handler makes a BLOCKING call back to "Inner" on the SAME
+     * connection: Outer runs on a serve worker and PARKS waiting for Inner's reply, and Inner needs
+     * its own serve worker. We fire MORE concurrent Outer calls than the pool's [serveBound] so that
+     * — with a naive fixed bound — every worker would be parked on an Outer and the queued Inner
+     * calls could never get a thread, deadlocking. The bounded pool's compensation must instead let
+     * every chain finish. [withTimeout] makes a regression FAIL FAST rather than hang.
+     */
+    @Test
+    fun nestedSameConnectionDispatch_underBoundedPool_completesWithoutDeadlock() = runBlocking {
+        val server = connectOrNull() ?: return@runBlocking
+        val client = connectOrNull() ?: run {
+            server.close()
+            return@runBlocking
+        }
+        val busName = "com.monkopedia.sdbus.wire.nest.s${System.nanoTime()}"
+        val path = "/com/monkopedia/sdbus/wire/nest"
+        val iface = "com.monkopedia.sdbus.wire.Nest"
+
+        server.setIncomingCallHandler { message ->
+            when (message.member) {
+                "Inner" -> server.send(
+                    WireMessage(
+                        type = WireMessageType.METHOD_RETURN,
+                        replySerial = message.serial,
+                        destination = message.sender,
+                        signature = "b",
+                        body = listOf(true)
+                    )
+                )
+
+                "Outer" -> {
+                    // Nested call on THIS same connection: parks this serve worker until the reader
+                    // delivers Inner's reply, which itself must be served on another worker.
+                    val innerOk = runCatching {
+                        server.callBlocking(
+                            WireMessage(
+                                type = WireMessageType.METHOD_CALL,
+                                destination = busName,
+                                path = path,
+                                interfaceName = iface,
+                                member = "Inner"
+                            )
+                        ).body.firstOrNull() == true
+                    }.getOrDefault(false)
+                    server.send(
+                        WireMessage(
+                            type = WireMessageType.METHOD_RETURN,
+                            replySerial = message.serial,
+                            destination = message.sender,
+                            signature = "b",
+                            body = listOf(innerOk)
+                        )
+                    )
+                }
+            }
+        }
+
+        try {
+            assertEquals(1, server.requestName(busName), "server should own $busName")
+            // Strictly exceed the pool bound so a fixed-bound pool would have no spare worker for the
+            // nested Inner calls (every worker parked on an Outer) -> deadlock without compensation.
+            val concurrency = server.serveBound + 8
+            val replies = withTimeout(20_000) {
+                (1..concurrency).map {
+                    async(Dispatchers.IO) {
+                        client.call(
+                            WireMessage(
+                                type = WireMessageType.METHOD_CALL,
+                                destination = busName,
+                                path = path,
+                                interfaceName = iface,
+                                member = "Outer"
+                            )
+                        )
+                    }
+                }.awaitAll()
+            }
+            assertEquals(concurrency, replies.size)
+            assertTrue(
+                replies.all { it.body.firstOrNull() == true },
+                "every nested Outer->Inner chain should complete successfully"
+            )
+        } finally {
+            client.close()
+            server.close()
+        }
+    }
+
+    /**
+     * The serve pool must NOT grow a thread per concurrently-served call (the old
+     * newCachedThreadPool behavior, issue #101). A flood of independent slow (non-nested) handlers,
+     * far exceeding [serveBound], must all complete while the live worker count stays capped at
+     * [serveBound]: the surplus calls queue instead of spawning unbounded threads.
+     */
+    @Test
+    fun serveWorkerPool_underFloodOfSlowHandlers_staysBounded() = runBlocking {
+        val server = connectOrNull() ?: return@runBlocking
+        val client = connectOrNull() ?: run {
+            server.close()
+            return@runBlocking
+        }
+        val busName = "com.monkopedia.sdbus.wire.flood.s${System.nanoTime()}"
+        val path = "/com/monkopedia/sdbus/wire/flood"
+        val iface = "com.monkopedia.sdbus.wire.Flood"
+
+        server.setIncomingCallHandler { message ->
+            if (message.member == "Slow") {
+                // Slow, but INDEPENDENT: no call back on this connection, so it never compensates.
+                Thread.sleep(200)
+                server.send(
+                    WireMessage(
+                        type = WireMessageType.METHOD_RETURN,
+                        replySerial = message.serial,
+                        destination = message.sender,
+                        signature = "b",
+                        body = listOf(true)
+                    )
+                )
+            }
+        }
+
+        try {
+            assertEquals(1, server.requestName(busName), "server should own $busName")
+            val concurrency = server.serveBound * 4
+            val replies = withTimeout(30_000) {
+                (1..concurrency).map {
+                    async(Dispatchers.IO) {
+                        client.call(
+                            WireMessage(
+                                type = WireMessageType.METHOD_CALL,
+                                destination = busName,
+                                path = path,
+                                interfaceName = iface,
+                                member = "Slow"
+                            )
+                        )
+                    }
+                }.awaitAll()
+            }
+            assertEquals(concurrency, replies.size)
+            assertTrue(replies.all { it.body.firstOrNull() == true }, "all slow calls should reply")
+            assertTrue(
+                server.serveLargestPoolSize <= server.serveBound,
+                "serve pool grew to ${server.serveLargestPoolSize} threads, exceeding the bound " +
+                    "of ${server.serveBound}: a flood of slow handlers must queue, not spawn " +
+                    "unbounded threads"
+            )
+        } finally {
+            client.close()
+            server.close()
         }
     }
 


### PR DESCRIPTION
Closes #101. Group 0 of the 0.6.0 wave (epic #108). JVM-internal only — no public API change.

## Problem
`DBusWireConnection` served incoming method calls on `newCachedThreadPool()` → one thread per concurrent call, unbounded growth under a flood of slow/blocking handlers.

## Design — bounded + deadlock-free
New `ServeWorkerPool`: a `ThreadPoolExecutor` pinned at a bounded `corePoolSize` (~2×CPU, clamped 4..64) with an unbounded `LinkedBlockingQueue` (so the sole submitter — the reader loop — never blocks/rejects/runs-inline; it must stay free to read the replies that unpark workers).

**The nested-call hazard:** a served handler X (on a worker) makes a blocking same-connection call to Y, also served here; X parks waiting for Y, Y needs a worker. A naive fixed bound saturated with slow handlers can never give Y a thread → deadlock.

**Fix — ForkJoinPool-style compensation:** every blocking wait in `call`/`callBlocking` is bracketed by `beginNestedBlock()`/`endNestedBlock()`. A per-pool ThreadLocal marks worker threads; when a *worker* is about to park on a nested call, `corePoolSize` is raised by one and a replacement worker pre-started (lowered on return). Invariant: **live workers == bound + (workers parked on nested calls)** → always ≥ bound runnable workers at any nesting depth. A flood of *independent* slow handlers never compensates, so it stays pinned at the bound and excess calls queue. Surplus compensating workers retire via `allowCoreThreadTimeOut`.

## Tests (jvmTest, under dbus-run-session)
- `nestedSameConnectionDispatch_underBoundedPool_completesWithoutDeadlock` — fires `bound+8` concurrent Outer→Inner chains; FIFO ordering means all base workers park on Outers before any Inner is enqueued → deterministically deadlocks a naive bound. `withTimeout(20s)` fails fast. Passes in ~9ms.
- `serveWorkerPool_underFloodOfSlowHandlers_staysBounded` — floods `bound×4` independent slow handlers; asserts completion and `largestPoolSize <= bound`.

## Verification
- `:jvmTest` under dbus-run-session: 300 tests, 0 failures, no regressions.
- `ktlintCheck` + `apiCheck` pass (new members are `internal`; no api dump change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
