### PR TITLE
Mechanical API batch: Resource:AutoCloseable, de-data Typed, etc. [#116]

### DIFF
--- a/api/sdbus-kotlin.api
+++ b/api/sdbus-kotlin.api
@@ -61,6 +61,10 @@ public abstract interface class com/monkopedia/sdbus/Connection : com/monkopedia
 	public abstract fun stopEventLoop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/monkopedia/sdbus/Connection$DefaultImpls {
+	public static fun close (Lcom/monkopedia/sdbus/Connection;)V
+}
+
 public final class com/monkopedia/sdbus/Connection_jvmKt {
 	public static final fun createBusConnection ()Lcom/monkopedia/sdbus/Connection;
 	public static final fun createBusConnection-em-jQOc (Ljava/lang/String;)Lcom/monkopedia/sdbus/Connection;
@@ -76,7 +80,6 @@ public final class com/monkopedia/sdbus/Connection_jvmKt {
 
 public final class com/monkopedia/sdbus/DegroupingReturnsKt {
 	public static final fun maybeDegrouped (Lkotlinx/serialization/KSerializer;Z)Lkotlinx/serialization/KSerializer;
-	public static final fun maybeDegrouped-qeoUwEc (Ljava/lang/String;Z)Ljava/lang/String;
 }
 
 public final class com/monkopedia/sdbus/Flags {
@@ -87,14 +90,6 @@ public final class com/monkopedia/sdbus/Flags {
 	public static synthetic fun set$default (Lcom/monkopedia/sdbus/Flags;Lcom/monkopedia/sdbus/Flags$PropertyUpdateBehaviorFlags;ZILjava/lang/Object;)V
 	public final fun test (Lcom/monkopedia/sdbus/Flags$GeneralFlags;)Z
 	public final fun test (Lcom/monkopedia/sdbus/Flags$PropertyUpdateBehaviorFlags;)Z
-}
-
-public final class com/monkopedia/sdbus/Flags$Count : java/lang/Enum {
-	public static final field FLAG_COUNT Lcom/monkopedia/sdbus/Flags$Count;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun getValue-w2LRezQ ()B
-	public static fun valueOf (Ljava/lang/String;)Lcom/monkopedia/sdbus/Flags$Count;
-	public static fun values ()[Lcom/monkopedia/sdbus/Flags$Count;
 }
 
 public final class com/monkopedia/sdbus/Flags$GeneralFlags : java/lang/Enum {
@@ -297,6 +292,10 @@ public abstract interface class com/monkopedia/sdbus/Object : com/monkopedia/sdb
 	public abstract fun getObjectPath-qg5VnaA ()Ljava/lang/String;
 }
 
+public final class com/monkopedia/sdbus/Object$DefaultImpls {
+	public static fun close (Lcom/monkopedia/sdbus/Object;)V
+}
+
 public final class com/monkopedia/sdbus/ObjectManagerProxy {
 	public static final field Companion Lcom/monkopedia/sdbus/ObjectManagerProxy$Companion;
 	public fun <init> (Lcom/monkopedia/sdbus/Proxy;)V
@@ -398,7 +397,6 @@ public class com/monkopedia/sdbus/PropertyDelegate : kotlin/properties/ReadOnlyP
 	public final fun get ()Ljava/lang/Object;
 	public final fun getInterfaceName-DgtVVXE ()Ljava/lang/String;
 	protected final fun getModule ()Lkotlinx/serialization/modules/SerializersModule;
-	public final fun getName ()Ljava/lang/String;
 	public final fun getOrNull ()Ljava/lang/Object;
 	public final fun getPropertyName-t13AQBo ()Ljava/lang/String;
 	protected final fun getProxy ()Lcom/monkopedia/sdbus/Proxy;
@@ -451,6 +449,10 @@ public abstract interface class com/monkopedia/sdbus/Proxy : com/monkopedia/sdbu
 	public abstract fun registerSignalHandler-kQgV_DE (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/monkopedia/sdbus/Resource;
 }
 
+public final class com/monkopedia/sdbus/Proxy$DefaultImpls {
+	public static fun close (Lcom/monkopedia/sdbus/Proxy;)V
+}
+
 public abstract interface class com/monkopedia/sdbus/ProxyHolder {
 	public abstract fun getProxy ()Lcom/monkopedia/sdbus/Proxy;
 }
@@ -469,8 +471,13 @@ public final class com/monkopedia/sdbus/Proxy_jvmKt {
 	public static synthetic fun createProxy-M1YkbpM$default (Lcom/monkopedia/sdbus/Connection;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/sdbus/Proxy;
 }
 
-public abstract interface class com/monkopedia/sdbus/Resource {
+public abstract interface class com/monkopedia/sdbus/Resource : java/lang/AutoCloseable {
+	public fun close ()V
 	public abstract fun release ()V
+}
+
+public final class com/monkopedia/sdbus/Resource$DefaultImpls {
+	public static fun close (Lcom/monkopedia/sdbus/Resource;)V
 }
 
 public final class com/monkopedia/sdbus/SdbusException : java/lang/Exception {
@@ -590,11 +597,6 @@ public final class com/monkopedia/sdbus/TypeTraitsKt {
 public final class com/monkopedia/sdbus/Typed {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;Lcom/monkopedia/sdbus/SdbusSig;)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;Lcom/monkopedia/sdbus/SdbusSig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;Lcom/monkopedia/sdbus/SdbusSig;)Lcom/monkopedia/sdbus/Typed;
-	public static synthetic fun copy$default (Lcom/monkopedia/sdbus/Typed;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;Lcom/monkopedia/sdbus/SdbusSig;ILjava/lang/Object;)Lcom/monkopedia/sdbus/Typed;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/monkopedia/sdbus/TypedArguments {
@@ -662,6 +664,7 @@ public final class com/monkopedia/sdbus/UnixFd : com/monkopedia/sdbus/Resource {
 	public fun <init> (I)V
 	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/monkopedia/sdbus/UnixFd;)V
+	public fun close ()V
 	public final fun getFd ()I
 	public fun release ()V
 }

--- a/api/sdbus-kotlin.klib.api
+++ b/api/sdbus-kotlin.klib.api
@@ -92,19 +92,15 @@ abstract interface com.monkopedia.sdbus/ProxyHolder { // com.monkopedia.sdbus/Pr
         abstract fun <get-proxy>(): com.monkopedia.sdbus/Proxy // com.monkopedia.sdbus/ProxyHolder.proxy.<get-proxy>|<get-proxy>(){}[0]
 }
 
-abstract interface com.monkopedia.sdbus/Resource { // com.monkopedia.sdbus/Resource|null[0]
+abstract interface com.monkopedia.sdbus/Resource : kotlin/AutoCloseable { // com.monkopedia.sdbus/Resource|null[0]
     abstract fun release() // com.monkopedia.sdbus/Resource.release|release(){}[0]
+    open fun close() // com.monkopedia.sdbus/Resource.close|close(){}[0]
 }
 
 sealed interface com.monkopedia.sdbus/VTableItem // com.monkopedia.sdbus/VTableItem|null[0]
 
 final class <#A: kotlin/Any> com.monkopedia.sdbus/Typed { // com.monkopedia.sdbus/Typed|null[0]
     constructor <init>(kotlin.reflect/KClass<#A>, kotlinx.serialization/KSerializer<#A>, com.monkopedia.sdbus/SdbusSig = ...) // com.monkopedia.sdbus/Typed.<init>|<init>(kotlin.reflect.KClass<1:0>;kotlinx.serialization.KSerializer<1:0>;com.monkopedia.sdbus.SdbusSig){}[0]
-
-    final fun copy(kotlin.reflect/KClass<#A> = ..., kotlinx.serialization/KSerializer<#A> = ..., com.monkopedia.sdbus/SdbusSig = ...): com.monkopedia.sdbus/Typed<#A> // com.monkopedia.sdbus/Typed.copy|copy(kotlin.reflect.KClass<1:0>;kotlinx.serialization.KSerializer<1:0>;com.monkopedia.sdbus.SdbusSig){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.sdbus/Typed.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // com.monkopedia.sdbus/Typed.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // com.monkopedia.sdbus/Typed.toString|toString(){}[0]
 }
 
 final class <#A: kotlin/Any?, #B: kotlin/Any> com.monkopedia.sdbus/MutablePropertyDelegate : com.monkopedia.sdbus/PropertyDelegate<#A, #B>, kotlin.properties/ReadWriteProperty<#A, #B> { // com.monkopedia.sdbus/MutablePropertyDelegate|null[0]
@@ -154,18 +150,6 @@ final class com.monkopedia.sdbus/Flags { // com.monkopedia.sdbus/Flags|null[0]
     final fun set(com.monkopedia.sdbus/Flags.PropertyUpdateBehaviorFlags, kotlin/Boolean = ...) // com.monkopedia.sdbus/Flags.set|set(com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags;kotlin.Boolean){}[0]
     final fun test(com.monkopedia.sdbus/Flags.GeneralFlags): kotlin/Boolean // com.monkopedia.sdbus/Flags.test|test(com.monkopedia.sdbus.Flags.GeneralFlags){}[0]
     final fun test(com.monkopedia.sdbus/Flags.PropertyUpdateBehaviorFlags): kotlin/Boolean // com.monkopedia.sdbus/Flags.test|test(com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags){}[0]
-
-    final enum class Count : kotlin/Enum<com.monkopedia.sdbus/Flags.Count> { // com.monkopedia.sdbus/Flags.Count|null[0]
-        enum entry FLAG_COUNT // com.monkopedia.sdbus/Flags.Count.FLAG_COUNT|null[0]
-
-        final val entries // com.monkopedia.sdbus/Flags.Count.entries|#static{}entries[0]
-            final fun <get-entries>(): kotlin.enums/EnumEntries<com.monkopedia.sdbus/Flags.Count> // com.monkopedia.sdbus/Flags.Count.entries.<get-entries>|<get-entries>#static(){}[0]
-        final val value // com.monkopedia.sdbus/Flags.Count.value|{}value[0]
-            final fun <get-value>(): kotlin/UByte // com.monkopedia.sdbus/Flags.Count.value.<get-value>|<get-value>(){}[0]
-
-        final fun valueOf(kotlin/String): com.monkopedia.sdbus/Flags.Count // com.monkopedia.sdbus/Flags.Count.valueOf|valueOf#static(kotlin.String){}[0]
-        final fun values(): kotlin/Array<com.monkopedia.sdbus/Flags.Count> // com.monkopedia.sdbus/Flags.Count.values|values#static(){}[0]
-    }
 
     final enum class GeneralFlags : kotlin/Enum<com.monkopedia.sdbus/Flags.GeneralFlags> { // com.monkopedia.sdbus/Flags.GeneralFlags|null[0]
         enum entry DEPRECATED // com.monkopedia.sdbus/Flags.GeneralFlags.DEPRECATED|null[0]
@@ -628,8 +612,6 @@ open class <#A: kotlin/Any?, #B: kotlin/Any> com.monkopedia.sdbus/PropertyDelega
         final fun <get-interfaceName>(): com.monkopedia.sdbus/InterfaceName // com.monkopedia.sdbus/PropertyDelegate.interfaceName.<get-interfaceName>|<get-interfaceName>(){}[0]
     final val module // com.monkopedia.sdbus/PropertyDelegate.module|{}module[0]
         final fun <get-module>(): kotlinx.serialization.modules/SerializersModule // com.monkopedia.sdbus/PropertyDelegate.module.<get-module>|<get-module>(){}[0]
-    final val name // com.monkopedia.sdbus/PropertyDelegate.name|{}name[0]
-        final fun <get-name>(): kotlin/String // com.monkopedia.sdbus/PropertyDelegate.name.<get-name>|<get-name>(){}[0]
     final val propertyName // com.monkopedia.sdbus/PropertyDelegate.propertyName|{}propertyName[0]
         final fun <get-propertyName>(): com.monkopedia.sdbus/MemberName // com.monkopedia.sdbus/PropertyDelegate.propertyName.<get-propertyName>|<get-propertyName>(){}[0]
     final val proxy // com.monkopedia.sdbus/PropertyDelegate.proxy|{}proxy[0]
@@ -791,7 +773,6 @@ final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/getAllProperties(): 
 final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/getAllPropertiesAsync(): com.monkopedia.sdbus/AsyncAllPropertiesGetter // com.monkopedia.sdbus/getAllPropertiesAsync|getAllPropertiesAsync@com.monkopedia.sdbus.Proxy(){}[0]
 final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/getPropertyAsync(com.monkopedia.sdbus/MemberName): com.monkopedia.sdbus/AsyncPropertyGetter // com.monkopedia.sdbus/getPropertyAsync|getPropertyAsync@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.MemberName){}[0]
 final fun (com.monkopedia.sdbus/Proxy).com.monkopedia.sdbus/setPropertyAsync(com.monkopedia.sdbus/MemberName): com.monkopedia.sdbus/AsyncPropertySetter // com.monkopedia.sdbus/setPropertyAsync|setPropertyAsync@com.monkopedia.sdbus.Proxy(com.monkopedia.sdbus.MemberName){}[0]
-final fun (com.monkopedia.sdbus/Signature).com.monkopedia.sdbus/maybeDegrouped(kotlin/Boolean): com.monkopedia.sdbus/Signature // com.monkopedia.sdbus/maybeDegrouped|maybeDegrouped@com.monkopedia.sdbus.Signature(kotlin.Boolean){}[0]
 final fun (com.monkopedia.sdbus/VTableBuilder).com.monkopedia.sdbus/method(com.monkopedia.sdbus/MemberName, kotlin/Function1<com.monkopedia.sdbus/MethodVTableItem, kotlin/Unit>) // com.monkopedia.sdbus/method|method@com.monkopedia.sdbus.VTableBuilder(com.monkopedia.sdbus.MemberName;kotlin.Function1<com.monkopedia.sdbus.MethodVTableItem,kotlin.Unit>){}[0]
 final fun <#A: kotlin/Any> (com.monkopedia.sdbus/Message).com.monkopedia.sdbus/deserialize(kotlinx.serialization/DeserializationStrategy<#A>, kotlinx.serialization.modules/SerializersModule): #A // com.monkopedia.sdbus/deserialize|deserialize@com.monkopedia.sdbus.Message(kotlinx.serialization.DeserializationStrategy<0:0>;kotlinx.serialization.modules.SerializersModule){0§<kotlin.Any>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.sdbus/Message).com.monkopedia.sdbus/serialize(kotlinx.serialization/SerializationStrategy<#A>, kotlinx.serialization.modules/SerializersModule, #A) // com.monkopedia.sdbus/serialize|serialize@com.monkopedia.sdbus.Message(kotlinx.serialization.SerializationStrategy<0:0>;kotlinx.serialization.modules.SerializersModule;0:0){0§<kotlin.Any?>}[0]

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/DegroupingReturns.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/DegroupingReturns.kt
@@ -41,7 +41,7 @@ import kotlinx.serialization.modules.SerializersModule
  * @param groupedReturn Whether the signature wraps grouped return values in a struct
  * @return The possibly-degrouped signature
  */
-fun Signature.maybeDegrouped(groupedReturn: Boolean): Signature {
+internal fun Signature.maybeDegrouped(groupedReturn: Boolean): Signature {
     if (groupedReturn) {
         require(value[0] == '(' && value.last() == ')') {
             "Value $value is not a struct and can't be degrouped"
@@ -56,7 +56,8 @@ fun Signature.maybeDegrouped(groupedReturn: Boolean): Signature {
  * to modify their serialization to not expect a struct to be wrapping them, degrouping does that
  * wrapping a trickery to avoid it.
  */
-fun <T> KSerializer<T>.maybeDegrouped(groupedReturn: Boolean): KSerializer<T> =
+@PublishedApi
+internal fun <T> KSerializer<T>.maybeDegrouped(groupedReturn: Boolean): KSerializer<T> =
     if (groupedReturn) this.degrouped() else this
 
 private fun <T> KSerializer<T>.degrouped(): KSerializer<T> {

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Flags.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Flags.kt
@@ -63,7 +63,7 @@ class Flags {
     }
 
     /** Internal marker carrying the total number of defined flags. */
-    enum class Count(val value: UByte) {
+    internal enum class Count(val value: UByte) {
         /** Sentinel value equal to the number of distinct flags. */
         FLAG_COUNT(7u)
     }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
@@ -151,10 +151,6 @@ open class PropertyDelegate<R, T : Any>(
     protected val module: SerializersModule,
     protected val signature: SdbusSig
 ) : ReadOnlyProperty<R, T> {
-    /** The property name as a plain string. */
-    val name: String
-        get() = propertyName.value
-
     override fun getValue(thisRef: R, property: KProperty<*>): T = get()
 
     /**

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Resource.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Resource.kt
@@ -33,9 +33,16 @@ package com.monkopedia.sdbus
  * Calling [release] multiple times will have no effect. Once [release] is called on
  * an object, that object should no longer be interacted with.
  */
-interface Resource {
+interface Resource : AutoCloseable {
     /**
      * Releases this resource and any child resources it may have.
      */
     fun release()
+
+    /**
+     * Closes this resource by delegating to [release], enabling use with `use { }`.
+     */
+    override fun close() {
+        release()
+    }
 }

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/TypedMethod.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/TypedMethod.kt
@@ -38,7 +38,7 @@ internal inline fun <reified T : Any> typed() = Typed(T::class, serializer<T>())
 /**
  * A reference to a type that can be serialized within a d-bus message.
  */
-data class Typed<T : Any> @PublishedApi internal constructor(
+class Typed<T : Any> @PublishedApi internal constructor(
     internal val cls: KClass<T>,
     internal val type: KSerializer<T>,
     internal val signature: SdbusSig = type.descriptor.asSignature


### PR DESCRIPTION
Closes #116. Group 2 of the 0.6.0 wave (epic #108). Mechanical public-API cleanups; api dumps net-shrink.

## Changes
1. `Resource : AutoCloseable` with default `override fun close() { release() }` — enables use in `use {}`. All impls already implement `release()`.
2. de-`data` `Typed` (TypedMethod.kt) — drops public `copy()`/`componentN()`/`equals`/`hashCode`/`toString`. Only constructed by the internal `typed<T>()` helper.
3. `Flags.Count` → `internal` — never referenced outside its own declaration.
4. Drop `PropertyDelegate.name` — unused getter (codegen/samples use `propertyName`).
5. `maybeDegrouped` → `internal`. The `Signature` overload is plain `internal`; the `KSerializer` overload is `@PublishedApi internal` because it's called from the public **inline** `Proxy.callMethod` (plain internal won't compile there) — functionally internal, still in the dump (unavoidable for an inline-public callee).

## api dump diff
Removed: `Typed.copy/copy$default/equals/hashCode/toString`, `Flags$Count`, `PropertyDelegate.getName`, `Signature.maybeDegrouped`. Added: `Resource.close` + `DefaultImpls.close` bridges (Resource/Proxy/Object/Connection) + `UnixFd.close`. Net −12 lines across 7 files.

## Verification
- compile jvm + linuxX64 + linuxArm64: green.
- `:jvmTest` + `:linuxX64Test` (dbus-run-session): no regressions.
- `ktlintCheck` + `apiCheck`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
