### PR TITLE
Rename Error -> SdbusException (+ deprecated typealias) [#109]

### DIFF
--- a/api/sdbus-kotlin.api
+++ b/api/sdbus-kotlin.api
@@ -79,13 +79,6 @@ public final class com/monkopedia/sdbus/DegroupingReturnsKt {
 	public static final fun maybeDegrouped-qeoUwEc (Ljava/lang/String;Z)Ljava/lang/String;
 }
 
-public final class com/monkopedia/sdbus/Error : java/lang/Exception {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getErrorMessage ()Ljava/lang/String;
-	public final fun getName ()Ljava/lang/String;
-}
-
 public final class com/monkopedia/sdbus/Flags {
 	public fun <init> ()V
 	public final fun set (Lcom/monkopedia/sdbus/Flags$GeneralFlags;Z)V
@@ -228,7 +221,7 @@ public final class com/monkopedia/sdbus/MethodBuilderKt {
 }
 
 public final class com/monkopedia/sdbus/MethodCall : com/monkopedia/sdbus/Message {
-	public final fun createErrorReply (Lcom/monkopedia/sdbus/Error;)Lcom/monkopedia/sdbus/MethodReply;
+	public final fun createErrorReply (Lcom/monkopedia/sdbus/SdbusException;)Lcom/monkopedia/sdbus/MethodReply;
 	public final fun createReply ()Lcom/monkopedia/sdbus/MethodReply;
 	public final fun getDontExpectReply ()Z
 	public final fun send-LRDsOJo (J)Lcom/monkopedia/sdbus/MethodReply;
@@ -478,6 +471,13 @@ public final class com/monkopedia/sdbus/Proxy_jvmKt {
 
 public abstract interface class com/monkopedia/sdbus/Resource {
 	public abstract fun release ()V
+}
+
+public final class com/monkopedia/sdbus/SdbusException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
 }
 
 public abstract class com/monkopedia/sdbus/SdbusSig {

--- a/api/sdbus-kotlin.klib.api
+++ b/api/sdbus-kotlin.klib.api
@@ -147,15 +147,6 @@ final class com.monkopedia.sdbus/AsyncPropertySetter { // com.monkopedia.sdbus/A
     final suspend fun getResult() // com.monkopedia.sdbus/AsyncPropertySetter.getResult|getResult(){}[0]
 }
 
-final class com.monkopedia.sdbus/Error : kotlin/Exception { // com.monkopedia.sdbus/Error|null[0]
-    constructor <init>(kotlin/String, kotlin/String = ...) // com.monkopedia.sdbus/Error.<init>|<init>(kotlin.String;kotlin.String){}[0]
-
-    final val errorMessage // com.monkopedia.sdbus/Error.errorMessage|{}errorMessage[0]
-        final fun <get-errorMessage>(): kotlin/String // com.monkopedia.sdbus/Error.errorMessage.<get-errorMessage>|<get-errorMessage>(){}[0]
-    final val name // com.monkopedia.sdbus/Error.name|{}name[0]
-        final fun <get-name>(): kotlin/String // com.monkopedia.sdbus/Error.name.<get-name>|<get-name>(){}[0]
-}
-
 final class com.monkopedia.sdbus/Flags { // com.monkopedia.sdbus/Flags|null[0]
     constructor <init>() // com.monkopedia.sdbus/Flags.<init>|<init>(){}[0]
 
@@ -233,7 +224,7 @@ final class com.monkopedia.sdbus/MethodCall : com.monkopedia.sdbus/Message { // 
         final fun <get-dontExpectReply>(): kotlin/Boolean // com.monkopedia.sdbus/MethodCall.dontExpectReply.<get-dontExpectReply>|<get-dontExpectReply>(){}[0]
         final fun <set-dontExpectReply>(kotlin/Boolean) // com.monkopedia.sdbus/MethodCall.dontExpectReply.<set-dontExpectReply>|<set-dontExpectReply>(kotlin.Boolean){}[0]
 
-    final fun createErrorReply(com.monkopedia.sdbus/Error): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.createErrorReply|createErrorReply(com.monkopedia.sdbus.Error){}[0]
+    final fun createErrorReply(com.monkopedia.sdbus/SdbusException): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.createErrorReply|createErrorReply(com.monkopedia.sdbus.SdbusException){}[0]
     final fun createReply(): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.createReply|createReply(){}[0]
     final fun send(kotlin.time/Duration): com.monkopedia.sdbus/MethodReply // com.monkopedia.sdbus/MethodCall.send|send(kotlin.time.Duration){}[0]
 }
@@ -372,6 +363,15 @@ final class com.monkopedia.sdbus/PropertyVTableItem : com.monkopedia.sdbus/VTabl
     final inline fun <#A1: reified kotlin/Any> with(kotlin.reflect/KProperty0<#A1>) // com.monkopedia.sdbus/PropertyVTableItem.with|with(kotlin.reflect.KProperty0<0:0>){0§<kotlin.Any>}[0]
     final inline fun <#A1: reified kotlin/Any> withGetter(crossinline kotlin/Function0<#A1>): com.monkopedia.sdbus/PropertyVTableItem // com.monkopedia.sdbus/PropertyVTableItem.withGetter|withGetter(kotlin.Function0<0:0>){0§<kotlin.Any>}[0]
     final inline fun <#A1: reified kotlin/Any> withSetter(crossinline kotlin/Function1<#A1, kotlin/Unit>): com.monkopedia.sdbus/PropertyVTableItem // com.monkopedia.sdbus/PropertyVTableItem.withSetter|withSetter(kotlin.Function1<0:0,kotlin.Unit>){0§<kotlin.Any>}[0]
+}
+
+final class com.monkopedia.sdbus/SdbusException : kotlin/Exception { // com.monkopedia.sdbus/SdbusException|null[0]
+    constructor <init>(kotlin/String, kotlin/String = ...) // com.monkopedia.sdbus/SdbusException.<init>|<init>(kotlin.String;kotlin.String){}[0]
+
+    final val errorMessage // com.monkopedia.sdbus/SdbusException.errorMessage|{}errorMessage[0]
+        final fun <get-errorMessage>(): kotlin/String // com.monkopedia.sdbus/SdbusException.errorMessage.<get-errorMessage>|<get-errorMessage>(){}[0]
+    final val name // com.monkopedia.sdbus/SdbusException.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.monkopedia.sdbus/SdbusException.name.<get-name>|<get-name>(){}[0]
 }
 
 final class com.monkopedia.sdbus/ServiceConnection { // com.monkopedia.sdbus/ServiceConnection|null[0]

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockBluezTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockBluezTest.kt
@@ -21,7 +21,6 @@
 package com.monkopedia.sdbus.integration
 
 import com.monkopedia.sdbus.Connection
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.MutablePropertyDelegate
@@ -31,6 +30,7 @@ import com.monkopedia.sdbus.PropertiesProxy
 import com.monkopedia.sdbus.PropertyDelegate
 import com.monkopedia.sdbus.PropertyName
 import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.SignalName
 import com.monkopedia.sdbus.Variant
@@ -105,7 +105,7 @@ import kotlinx.coroutines.withTimeout
  * The BlueZ wire profile is dicts/object-paths/arrays — no structs (#71) and no multi-out
  * methods (#74) anywhere in the covered surface, so only issue #72 needs gating:
  * `org.bluez.Error.*` error-name assertions run behind [peerErrorNameMappingSupported] while
- * the `assertFailsWith<Error>` part always runs on both backends.
+ * the `assertFailsWith<SdbusException>` part always runs on both backends.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
  * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Skips cleanly when
@@ -334,12 +334,12 @@ class DbusmockBluezTest {
             assertEquals(true, events.awaitChanged(DEVICE1, "Connected").get<Boolean>())
 
             // Connecting an already-connected device is rejected.
-            val alreadyConnected = assertFailsWith<Error> { device.connect() }
+            val alreadyConnected = assertFailsWith<SdbusException> { device.connect() }
             assertBluezError(alreadyConnected, "org.bluez.Error.AlreadyConnected")
 
             device.disconnect()
             assertEquals(false, events.awaitChanged(DEVICE1, "Connected").get<Boolean>())
-            val notConnected = assertFailsWith<Error> { device.disconnect() }
+            val notConnected = assertFailsWith<SdbusException> { device.disconnect() }
             assertBluezError(notConnected, "org.bluez.Error.NotConnected")
 
             // The ConnectDevice/DisconnectDevice conveniences update the property store too,
@@ -368,7 +368,7 @@ class DbusmockBluezTest {
             assertTrue(device.paired)
             assertTrue(device.uuids.isNotEmpty(), "pairing should populate service UUIDs")
 
-            val alreadyPaired = assertFailsWith<Error> { device.pair() }
+            val alreadyPaired = assertFailsWith<SdbusException> { device.pair() }
             assertBluezError(alreadyPaired, "org.bluez.Error.AlreadyExists")
         }
     }
@@ -491,10 +491,10 @@ class DbusmockBluezTest {
     /**
      * Asserts the `org.bluez.Error.*` name produced by the BlueZ-shaped peer — gated on
      * [peerErrorNameMappingSupported] (issue #72), where the JVM backend is known to discard
-     * foreign error names. The fact that an [Error] is thrown at all is asserted
+     * foreign error names. The fact that an [SdbusException] is thrown at all is asserted
      * unconditionally at each call site via `assertFailsWith`.
      */
-    private fun assertBluezError(error: Error, expectedName: String) {
+    private fun assertBluezError(error: SdbusException, expectedName: String) {
         if (!peerErrorNameMappingSupported) {
             // KNOWN JVM BACKEND BUG (issue #72; see peerErrorNameMappingSupported KDoc).
             println(

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockForeignErrorTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockForeignErrorTest.kt
@@ -20,9 +20,9 @@
  */
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.callMethod
 import com.monkopedia.sdbus.callMethodAsync
 import com.monkopedia.sdbus.getProperty
@@ -33,7 +33,7 @@ import kotlin.test.assertFailsWith
 /**
  * Foreign error mapping against the python-dbusmock independent peer (issue #36): D-Bus error
  * replies produced by a non-sdbus implementation (Python/GDBus raising `DBusException` with
- * arbitrary error names) must surface as [com.monkopedia.sdbus.Error] with the error name and
+ * arbitrary error names) must surface as [com.monkopedia.sdbus.SdbusException] with the error name and
  * message preserved verbatim.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
@@ -46,7 +46,7 @@ class DbusmockForeignErrorTest {
     @Test
     fun standardErrorName_surfacesWithNameAndMessage() = withDbusmockPeer("ErrStd") {
         addRaisingMethod("Boom", "org.freedesktop.DBus.Error.NotSupported", "peer says no")
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             proxy.callMethod<Unit>(iface, MethodName("Boom")) {}
         }
         assertForeignError(error, "org.freedesktop.DBus.Error.NotSupported", "peer says no")
@@ -59,7 +59,7 @@ class DbusmockForeignErrorTest {
             "com.monkopedia.sdbus.test.SomethingWentWrong",
             "completely custom failure detail"
         )
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             proxy.callMethod<Unit>(iface, MethodName("Custom")) {}
         }
         assertForeignError(
@@ -70,7 +70,7 @@ class DbusmockForeignErrorTest {
 
         // AccessDenied-style names commonly raised by real services map the same way.
         addRaisingMethod("Denied", "org.freedesktop.DBus.Error.AccessDenied", "not for you")
-        val denied = assertFailsWith<Error> {
+        val denied = assertFailsWith<SdbusException> {
             proxy.callMethod<Unit>(iface, MethodName("Denied")) {}
         }
         assertForeignError(denied, "org.freedesktop.DBus.Error.AccessDenied", "not for you")
@@ -79,7 +79,7 @@ class DbusmockForeignErrorTest {
     @Test
     fun asyncCallPath_mapsForeignErrorsIdentically() = withDbusmockPeer("ErrAsync") {
         addRaisingMethod("Boom", "org.freedesktop.DBus.Error.InvalidArgs", "async boom")
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             proxy.callMethodAsync<Unit>(iface, MethodName("Boom")) {}
         }
         assertForeignError(error, "org.freedesktop.DBus.Error.InvalidArgs", "async boom")
@@ -90,7 +90,7 @@ class DbusmockForeignErrorTest {
         // The error here is produced by the foreign stack itself (dbus-python's dispatch),
         // not by scripted code; the message text is implementation-defined so only the name
         // is asserted.
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             proxy.callMethod<Unit>(iface, MethodName("NoSuchMethodHere")) {}
         }
         assertForeignError(error, "org.freedesktop.DBus.Error.UnknownMethod")
@@ -99,7 +99,7 @@ class DbusmockForeignErrorTest {
     @Test
     fun foreignPropertyErrors_surfaceWithPeerErrorNames() = withDbusmockPeer("ErrProp") {
         // dbusmock raises "<main interface>.UnknownProperty" for a Get on a missing property.
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             proxy.getProperty<Int>(iface, PropertyName("NoSuchProperty"))
         }
         assertForeignError(
@@ -112,11 +112,11 @@ class DbusmockForeignErrorTest {
     /**
      * Asserts that [error]'s name (and, when given, message) match what the foreign peer put
      * in its error reply — gated on [peerErrorNameMappingSupported] where the JVM backend is
-     * known to discard both (the `Error` is still thrown, which is asserted unconditionally
+     * known to discard both (the `SdbusException` is still thrown, which is asserted unconditionally
      * at each call site via `assertFailsWith`).
      */
     private fun assertForeignError(
-        error: Error,
+        error: SdbusException,
         expectedName: String,
         expectedMessage: String? = null
     ) {
@@ -155,8 +155,8 @@ class DbusmockForeignErrorTest {
  * from a real remote (out-of-process) peer.
  *
  * `true` on both backends. On native sd-bus the wire error name/message land verbatim in
- * [com.monkopedia.sdbus.Error]'s `name`/`errorMessage`. On the JVM the owned wire backend
- * likewise copies the wire ERROR_NAME / message straight into [com.monkopedia.sdbus.Error]
+ * [com.monkopedia.sdbus.SdbusException]'s `name`/`errorMessage`. On the JVM the owned wire backend
+ * likewise copies the wire ERROR_NAME / message straight into [com.monkopedia.sdbus.SdbusException]
  * (see `WireDbusProxy.callRemote`) instead of squeezing them through the errno-based
  * `createError` mapping.
  *

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSecretServiceTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSecretServiceTest.kt
@@ -20,7 +20,6 @@
  */
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.MutablePropertyDelegate
@@ -28,6 +27,7 @@ import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PropertyDelegate
 import com.monkopedia.sdbus.PropertyName
 import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.SignalName
 import com.monkopedia.sdbus.Variant
 import com.monkopedia.sdbus.callMethod
@@ -71,7 +71,7 @@ import kotlinx.serialization.Serializable
  *   to/from a real remote peer, which covers every `(oayays)` Secret transfer.
  * - issue #72 ([peerErrorNameMappingSupported]): foreign error names/messages are discarded
  *   (everything surfaces as AccessDenied), so error-name assertions are gated while the
- *   `assertFailsWith<Error>` part always runs.
+ *   `assertFailsWith<SdbusException>` part always runs.
  * - issue #74 ([peerGroupedReturnSupported], FOUND BY THIS SUITE): multi-out method replies
  *   (`isGroupedReturn`, the shape codegen emits for 2+-out-arg methods) cannot be
  *   deserialized from a real remote peer, which covers `OpenSession` (vo), service-level
@@ -113,7 +113,7 @@ class DbusmockSecretServiceTest {
             val session = SecretSessionProxy(sessionProxy)
             session.close()
             // The session object is gone from the peer once closed.
-            assertFailsWith<Error> { session.close() }
+            assertFailsWith<SdbusException> { session.close() }
         }
 
         // Closing the second session does not affect the first.
@@ -351,7 +351,7 @@ class DbusmockSecretServiceTest {
                 // itself is asserted: the error *name* for a vanished object is produced by
                 // the foreign stack and is implementation-defined.)
                 withProxyAt(itemPath) { itemProxy ->
-                    assertFailsWith<Error> {
+                    assertFailsWith<SdbusException> {
                         SecretItemProxy(itemProxy).getSecret(ObjectPath("/"))
                     }
                 }
@@ -388,13 +388,16 @@ class DbusmockSecretServiceTest {
             // Reading a secret of an item in a locked collection is rejected. (The error
             // happens before any secret struct is marshalled, so this runs on both backends.)
             withProxyAt(vaultItem) { itemProxy ->
-                val error = assertFailsWith<Error> { SecretItemProxy(itemProxy).getSecret(session) }
+                val error =
+                    assertFailsWith<SdbusException> {
+                        SecretItemProxy(itemProxy).getSecret(session)
+                    }
                 assertSecretError(error, "org.freedesktop.Secret.Error.IsLocked")
             }
 
             if (peerStructMarshallingSupported) {
                 // Creating an item in a locked collection is rejected too.
-                val error = assertFailsWith<Error> {
+                val error = assertFailsWith<SdbusException> {
                     vault.createItem(
                         mapOf("org.freedesktop.Secret.Item.Label" to Variant("Denied")),
                         Secret(session, emptyList(), "nope".toSecretBytes(), "text/plain"),
@@ -450,7 +453,10 @@ class DbusmockSecretServiceTest {
             assertEquals(listOf(ObjectPath(VAULT_PATH)), locked.objects)
             assertTrue(vault.locked)
             withProxyAt(vaultItem) { itemProxy ->
-                val error = assertFailsWith<Error> { SecretItemProxy(itemProxy).getSecret(session) }
+                val error =
+                    assertFailsWith<SdbusException> {
+                        SecretItemProxy(itemProxy).getSecret(session)
+                    }
                 assertSecretError(error, "org.freedesktop.Secret.Error.IsLocked")
             }
         }
@@ -459,10 +465,10 @@ class DbusmockSecretServiceTest {
     /**
      * Asserts the D-Bus error name produced by the mocked Secret Service — gated on
      * [peerErrorNameMappingSupported] (issue #72), where the JVM backend is known to discard
-     * foreign error names. The fact that an [Error] is thrown at all is asserted
+     * foreign error names. The fact that an [SdbusException] is thrown at all is asserted
      * unconditionally at each call site via `assertFailsWith`.
      */
-    private fun assertSecretError(error: Error, expectedName: String) {
+    private fun assertSecretError(error: SdbusException, expectedName: String) {
         if (!peerErrorNameMappingSupported) {
             // KNOWN JVM BACKEND BUG (issue #72; see peerErrorNameMappingSupported KDoc).
             println(

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
@@ -357,7 +357,7 @@ class CrossRuntimeInteropSmokeTest {
                     ) {
                         call(UnixFd.adopt(-1))
                     }
-                }.exceptionOrNull() as? com.monkopedia.sdbus.Error
+                }.exceptionOrNull() as? com.monkopedia.sdbus.SdbusException
                 assertTrue(invalidFailure != null, "Expected invalid Unix FD call to fail")
                 val message = invalidFailure.errorMessage
                 assertTrue(

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockFdSupport.jvm.kt
@@ -134,7 +134,7 @@ private object JunixFdBridge {
 
 /**
  * Foreign error names/messages are preserved verbatim since the issue #72 fix (remote error
- * replies construct Error(wireName, wireMessage) instead of going through the errno mapping).
+ * replies construct SdbusException(wireName, wireMessage) instead of going through the errno mapping).
  */
 internal actual val peerErrorNameMappingSupported: Boolean = true
 

--- a/cross_test/src/linuxX64Test/kotlin/integration/NativeInteropPeerTest.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/NativeInteropPeerTest.kt
@@ -829,7 +829,7 @@ class NativeInteropPeerTest {
                     timeout = 5.seconds
                     call(UnixFd.adopt(-1))
                 }
-            }.exceptionOrNull() as? com.monkopedia.sdbus.Error
+            }.exceptionOrNull() as? com.monkopedia.sdbus.SdbusException
             assertTrue(invalidError != null, "Expected invalid Unix FD call to fail")
             assertTrue(
                 invalidError.errorMessage.contains("Invalid Unix FD", ignoreCase = true),
@@ -1115,5 +1115,5 @@ class NativeInteropPeerTest {
  * Replaces the previously-used internal `createError(errNo, msg)` helper; the asserting side only
  * matches on the error message, so a stable generic error name is used.
  */
-private fun peerError(message: String): com.monkopedia.sdbus.Error =
-    com.monkopedia.sdbus.Error("org.freedesktop.DBus.Error.Failed", message)
+private fun peerError(message: String): com.monkopedia.sdbus.SdbusException =
+    com.monkopedia.sdbus.SdbusException("org.freedesktop.DBus.Error.Failed", message)

--- a/samples/bluez-scan/src/commonMain/kotlin/Main.kt
+++ b/samples/bluez-scan/src/commonMain/kotlin/Main.kt
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with
  * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
  */
-import com.monkopedia.sdbus.Error
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ObjectManagerProxy
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.ServiceName
@@ -62,10 +62,10 @@ fun main(args: Array<String>) {
                 val device = Device1Proxy(connection.createProxy(path))
                 try {
                     println("Found device ${device.name} ${device.address}")
-                } catch (t: Error) {
+                } catch (t: SdbusException) {
                     try {
                         println("Found device ${device.address}")
-                    } catch (t: Error) {
+                    } catch (t: SdbusException) {
                         println("Can't handle device $path")
                     }
                 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
@@ -30,7 +30,7 @@ import kotlin.time.Duration
  * An interface to D-Bus bus connection. Incorporates implementation
  * of both synchronous and asynchronous D-Bus I/O event loop.
  *
- * All methods throw [com.monkopedia.sdbus.Error] in case of failure. All methods in
+ * All methods throw [com.monkopedia.sdbus.SdbusException] in case of failure. All methods in
  * this class are thread-aware, but not thread-safe.
  *
  ***********************************************/
@@ -51,7 +51,7 @@ interface Connection : Resource {
      * This causes the loop started by [startEventLoop] to exit, and frees the
      * thread serving the loop
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     suspend fun stopEventLoop()
 
@@ -76,7 +76,7 @@ interface Connection : Resource {
      * General method call timeout is used for all method calls upon this connection.
      * Method call-specific timeout overrides this general setting.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     var methodCallTimeout: Duration
 
@@ -97,7 +97,7 @@ interface Connection : Resource {
      *
      * @see Object.addObjectManager
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun addObjectManager(objectPath: ObjectPath): Resource
 
@@ -125,7 +125,7 @@ interface Connection : Resource {
      *
      * For more information, consult `man sd_bus_add_match`.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun addMatch(match: String, callback: MessageHandler): Resource
 
@@ -149,7 +149,7 @@ interface Connection : Resource {
      *
      * For more information, consult `man sd_bus_add_match_async`.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun addMatchAsync(
         match: String,
@@ -160,7 +160,7 @@ interface Connection : Resource {
     /**
      * The unique name of the connection. E.g. ":1.xx"
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     val uniqueName: BusName
 
@@ -169,7 +169,7 @@ interface Connection : Resource {
      *
      * @param name Name to request
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun requestName(name: ServiceName)
 
@@ -178,7 +178,7 @@ interface Connection : Resource {
      *
      * @param name Name to release
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun releaseName(name: ServiceName)
 }
@@ -190,7 +190,7 @@ internal expect fun now(): Duration
  *
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createBusConnection(): Connection
 
@@ -200,7 +200,7 @@ expect fun createBusConnection(): Connection
  * @param name Name to request on the connection after its opening
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createBusConnection(name: ServiceName): Connection
 
@@ -209,7 +209,7 @@ expect fun createBusConnection(name: ServiceName): Connection
  *
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createSystemBusConnection(): Connection
 
@@ -219,7 +219,7 @@ expect fun createSystemBusConnection(): Connection
  * @param name Name to request on the connection after its opening
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createSystemBusConnection(name: ServiceName): Connection
 
@@ -228,7 +228,7 @@ expect fun createSystemBusConnection(name: ServiceName): Connection
  *
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createSessionBusConnection(): Connection
 
@@ -238,7 +238,7 @@ expect fun createSessionBusConnection(): Connection
  * @param name Name to request on the connection after its opening
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createSessionBusConnection(name: ServiceName): Connection
 
@@ -248,7 +248,7 @@ expect fun createSessionBusConnection(name: ServiceName): Connection
  * @param address ";"-separated list of addresses of bus brokers to try to connect
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  *
  * Consult manual pages for `sd_bus_set_address` of the underlying sd-bus library for more information.
  */
@@ -260,7 +260,7 @@ expect fun createSessionBusConnection(address: String): Connection
  * @param address ";"-separated list of addresses of bus brokers to try to connect to
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createDirectBusConnection(address: String): Connection
 
@@ -282,7 +282,7 @@ expect fun createDirectBusConnection(address: String): Connection
  * Use `UnixFd.adopt(rawFd)` to hand off a raw descriptor you own, or `UnixFd(rawFd)` to pass
  * a duplicate while keeping your own descriptor.
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createDirectBusConnection(fd: UnixFd): Connection
 
@@ -307,6 +307,6 @@ expect fun createDirectBusConnection(fd: UnixFd): Connection
  * Use `UnixFd.adopt(rawFd)` to hand off a raw descriptor you own, or `UnixFd(rawFd)` to pass
  * a duplicate while keeping your own descriptor.
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 expect fun createServerBusConnection(fd: UnixFd): Connection

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Error.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Error.kt
@@ -37,21 +37,29 @@ package com.monkopedia.sdbus
  * @property name The D-Bus error name
  * @property errorMessage Human-readable detail describing the error
  */
-class Error(val name: String, val errorMessage: String = "") : Exception("$name: $errorMessage")
+class SdbusException(val name: String, val errorMessage: String = "") :
+    Exception("$name: $errorMessage")
+
+@Deprecated(
+    "Renamed to SdbusException",
+    ReplaceWith("SdbusException", "com.monkopedia.sdbus.SdbusException"),
+    DeprecationLevel.WARNING
+)
+typealias Error = SdbusException
 
 internal fun Throwable.toError() =
-    (this as? Error) ?: Error(message ?: toString(), stackTraceToString())
+    (this as? SdbusException) ?: SdbusException(message ?: toString(), stackTraceToString())
 
 /**
- * Creates an [Error] from a numeric error code and a custom message.
+ * Creates an [SdbusException] from a numeric error code and a custom message.
  *
  * The error code is mapped to a corresponding D-Bus error name where possible.
  *
  * @param errNo Numeric (errno-style) error code
  * @param customMsg Additional human-readable context for the error
- * @return The constructed [Error]
+ * @return The constructed [SdbusException]
  */
-internal expect fun createError(errNo: Int, customMsg: String): Error
+internal expect fun createError(errNo: Int, customMsg: String): SdbusException
 
 internal inline fun sdbusRequire(condition: () -> Boolean, msg: String, errNo: Int) {
     if (condition()) throw createError((errNo), (msg))

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/MethodCall.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/MethodCall.kt
@@ -39,7 +39,7 @@ expect class MethodCall : Message {
      *
      * @param timeout Call timeout; [Duration.ZERO] uses the connection default
      * @return The reply message
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun send(timeout: Duration): MethodReply
 
@@ -51,7 +51,7 @@ expect class MethodCall : Message {
      *
      * @param error The error to report back to the caller
      */
-    fun createErrorReply(error: Error): MethodReply
+    fun createErrorReply(error: SdbusException): MethodReply
 
     /** Whether this call is flagged to not expect a reply. */
     var dontExpectReply: Boolean

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/MethodInvoker.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/MethodInvoker.kt
@@ -53,7 +53,7 @@ import kotlinx.serialization.serializer
  * println("Got result of multiplying $a and $b: $result")
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 suspend inline fun <reified R : Any> Proxy.callMethodAsync(
     interfaceName: InterfaceName,
@@ -100,8 +100,8 @@ internal suspend fun <R : Any> Proxy.callMethodAsyncImpl(
 
         try {
             return completable.await()
-        } catch (t: Error) {
-            throw Error(t.name, t.errorMessage)
+        } catch (t: SdbusException) {
+            throw SdbusException(t.name, t.errorMessage)
         } catch (t: CancellationException) {
             call.release()
             throw t
@@ -131,7 +131,7 @@ internal suspend fun <R : Any> Proxy.callMethodAsyncImpl(
  * println("Got result of multiplying $a and $b: $result")
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 inline fun <reified R : Any> Proxy.callMethod(
     interfaceName: InterfaceName,

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/MethodReply.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/MethodReply.kt
@@ -33,7 +33,7 @@ expect class MethodReply : Message {
     /**
      * Sends this reply back to the original caller.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun send()
 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Object.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Object.kt
@@ -28,7 +28,7 @@ package com.monkopedia.sdbus
  * D-Bus object provides its interfaces, methods, signals and properties on a bus
  * identified by a specific bus name.
  *
- * All Object member methods throw [com.monkopedia.sdbus.Error] in case of D-Bus or sdbus-kotlin error.
+ * All Object member methods throw [com.monkopedia.sdbus.SdbusException] in case of D-Bus or sdbus-kotlin error.
  * The Object class has been designed as thread-aware. However, the operation of
  * creating and sending asynchronous method replies, as well as creating and emitting
  * signals, is thread-safe by design.
@@ -42,7 +42,7 @@ interface Object : Resource {
      * @param interfaceName Name of an interface that properties belong to
      * @param propNames Names of properties that will be included in the PropertiesChanged signal
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitPropertiesChangedSignal(interfaceName: InterfaceName, propNames: List<PropertyName>)
 
@@ -51,7 +51,7 @@ interface Object : Resource {
      *
      * @param interfaceName Name of an interface
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitPropertiesChangedSignal(interfaceName: InterfaceName)
 
@@ -65,7 +65,7 @@ interface Object : Resource {
      * call can figure out the list of supported interfaces itself. Furthermore, it properly
      * adds the builtin org.freedesktop.DBus.* interfaces.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitInterfacesAddedSignal()
 
@@ -75,7 +75,7 @@ interface Object : Resource {
      * This emits an InterfacesAdded signal on this object path with explicitly provided list
      * of registered interfaces.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitInterfacesAddedSignal(interfaces: List<InterfaceName>)
 
@@ -86,7 +86,7 @@ interface Object : Resource {
      * object path. This only includes any registered interfaces but skips the properties.
      * This function shall be called (just) before destroying the object.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitInterfacesRemovedSignal()
 
@@ -96,7 +96,7 @@ interface Object : Resource {
      * This emits an InterfacesRemoved signal on the given path with explicitly provided list
      * of registered interfaces.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitInterfacesRemovedSignal(interfaces: List<InterfaceName>)
 
@@ -117,7 +117,7 @@ interface Object : Resource {
      *
      * @see Connection.addObjectManager
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun addObjectManager(): Resource
 
@@ -170,7 +170,7 @@ interface Object : Resource {
      * The function provides strong exception guarantee. The state of the object remains
      * unmodified in face of an exception.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun addVTable(interfaceName: InterfaceName, vtable: List<VTableItem>): Resource
 
@@ -185,7 +185,7 @@ interface Object : Resource {
      * the message with serialized arguments to the @c emitSignal function.
      * Alternatively, use higher-level API @c emitSignal(signalName: String) defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun createSignal(interfaceName: InterfaceName, signalName: SignalName): Signal
 
@@ -196,7 +196,7 @@ interface Object : Resource {
      *
      * Note: To avoid messing with messages, use higher-level API defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun emitSignal(message: Signal)
 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
@@ -53,7 +53,7 @@ import kotlinx.serialization.serializer
  * val state = object.getProperty(InterfaceName("com.kistler.foo"), PropertyName("state"))
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 inline fun <reified T : Any> Proxy.getProperty(
     interfaceName: InterfaceName,
@@ -71,7 +71,7 @@ inline fun <reified T : Any> Proxy.getProperty(
  * @param propertyName Name of the property to set
  * @param value New value
  * @param dontExpectReply When `true`, send the set without waiting for a reply
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 inline fun <reified T : Any> Proxy.setProperty(
     interfaceName: InterfaceName,
@@ -160,7 +160,7 @@ open class PropertyDelegate<R, T : Any>(
     /**
      * Gets the current value of the property.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure, including when the property
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure, including when the property
      * doesn't currently exist (use [getOrNull] for a null-returning variant)
      */
     fun get(): T = proxy.callMethod<Variant>(PropertiesProxy.INTERFACE_NAME, MethodName("Get")) {
@@ -170,11 +170,11 @@ open class PropertyDelegate<R, T : Any>(
     /**
      * Gets the current value of the property, however if the property doesn't currently exist
      * (`org.freedesktop.DBus.Error.InvalidArgs`), returns null rather than throwing. Any other
-     * [com.monkopedia.sdbus.Error] is still thrown.
+     * [com.monkopedia.sdbus.SdbusException] is still thrown.
      */
     fun getOrNull(): T? = try {
         get()
-    } catch (e: Error) {
+    } catch (e: SdbusException) {
         if (e.name != "org.freedesktop.DBus.Error.InvalidArgs") {
             throw e
         }
@@ -231,7 +231,7 @@ open class PropertyDelegate<R, T : Any>(
      * first when collection starts, followed by every subsequent change (from [changes]).
      *
      * Because the initial emission uses [get], collecting this flow throws
-     * [com.monkopedia.sdbus.Error] if the property doesn't currently exist; use [valuesOrNull]
+     * [com.monkopedia.sdbus.SdbusException] if the property doesn't currently exist; use [valuesOrNull]
      * for a null-emitting variant. Use [changes] to observe change events only, without the
      * initial value.
      */

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
@@ -33,7 +33,7 @@ import kotlin.time.Duration
  * The proxy enables calling methods on remote objects, receiving signals from remote
  * objects, and getting/setting properties of remote objects.
  *
- * All IProxy member methods throw @c [com.monkopedia.sdbus.Error] in case of D-Bus or sdbus-kotlin error.
+ * All IProxy member methods throw @c [com.monkopedia.sdbus.SdbusException] in case of D-Bus or sdbus-kotlin error.
  * The IProxy class has been designed as thread-aware. However, the operation of
  * creating and sending method calls (both synchronously and asynchronously) is
  * thread-safe by design.
@@ -79,7 +79,7 @@ interface Proxy : Resource {
      * the message with serialized arguments to the @c callMethod function.
      * Alternatively, use higher-level API @c callMethod(const & methodName: String) defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun createMethodCall(interfaceName: InterfaceName, methodName: MethodName): MethodCall
 
@@ -109,7 +109,7 @@ interface Proxy : Resource {
      *
      * Note: To avoid messing with messages, use API on a higher level of abstraction defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure (also in case the remote function returned an error)
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure (also in case the remote function returned an error)
      */
     fun callMethod(message: MethodCall): MethodReply
 
@@ -141,7 +141,7 @@ interface Proxy : Resource {
      *
      * Note: To avoid messing with messages, use API on a higher level of abstraction defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure (also in case the remote function returned an error)
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure (also in case the remote function returned an error)
      */
     fun callMethod(message: MethodCall, timeout: Duration): MethodReply
 
@@ -155,14 +155,14 @@ interface Proxy : Resource {
      * This is a std::future-based way of asynchronously calling a remote D-Bus method.
      *
      * The call itself is non-blocking. It doesn't wait for the reply. Once the reply arrives,
-     * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.Error]
+     * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.SdbusException]
      * in case the remote method threw an exception).
      *
      * The default D-Bus method call timeout is used. See [Connection.methodCallTimeout].
      *
      * Note: To avoid messing with messages, use higher-level API defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     suspend fun callMethodAsync(message: MethodCall): MethodReply
 
@@ -177,7 +177,7 @@ interface Proxy : Resource {
      * This is a std::future-based way of asynchronously calling a remote D-Bus method.
      *
      * The call itself is non-blocking. It doesn't wait for the reply. Once the reply arrives,
-     * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.Error]
+     * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.SdbusException]
      * in case the remote method threw an exception, or the call timed out).
      *
      * If timeout is [Duration.ZERO], the default D-Bus method call timeout is used.
@@ -185,7 +185,7 @@ interface Proxy : Resource {
      *
      * Note: To avoid messing with messages, use higher-level API defined below.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     suspend fun callMethodAsync(message: MethodCall, timeout: Duration): MethodReply
 
@@ -206,7 +206,7 @@ interface Proxy : Resource {
      * Library convention: `register*` functions return a [Resource] when the registration
      * must be explicitly released, and `Unit` (or the registered item) otherwise.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun registerSignalHandler(
         interfaceName: InterfaceName,
@@ -303,7 +303,7 @@ internal fun Proxy.callMethodAsync(
  *   .get()
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 fun Proxy.getPropertyAsync(propertyName: PropertyName): AsyncPropertyGetter =
     AsyncPropertyGetter(this, propertyName)
@@ -325,7 +325,7 @@ fun Proxy.getPropertyAsync(propertyName: PropertyName): AsyncPropertyGetter =
  *   .toValue(state)
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 fun Proxy.setPropertyAsync(propertyName: PropertyName): AsyncPropertySetter =
     AsyncPropertySetter(this, propertyName)
@@ -343,7 +343,7 @@ fun Proxy.setPropertyAsync(propertyName: PropertyName): AsyncPropertySetter =
  * val props = proxy.getAllProperties().onInterface(InterfaceName("com.kistler.foo"))
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 fun Proxy.getAllProperties(): AllPropertiesGetter = AllPropertiesGetter(this)
 
@@ -361,7 +361,7 @@ fun Proxy.getAllProperties(): AllPropertiesGetter = AllPropertiesGetter(this)
  *   getResult();
  * ```
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 
 fun Proxy.getAllPropertiesAsync(): AsyncAllPropertiesGetter = AsyncAllPropertiesGetter(this)

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Signal.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Signal.kt
@@ -43,7 +43,7 @@ expect class Signal : Message {
     /**
      * Emits this signal on the bus.
      *
-     * @throws [com.monkopedia.sdbus.Error] in case of failure
+     * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
     fun send()
 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/SignalEmitter.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/SignalEmitter.kt
@@ -32,7 +32,7 @@ package com.monkopedia.sdbus
  * from the D-Bus message concept. Signal arguments are automatically serialized
  * in a message and D-Bus signatures automatically deduced from the provided native arguments.
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 inline fun Object.emitSignal(
     interfaceName: InterfaceName = InterfaceName(""),
@@ -44,7 +44,7 @@ inline fun Object.emitSignal(
  * Emits the signal described by the given [SignalEmitter] from this object.
  *
  * @param signal Emitter carrying the interface, signal name, and serialized arguments
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 fun Object.emit(signal: SignalEmitter) {
     val m = createSignal(signal.interfaceName, signal.signalName)

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/SignalSubscriber.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/SignalSubscriber.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.flow.callbackFlow
  * object_.uponSignal(levelChanged).onInterface(foo).call([this](uint16_t level){ this->onLevelChanged(level); });
  * @endcode
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 inline fun Proxy.onSignal(
     interfaceName: InterfaceName,

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/TypeTraits.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/TypeTraits.kt
@@ -51,8 +51,8 @@ import kotlinx.serialization.serializer
 /** Handler invoked with an incoming [MethodCall] for a method exported by an [Object]. */
 typealias MethodCallback = (msg: MethodCall) -> Unit
 
-/** Handler invoked with the [MethodReply] (or [Error]) of an asynchronous method call. */
-internal typealias AsyncReplyHandler = (reply: MethodReply, error: Error?) -> Unit
+/** Handler invoked with the [MethodReply] (or [SdbusException]) of an asynchronous method call. */
+internal typealias AsyncReplyHandler = (reply: MethodReply, error: SdbusException?) -> Unit
 
 /** Handler invoked with an incoming [Signal]. */
 typealias SignalHandler = (signal: Signal) -> Unit

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
@@ -135,7 +135,7 @@ class Variant constructor() {
      * Serializes the value held by this variant into [msg].
      *
      * @param msg Destination message to append the variant's contents to
-     * @throws [com.monkopedia.sdbus.Error] if this variant is empty
+     * @throws [com.monkopedia.sdbus.SdbusException] if this variant is empty
      */
     fun serializeTo(msg: Message) {
         if (isEmpty) {

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/VTableBuilder.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/VTableBuilder.kt
@@ -75,7 +75,7 @@ package com.monkopedia.sdbus
  * The function provides strong exception guarantee. The state of the object remains
  * unmodified in face of an exception.
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  * @see [com.monkopedia.sdbus.Resource]
  * @see [prop]
  * @see [method]

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -1,6 +1,5 @@
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodName
@@ -8,6 +7,7 @@ import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PendingAsyncCall
 import com.monkopedia.sdbus.PropertiesProxy
 import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.SignalName
 import com.monkopedia.sdbus.Variant
@@ -232,7 +232,7 @@ class CommonApiIntegrationTest {
 
             registration.release()
 
-            assertFailsWith<Error> {
+            assertFailsWith<SdbusException> {
                 proxy.callMethod<Int>(ids.iface, MethodName("Echo")) {
                     call(42)
                 }
@@ -259,7 +259,7 @@ class CommonApiIntegrationTest {
         serverConnection.startEventLoop()
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
         val callbackValue = CompletableDeferred<Int>()
-        val callbackError = CompletableDeferred<Error?>()
+        val callbackError = CompletableDeferred<SdbusException?>()
 
         try {
             val call = proxy.createMethodCall(ids.iface, MethodName("Multiply"))
@@ -371,7 +371,7 @@ class CommonApiIntegrationTest {
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
 
         try {
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 proxy.callMethod<Int>(ids.iface, MethodName("Fail")) {
                     call(1)
                 }
@@ -441,7 +441,7 @@ class CommonApiIntegrationTest {
         }
         serverConnection.startEventLoop()
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
-        val callbackError = CompletableDeferred<Error?>()
+        val callbackError = CompletableDeferred<SdbusException?>()
 
         try {
             val call = proxy.createMethodCall(ids.iface, MethodName("Fail"))
@@ -482,7 +482,7 @@ class CommonApiIntegrationTest {
         }
         serverConnection.startEventLoop()
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
-        val callbackError = CompletableDeferred<Error?>()
+        val callbackError = CompletableDeferred<SdbusException?>()
 
         try {
             val call = proxy.createMethodCall(ids.iface, MethodName("SlowAdd"))
@@ -527,7 +527,7 @@ class CommonApiIntegrationTest {
         }
         serverConnection.startEventLoop()
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
-        val callbackError = CompletableDeferred<Error?>()
+        val callbackError = CompletableDeferred<SdbusException?>()
 
         try {
             val call = proxy.createMethodCall(ids.iface, MethodName("SlowAdd"))
@@ -662,7 +662,7 @@ class CommonApiIntegrationTest {
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
 
         try {
-            assertFailsWith<Error> {
+            assertFailsWith<SdbusException> {
                 proxy.callMethodAsync<Int>(ids.iface, MethodName("Fail")) {
                     call(1)
                 }
@@ -1329,7 +1329,7 @@ class CommonApiIntegrationTest {
         val propertiesProxy = PropertiesProxy(proxy)
 
         try {
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 PropertiesProxy.run {
                     propertiesProxy.set(ids.iface, stateProperty, false)
                 }

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -1,9 +1,9 @@
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.addVTable
 import com.monkopedia.sdbus.callMethod
@@ -23,11 +23,11 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
- * Error / failure-path consistency tests. These assert that BOTH backends (the native sd-bus
+ * SdbusException / failure-path consistency tests. These assert that BOTH backends (the native sd-bus
  * backend exercised by the linux*Test targets and the pure-JVM backend exercised by jvmTest)
- * surface failures the same way: a timeout becomes a timeout [Error], a server-thrown named
+ * surface failures the same way: a timeout becomes a timeout [SdbusException], a server-thrown named
  * D-Bus error round-trips its name + message, a wrong-argument-type / signature mismatch becomes
- * an [Error] rather than reaching the handler, and tearing a connection down stays consistent
+ * an [SdbusException] rather than reaching the handler, and tearing a connection down stays consistent
  * without crashing or hanging.
  *
  * Because the suite is in commonTest it is compiled and run against every target, so a backend
@@ -58,7 +58,7 @@ class FailurePathParityTest {
     // --- method-call timeout ---------------------------------------------------------------
 
     // A server method that deliberately sleeps far past the client's per-call timeout must
-    // surface as a timeout Error on both backends -- not a hang, and not some other error type.
+    // surface as a timeout SdbusException on both backends -- not a hang, and not some other error type.
     @Test
     fun methodCallTimeout_surfacesTimeoutError() = runBlocking {
         val ids = uniqueFixtureIds("timeout")
@@ -83,7 +83,7 @@ class FailurePathParityTest {
 
         try {
             val thrown = withTimeout(3_000) {
-                assertFailsWith<Error> {
+                assertFailsWith<SdbusException> {
                     proxy.callMethodAsync<Int>(ids.iface, MethodName("Slow")) {
                         call(1)
                         timeout = 100.milliseconds
@@ -146,7 +146,7 @@ class FailurePathParityTest {
             // No per-call timeout anywhere in this call: the raw message API's
             // callMethod(message) overload carries the unset sentinel, so the connection's
             // methodCallTimeout default must apply and expire the call.
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 val call = proxy.createMethodCall(ids.iface, MethodName("Slow"))
                 call.append(1)
                 proxy.callMethod(call)
@@ -185,7 +185,7 @@ class FailurePathParityTest {
 
     // --- remote D-Bus error propagation ----------------------------------------------------
 
-    // A handler that throws a named D-Bus Error must reach the client with the same name AND
+    // A handler that throws a named D-Bus SdbusException must reach the client with the same name AND
     // message on both backends. This pins the error model: the name is the contract, not an
     // implementation detail that one backend is free to rewrite.
     @Test
@@ -199,7 +199,7 @@ class FailurePathParityTest {
         val registration = obj.addVTable(ids.iface) {
             method(MethodName("Throw")) {
                 call<Int, Int> { _ ->
-                    throw Error(errorName, errorMessage)
+                    throw SdbusException(errorName, errorMessage)
                 }
             }
         }
@@ -207,7 +207,7 @@ class FailurePathParityTest {
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
 
         try {
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 proxy.callMethod<Int>(ids.iface, MethodName("Throw")) {
                     call(1)
                 }
@@ -223,7 +223,7 @@ class FailurePathParityTest {
         }
     }
 
-    // A method that simply doesn't exist must produce an Error (the daemon's UnknownMethod) on
+    // A method that simply doesn't exist must produce an SdbusException (the daemon's UnknownMethod) on
     // both backends rather than silently returning or hanging.
     @Test
     fun callToNonexistentMethod_surfacesError() = runBlocking {
@@ -240,7 +240,7 @@ class FailurePathParityTest {
         val proxy = createProxy(proxyConnection, ids.service, ids.path)
 
         try {
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 proxy.callMethod<Int>(ids.iface, MethodName("DoesNotExist")) {
                     call(1)
                 }
@@ -356,7 +356,7 @@ class FailurePathParityTest {
     }
 
     // Tearing down the server side while the client still holds a proxy must not crash the
-    // client: a call to the now-gone service surfaces as an Error on both backends. Time-bounded
+    // client: a call to the now-gone service surfaces as an SdbusException on both backends. Time-bounded
     // to keep a teardown hang from stalling the suite.
     @Test
     fun callAfterServerTeardown_failsConsistently() = runBlocking {
@@ -386,9 +386,9 @@ class FailurePathParityTest {
             obj.release()
             serverConnection.release()
 
-            // The service no longer exists; the client call must surface an Error, not hang.
+            // The service no longer exists; the client call must surface an SdbusException, not hang.
             withTimeout(5_000) {
-                assertFailsWith<Error> {
+                assertFailsWith<SdbusException> {
                     proxy.callMethod<Int>(ids.iface, MethodName("Echo")) {
                         call(10)
                         timeout = 2_000.milliseconds

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TypeMatrixRoundTripTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TypeMatrixRoundTripTest.kt
@@ -1,9 +1,9 @@
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.Signature
 import com.monkopedia.sdbus.Variant
@@ -398,7 +398,7 @@ class TypeMatrixRoundTripTest {
 
         try {
             // ... while the client deserializes the reply as a struct (signature "(ii)").
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 proxy.callMethod<IntPair>(ids.iface, MethodName("Echo")) {
                     call(7)
                 }

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/unit/MessageCommonTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/unit/MessageCommonTest.kt
@@ -1,8 +1,8 @@
 package com.monkopedia.sdbus.unit
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PlainMessage
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.Signature
 import com.monkopedia.sdbus.UnixFd
 import com.monkopedia.sdbus.Variant
@@ -179,7 +179,7 @@ class MessageCommonTest {
         try {
             msgCopy.deserialize<String>()
             fail("Expected read failure from shallow copy")
-        } catch (_: Error) {
+        } catch (_: SdbusException) {
             // Expected: both references share cursor state.
         }
     }
@@ -256,7 +256,7 @@ class MessageCommonTest {
         try {
             variant.get<Boolean>()
             fail("Expected variant type mismatch error")
-        } catch (_: Error) {
+        } catch (_: SdbusException) {
             // Expected mismatch.
         }
     }

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/unit/TypesCommonTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/unit/TypesCommonTest.kt
@@ -1,8 +1,8 @@
 package com.monkopedia.sdbus.unit
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PlainMessage.Companion.createPlainMessage
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.Signature
 import com.monkopedia.sdbus.Variant
 import com.monkopedia.sdbus.containsValueOfType
@@ -105,7 +105,7 @@ class TypesCommonTest {
         val msg = createPlainMessage()
         try {
             variant.serializeTo(msg)
-        } catch (_: Error) {
+        } catch (_: SdbusException) {
             return
         }
         kotlin.test.fail("Expected serialization to fail for empty variant")
@@ -138,15 +138,15 @@ class TypesCommonTest {
 
     @Test
     fun anError_CanBeConstructedFromANameAndAMessage() {
-        val error = Error("org.sdbuscpp.error", "message")
+        val error = SdbusException("org.sdbuscpp.error", "message")
         assertEquals("org.sdbuscpp.error", error.name)
         assertEquals("message", error.errorMessage)
     }
 
     @Test
     fun anError_CanBeConstructedFromANameOnly() {
-        val error1 = Error("org.sdbuscpp.error")
-        val error2 = Error("org.sdbuscpp.error", "")
+        val error1 = SdbusException("org.sdbuscpp.error")
+        val error2 = SdbusException("org.sdbuscpp.error", "")
         assertEquals("org.sdbuscpp.error", error1.name)
         assertEquals("org.sdbuscpp.error", error2.name)
         assertEquals("", error1.errorMessage)

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Error.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Error.jvm.kt
@@ -58,15 +58,15 @@ private val errnoMappings: Map<Int, ErrnoMapping> = mapOf(
  * and the message is `"$customMsg (<strerror text>)"`. Keeping the same mapping on
  * the JVM makes error names a cross-backend contract instead of a backend detail.
  */
-internal actual fun createError(errNo: Int, customMsg: String): Error {
+internal actual fun createError(errNo: Int, customMsg: String): SdbusException {
     // sd_bus_error_set_errno accepts negated errnos (e.g. -EINVAL) and takes the absolute value.
     val errno = if (errNo < 0) -errNo else errNo
     if (errno == 0) {
         // sd_bus_error_set_errno(0) leaves the error unset; the native createError then falls
         // back to "$errNo" as the name and an empty strerror text.
-        return Error("$errNo", "$customMsg ()")
+        return SdbusException("$errNo", "$customMsg ()")
     }
     val mapping = errnoMappings[errno]
         ?: ErrnoMapping("${DBUS_ERROR_PREFIX}Failed", "Unknown error $errno")
-    return Error(mapping.name, "$customMsg (${mapping.description})")
+    return SdbusException(mapping.name, "$customMsg (${mapping.description})")
 }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/JvmValueCodec.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/JvmValueCodec.jvm.kt
@@ -329,14 +329,14 @@ internal class JvmValueDecoder(
         }
     }
 
-    private fun slotTypeError(operation: String, slot: Any?): Error = createError(
+    private fun slotTypeError(operation: String, slot: Any?): SdbusException = createError(
         -1,
         "$operation failed: unexpected payload type ${slot?.let { it::class.simpleName }}"
     )
 
     // ENXIO mirrors the native backend, which fails entering a mismatched container with
     // -ENXIO from sd_bus_message_enter_container.
-    private fun structMismatchError(descriptor: SerialDescriptor, slot: Any?): Error {
+    private fun structMismatchError(descriptor: SerialDescriptor, slot: Any?): SdbusException {
         val expected = runCatching { descriptor.asSignature.value }.getOrNull() ?: "?"
         val actual = inferJvmPayloadSignature(slot) ?: slot?.let { it::class.simpleName } ?: "null"
         return createError(

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -468,7 +468,7 @@ actual class MethodCall internal constructor() : Message() {
     actual fun createReply(): MethodReply = MethodReply(this).also {
         it.metadata = Metadata(valid = true, empty = true)
     }
-    actual fun createErrorReply(error: Error): MethodReply = MethodReply(this).also {
+    actual fun createErrorReply(error: SdbusException): MethodReply = MethodReply(this).also {
         it.error = error
         it.metadata = Metadata(valid = false, empty = true)
     }
@@ -488,7 +488,7 @@ actual class MethodCall internal constructor() : Message() {
 
 actual class MethodReply internal constructor(private val parentCall: MethodCall? = null) :
     Message() {
-    internal var error: Error? = null
+    internal var error: SdbusException? = null
 
     actual fun send(): Unit = run {
         if (metadata.valid) {
@@ -584,7 +584,7 @@ internal actual fun <T : Any> Message.deserialize(
         !isSignatureCompatible(expectedSig, actualSig)
     ) {
         // ENXIO: the native backend surfaces a signature mismatch as -ENXIO from
-        // sd_bus_message_enter_container / read_basic, i.e. Error("System.Error.ENXIO", ...).
+        // sd_bus_message_enter_container / read_basic, i.e. SdbusException("System.Error.ENXIO", ...).
         throw createError(
             6,
             "Message.deserialize failed: signature mismatch expected=$expectedSig actual=$actualSig"

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -348,7 +348,7 @@ internal class DBusWireConnection private constructor(
             // A pre-send rejection (e.g. an invalid Unix FD) is synchronous: nothing went on the
             // wire, so there is no reply to await. Evict the orphaned pending entry and rethrow so
             // [call]/[callBlocking] surface it directly to the caller (the wire backend then maps a
-            // DBusCallException to a com.monkopedia.sdbus.Error — see WireDbusProxy.callRemote).
+            // DBusCallException to a com.monkopedia.sdbus.SdbusException — see WireDbusProxy.callRemote).
             pending.remove(serial)
             throw e
         }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -296,7 +296,7 @@ internal class WireDbusProxy(
             // (phase 4), so our own peer would never reply and the caller would hang until
             // timeout. Fail fast with UnknownMethod, the same outcome dbus-java produces by
             // auto-replying for an unexported member.
-            throw com.monkopedia.sdbus.Error(
+            throw com.monkopedia.sdbus.SdbusException(
                 "org.freedesktop.DBus.Error.UnknownMethod",
                 "No handler for $path:$interfaceName.$methodName on local destination " +
                     destination.value
@@ -340,7 +340,7 @@ internal class WireDbusProxy(
                 java.util.concurrent.TimeUnit.MILLISECONDS
             )
         ) {
-            throw com.monkopedia.sdbus.Error(
+            throw com.monkopedia.sdbus.SdbusException(
                 "org.freedesktop.DBus.Error.Timeout",
                 "Method call timed out"
             )
@@ -438,7 +438,7 @@ internal class WireDbusProxy(
         } catch (e: DBusCallException) {
             // Preserve the wire ERROR_NAME verbatim, like the native backend copies it straight
             // into sd_bus_error instead of squeezing it through the errno mapping (issue #72).
-            throw com.monkopedia.sdbus.Error(
+            throw com.monkopedia.sdbus.SdbusException(
                 e.errorName ?: "org.freedesktop.DBus.Error.Failed",
                 e.errorMessage.orEmpty()
             )
@@ -487,7 +487,7 @@ internal class WireDbusProxy(
             outcome.fold(
                 onSuccess = { asyncReplyCallback(it, null) },
                 onFailure = {
-                    val error = it as? com.monkopedia.sdbus.Error
+                    val error = it as? com.monkopedia.sdbus.SdbusException
                         ?: createError(-1, it.message ?: "JVM wire async call failed")
                     asyncReplyCallback(invalidReply(path, interfaceName, methodName), error)
                 }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
@@ -101,7 +101,7 @@ internal object WireServe {
                 INTROSPECTABLE_INTERFACE -> serveIntrospect(localUniqueName, message, member)
                 else -> serveDispatch(localUniqueName, message, iface, member)
             }
-        } catch (e: com.monkopedia.sdbus.Error) {
+        } catch (e: com.monkopedia.sdbus.SdbusException) {
             errorReply(message, e.name, e.errorMessage)
         } catch (e: Throwable) {
             errorReply(message, ERROR_FAILED, e.message ?: "Handler failed")

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
@@ -73,7 +73,7 @@ class JvmMessageSupportTest {
             call.append(20)
             call.append(22)
 
-            val thrown = assertFailsWith<Error> {
+            val thrown = assertFailsWith<SdbusException> {
                 call.send(1.milliseconds)
             }
             assertTrue(thrown.errorMessage.contains("timed out"))
@@ -133,7 +133,7 @@ class JvmMessageSupportTest {
             )
         }
 
-        assertFailsWith<Error> {
+        assertFailsWith<SdbusException> {
             signal.send()
         }
     }
@@ -161,13 +161,13 @@ class JvmMessageSupportTest {
     fun credentialAccessors_withoutSenderCredentialsFailWithSdbusError() {
         val message = PlainMessage.createPlainMessage()
 
-        assertFailsWith<Error> { message.credsPid }
-        assertFailsWith<Error> { message.credsUid }
-        assertFailsWith<Error> { message.credsEuid }
-        assertFailsWith<Error> { message.credsGid }
-        assertFailsWith<Error> { message.credsEgid }
-        assertFailsWith<Error> { message.credsSupplementaryGids }
-        assertFailsWith<Error> { message.seLinuxContext }
+        assertFailsWith<SdbusException> { message.credsPid }
+        assertFailsWith<SdbusException> { message.credsUid }
+        assertFailsWith<SdbusException> { message.credsEuid }
+        assertFailsWith<SdbusException> { message.credsGid }
+        assertFailsWith<SdbusException> { message.credsEgid }
+        assertFailsWith<SdbusException> { message.credsSupplementaryGids }
+        assertFailsWith<SdbusException> { message.seLinuxContext }
     }
 
     // Regression: D-Bus `ay` (e.g. a GATT characteristic value) arrives from dbus-java as

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -11,11 +11,11 @@ class JvmRealBusIntegrationTest {
 
     // These tests need a *real* bus. The connection factories throw when the bus is
     // unreachable (issue #81) instead of silently returning the in-process stub backend, so
-    // "no usable bus in this environment" now surfaces as a thrown Error -- treat it as a
+    // "no usable bus in this environment" now surfaces as a thrown SdbusException -- treat it as a
     // skip, the way the old ":jvm-stub" unique-name gate did.
     private fun connectOrNull(connect: () -> Connection): Connection? = try {
         connect()
-    } catch (e: Error) {
+    } catch (e: SdbusException) {
         null
     }
 

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmScaffoldTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmScaffoldTest.kt
@@ -22,7 +22,7 @@ class JvmScaffoldTest {
         val proxy = createProxy(ServiceName("org.example"), ObjectPath("/org/example"))
         val call = proxy.createMethodCall(InterfaceName("org.example"), MethodName("Ping"))
 
-        assertFailsWith<Error> {
+        assertFailsWith<SdbusException> {
             proxy.callMethod(call)
         }
     }
@@ -79,7 +79,7 @@ class JvmScaffoldTest {
         assertEquals(10, reply.readInt())
 
         registration.release()
-        assertFailsWith<Error> {
+        assertFailsWith<SdbusException> {
             proxy.callMethod(call)
         }
     }
@@ -129,7 +129,7 @@ class JvmScaffoldTest {
 
             val latch = CountDownLatch(1)
             val resultRef = AtomicReference<Int?>(null)
-            val errorRef = AtomicReference<Error?>(null)
+            val errorRef = AtomicReference<SdbusException?>(null)
             val pending = proxy.callMethodAsync(call) { reply, error ->
                 errorRef.set(error)
                 if (error == null) {

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmUnreachableBusTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmUnreachableBusTest.kt
@@ -6,11 +6,11 @@ import kotlin.test.assertTrue
 
 /**
  * Pins the issue #81 fix: when the bus is unreachable, the JVM connection factories must THROW
- * a [com.monkopedia.sdbus.Error] like the native backend (whose openBus fails with
+ * a [com.monkopedia.sdbus.SdbusException] like the native backend (whose openBus fails with
  * "Failed to open bus") -- never silently fall back to a stub that fakes a successful connection.
  *
  * The exact D-Bus error *name* is not pinned across backends (the owned wire connection surfaces a
- * connect/transport failure rather than an sd-bus errno); the contract is the Error type and the
+ * connect/transport failure rather than an sd-bus errno); the contract is the SdbusException type and the
  * throw.
  */
 class JvmUnreachableBusTest {
@@ -23,7 +23,7 @@ class JvmUnreachableBusTest {
     // the test runner itself was started with.
     @Test
     fun createSessionBusConnection_withUnreachableAddress_throwsInsteadOfStubFallback() {
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             createSessionBusConnection(unreachableAddress())
         }
         assertTrue(
@@ -35,7 +35,7 @@ class JvmUnreachableBusTest {
 
     @Test
     fun createDirectBusConnection_withUnreachableAddress_throwsError() {
-        val error = assertFailsWith<Error> {
+        val error = assertFailsWith<SdbusException> {
             createDirectBusConnection(unreachableAddress())
         }
         assertTrue(

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Connection.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Connection.native.kt
@@ -66,7 +66,7 @@ actual fun createSessionBusConnection(address: String): Connection =
  * @param host Name of the host to connect
  * @return [Connection] instance
  *
- * @throws [com.monkopedia.sdbus.Error] in case of failure
+ * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */
 fun createRemoteSystemBusConnection(host: String): Connection = remoteConnection(SdBus(), host)
 

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Error.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Error.native.kt
@@ -34,7 +34,7 @@ import sdbus.sd_bus_error
 import sdbus.sd_bus_error_free
 import sdbus.sd_bus_error_set_errno
 
-internal actual fun createError(errNo: Int, customMsg: String): Error {
+internal actual fun createError(errNo: Int, customMsg: String): SdbusException {
     memScoped {
         val sdbusError: CPointer<sd_bus_error> = cValue<sd_bus_error>().getPointer(this)
 
@@ -49,6 +49,6 @@ internal actual fun createError(errNo: Int, customMsg: String): Error {
             append(')')
         }
 
-        return Error(name, message)
+        return SdbusException(name, message)
     }
 }

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/MethodCall.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/MethodCall.native.kt
@@ -100,7 +100,7 @@ actual class MethodCall internal constructor(
         MethodReply(sdbusReply[0]!!, sdbus, adoptMessage = true)
     }
 
-    actual fun createErrorReply(error: Error): MethodReply = memScoped {
+    actual fun createErrorReply(error: SdbusException): MethodReply = memScoped {
         val sdbusError = sdBusNullError()
         sd_bus_error_set(sdbusError, error.name, error.errorMessage)
 
@@ -132,7 +132,7 @@ actual class MethodCall internal constructor(
 
         if (sd_bus_error_is_set(sdbusError) != 0) {
             sdbusError[0].apply {
-                throw Error(name?.toKString()!!, message?.toKString()!!)
+                throw SdbusException(name?.toKString()!!, message?.toKString()!!)
             }
         }
 

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ProxyImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ProxyImpl.kt
@@ -27,7 +27,6 @@ package com.monkopedia.sdbus.internal
 import cnames.structs.sd_bus_message
 import com.monkopedia.sdbus.AsyncReplyHandler
 import com.monkopedia.sdbus.CallbackAsyncProxy
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodCall
@@ -35,6 +34,7 @@ import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.MethodReply
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.Signal
 import com.monkopedia.sdbus.SignalHandler
@@ -158,8 +158,8 @@ internal class ProxyImpl(
 
         try {
             return deferred.await()
-        } catch (e: Error) {
-            throw Error(e.name, e.errorMessage)
+        } catch (e: SdbusException) {
+            throw SdbusException(e.name, e.errorMessage)
         }
     }
 
@@ -260,7 +260,7 @@ internal class ProxyImpl(
                             if (error == null) {
                                 asyncCallInfo.callback(message, null)
                             } else {
-                                val exception = Error(
+                                val exception = SdbusException(
                                     error[0].name?.toKString() ?: "",
                                     error[0].message?.toKString() ?: ""
                                 )

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/Utils.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/Utils.kt
@@ -24,7 +24,7 @@
 
 package com.monkopedia.sdbus.internal
 
-import com.monkopedia.sdbus.Error
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.sdbusRequire
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
@@ -47,7 +47,7 @@ internal inline fun invokeHandlerAndCatchErrors(
 ): Boolean {
     try {
         callable()
-    } catch (e: Error) {
+    } catch (e: SdbusException) {
         sd_bus_error_set(retError, e.name, e.message)
         return false
     } catch (t: Throwable) {

--- a/src/nativeTest/kotlin/integration/DBusMethodTests.kt
+++ b/src/nativeTest/kotlin/integration/DBusMethodTests.kt
@@ -24,10 +24,10 @@
 
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.Variant
 import com.monkopedia.sdbus.addVTable
@@ -187,8 +187,8 @@ class DBusMethodTests : BaseTest() {
                 1.microseconds,
                 1000u
             ) // The operation will take 1s, but the timeout is 1us, so we should time out
-            fail("Expected Error exception")
-        } catch (e: Error) {
+            fail("Expected SdbusException exception")
+        } catch (e: SdbusException) {
             assertContains(
                 listOf("org.freedesktop.DBus.Error.Timeout", "org.freedesktop.DBus.Error.NoReply"),
                 e.name
@@ -206,8 +206,8 @@ class DBusMethodTests : BaseTest() {
     fun callsMethodThatThrowsError() {
         try {
             fixture.proxy!!.throwError()
-            fail("Expected Error exception")
-        } catch (e: Error) {
+            fail("Expected SdbusException exception")
+        } catch (e: SdbusException) {
             assertEquals("org.freedesktop.DBus.Error.AccessDenied", e.name)
             assertEquals("A test error occurred (Operation not permitted)", e.errorMessage)
         }
@@ -225,7 +225,7 @@ class DBusMethodTests : BaseTest() {
         try {
             fixture.proxy!!.callNonexistentMethod()
             fail("Expected error")
-        } catch (t: Error) {
+        } catch (t: SdbusException) {
             // Expected error
         }
     }
@@ -235,7 +235,7 @@ class DBusMethodTests : BaseTest() {
         try {
             fixture.proxy!!.callMethodOnNonexistentInterface()
             fail("Expected error")
-        } catch (t: Error) {
+        } catch (t: SdbusException) {
             // Expected error
         }
     }
@@ -248,7 +248,7 @@ class DBusMethodTests : BaseTest() {
             try {
                 proxy.getInt()
                 fail("Expected error")
-            } catch (t: Error) {
+            } catch (t: SdbusException) {
                 // Expected error
             }
         } finally {
@@ -263,7 +263,7 @@ class DBusMethodTests : BaseTest() {
             try {
                 proxy.getInt()
                 fail("Expected error")
-            } catch (t: Error) {
+            } catch (t: SdbusException) {
                 // Expected error
             }
         } finally {

--- a/src/nativeTest/kotlin/integration/TestProxy.kt
+++ b/src/nativeTest/kotlin/integration/TestProxy.kt
@@ -24,7 +24,6 @@
 
 package com.monkopedia.sdbus.integration
 
-import com.monkopedia.sdbus.Error
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodName
@@ -32,6 +31,7 @@ import com.monkopedia.sdbus.MethodReply
 import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PropertyName
 import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.SignalName
 import com.monkopedia.sdbus.Variant
@@ -72,7 +72,7 @@ class TestProxy private constructor(proxy: Proxy) : IntegrationTestsProxy(proxy)
     var gotSignalWithVariant = atomic(false)
     var variantFromSignal = 0.0
 
-    var doOperationClientSideAsyncReplyHandler: ((UInt, Error?) -> Unit)? = null
+    var doOperationClientSideAsyncReplyHandler: ((UInt, SdbusException?) -> Unit)? = null
     var propertiesChangedHandler: (
         (InterfaceName, Map<PropertyName, Variant>, List<PropertyName>) -> Unit
     )? =
@@ -98,7 +98,7 @@ class TestProxy private constructor(proxy: Proxy) : IntegrationTestsProxy(proxy)
         gotSignalWithVariant.value = true
     }
 
-    fun onDoOperationReply(returnValue: UInt, error: Error?) {
+    fun onDoOperationReply(returnValue: UInt, error: SdbusException?) {
         doOperationClientSideAsyncReplyHandler?.invoke(returnValue, error)
     }
 
@@ -114,7 +114,7 @@ class TestProxy private constructor(proxy: Proxy) : IntegrationTestsProxy(proxy)
         )
     }
 
-    fun installDoOperationClientSideAsyncReplyHandler(handler: (UInt, Error?) -> Unit) {
+    fun installDoOperationClientSideAsyncReplyHandler(handler: (UInt, SdbusException?) -> Unit) {
         doOperationClientSideAsyncReplyHandler = handler
     }
 


### PR DESCRIPTION
Closes #109. Group 1 of the 0.6.0 wave (epic #108). Public API change (api dumps regenerated).

## What
Renames the public exception type `com.monkopedia.sdbus.Error` → `SdbusException`, with a deprecated typealias for source compatibility:
```
@Deprecated("Renamed to SdbusException", ReplaceWith("SdbusException", "com.monkopedia.sdbus.SdbusException"), DeprecationLevel.WARNING)
typealias Error = SdbusException
```
Cadence: 0.6.0 deprecates `Error`; 1.0 removes the alias.

## Scope
- `Error.kt` class renamed; `createError` (common expect + native/jvm actuals) and `createErrorReply` signatures updated; 45 files migrated to `SdbusException` (library + tests + cross_test + samples/bluez-scan); KDoc `[Error]` links repointed.
- Deliberately untouched: genuine `kotlin.Error` usages and all `org.freedesktop.DBus.Error.*` D-Bus error-name strings (substitution skipped dotted names; verified no string corruption).
- Library compiles with zero deprecation warnings (the one FQN self-reference was migrated).

## Verification
- compile jvm + linuxX64 + linuxArm64: green.
- `:jvmTest` 300/0, `:linuxX64Test` 270/0 (under dbus-run-session).
- `ktlintCheck` + `apiCheck` green against the regenerated dumps (`Error`→`SdbusException` in both .api and .klib.api; BCV doesn't track the source-only typealias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
