### PR TITLE
Fix native event-loop thread starvation (dedicated thread per connection) [#114 prereq]

### DIFF
--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
@@ -22,7 +22,8 @@
  */
 @file:OptIn(
     ExperimentalForeignApi::class,
-    ExperimentalNativeApi::class
+    ExperimentalNativeApi::class,
+    DelicateCoroutinesApi::class
 )
 
 package com.monkopedia.sdbus.internal
@@ -74,10 +75,12 @@ import kotlinx.cinterop.placeTo
 import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.value
+import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.newSingleThreadContext
 import platform.linux.EFD_CLOEXEC
 import platform.linux.EFD_NONBLOCK
 import platform.linux.eventfd
@@ -188,6 +191,14 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
     private var asyncLoopThread: Job? = null
     private var eventLoopStarting = false
     private val asyncLoopStateLock = atomic(false)
+
+    // The event loop runs a BLOCKING poll() for its whole lifetime, so it pins whatever thread it
+    // runs on. Each connection therefore gets its OWN single-thread dispatcher (created lazily on
+    // first startEventLoop, reused across stop/start, closed in release) rather than sharing a fixed
+    // pool — otherwise only as many loops as the pool has threads could ever run concurrently, and
+    // the rest would be queued and never reach poll(). Guarded by [asyncLoopStateLock].
+    private val connectionId = nextConnectionId.getAndIncrement()
+    private var eventDispatcher: CloseableCoroutineDispatcher? = null
     val floatingMatchRules = mutableListOf<Resource>()
     private val eventThread = EventLoopThread(bus, sdbus)
     private val loopExitResource = Reference(eventThread.exitFd) {
@@ -217,7 +228,8 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
                 waitedMs += 10
             }
             // Fail-safe: if the loop never exits, avoid unref-ing resources
-            // that may still be touched by the running event loop.
+            // that may still be touched by the running event loop. We also deliberately leave the
+            // dispatcher open here — its thread may still be parked in poll().
             if (!loopJob.isCompleted) return
             withAsyncLoopStateLock {
                 if (asyncLoopThread === loopJob) {
@@ -225,6 +237,12 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
                 }
             }
         }
+        // The loop has stopped (or never started). Close the dedicated dispatcher exactly once so we
+        // do not leak its thread; reading + nulling under the lock guards against a double close.
+        val dispatcherToClose = withAsyncLoopStateLock {
+            eventDispatcher.also { eventDispatcher = null }
+        }
+        dispatcherToClose?.close()
         loopExitResource.release()
         floatingMatchRules.forEach { it.release() }
         floatingMatchRules.clear()
@@ -323,8 +341,15 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
         // would cause a newly started loop to terminate immediately.
         eventThread.clearPendingExitNotifications()
 
+        // Lazily create this connection's dedicated single-thread dispatcher and reuse it across
+        // stop/start cycles. It is closed once in release(), after the loop has stopped.
+        val dispatcher = withAsyncLoopStateLock {
+            eventDispatcher ?: newSingleThreadContext("sdbus-eventloop-$connectionId")
+                .also { eventDispatcher = it }
+        }
+
         val launchedLoop = try {
-            eventThread.launch(CoroutineScope(eventPool))
+            eventThread.launch(CoroutineScope(dispatcher))
         } catch (throwable: Throwable) {
             withAsyncLoopStateLock {
                 eventLoopStarting = false
@@ -895,7 +920,9 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
                 if (ok) 0 else -1
             }
 
-        private val eventPool = newFixedThreadPoolContext(8, "EventThreads")
+        // Monotonic id used only to give each connection's dedicated event-loop thread a distinct,
+        // debuggable name.
+        private val nextConnectionId = atomic(0L)
 
         fun defaultConnection(intf: ISdBus) = ConnectionImpl(intf) { intf.sd_bus_open(it) }
 

--- a/src/nativeTest/kotlin/com/monkopedia/sdbus/unit/EventLoopConcurrencyStressTest.kt
+++ b/src/nativeTest/kotlin/com/monkopedia/sdbus/unit/EventLoopConcurrencyStressTest.kt
@@ -1,0 +1,140 @@
+/**
+ *
+ * (C) 2024 - 2025 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.monkopedia.sdbus.unit
+
+import com.monkopedia.sdbus.Connection
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.method
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.cinterop.ExperimentalForeignApi
+
+/**
+ * Regression test for the native event-loop thread-starvation bug.
+ *
+ * Each [Connection]'s event loop runs a BLOCKING `poll()` for the loop's whole lifetime. Before the
+ * fix every loop was launched onto a single shared, process-wide fixed thread pool of 8 threads
+ * (`newFixedThreadPoolContext(8, "EventThreads")`). A running loop occupies its pool thread for as
+ * long as it lives, so AT MOST 8 connection loops can run at once: with more than 8 live loops, the
+ * 9th+ coroutine is QUEUED and never actually runs.
+ *
+ * The user-visible symptom (and exactly what wave #114 will multiply by auto-starting a loop in
+ * `createObject`) is that a served object whose connection loop never runs can never process an
+ * incoming call. This test stands up [SERVERS] (> 8) independent served objects, each on its own
+ * connection with its own event loop, and calls every one of them synchronously. On the buggy code
+ * the calls to the servers past the 8-thread boundary block until they time out (their loops never
+ * run); with the per-connection dedicated dispatcher they all answer promptly. It also asserts each
+ * connection releases promptly afterwards.
+ *
+ * Needs a real D-Bus session bus — run under `dbus-run-session`.
+ */
+class EventLoopConcurrencyStressTest {
+
+    private val servers = 16
+    private val iface = InterfaceName("org.sdbuskotlin.loopstress.Iface")
+    private val path = ObjectPath("/org/sdbuskotlin/loopstress")
+    private val echo = MethodName("Echo")
+    private val callTimeout = 5.seconds
+
+    @Test
+    fun moreThanEightConcurrentLoopsAllServeAndReleasePromptly() {
+        val connections = ArrayList<Connection>(servers)
+        val vtables = ArrayList<Resource>(servers)
+        val objects = ArrayList<Object>(servers)
+        try {
+            // Stand up `servers` independent served objects, each with its own connection + loop.
+            repeat(servers) { index ->
+                val name = ServiceName("org.sdbuskotlin.loopstress.Server$index")
+                val conn = createBusConnection(name)
+                val obj = createObject(conn, path)
+                val vtable = obj.addVTable(iface) {
+                    method(echo) {
+                        call { value: Int -> value }
+                    }
+                }
+                conn.startEventLoop()
+                connections.add(conn)
+                objects.add(obj)
+                vtables.add(vtable)
+            }
+
+            // Call every server. With the 8-thread cap, servers >= 8 never run their loop, so these
+            // calls block until `callTimeout` and then throw. With dedicated dispatchers, all answer.
+            repeat(servers) { index ->
+                val name = ServiceName("org.sdbuskotlin.loopstress.Server$index")
+                val proxy = createProxy(name, path, runEventLoopThread = false)
+                try {
+                    val mark = TimeSource.Monotonic.markNow()
+                    val result = proxy.callMethod<Int>(iface, echo) {
+                        timeout = callTimeout
+                        call(index)
+                    }
+                    val elapsed = mark.elapsedNow().inWholeMilliseconds
+                    assertEquals(
+                        index,
+                        result,
+                        "server $index returned wrong value"
+                    )
+                    assertTrue(
+                        elapsed < 2_000,
+                        "call to server $index took ${elapsed}ms — its event loop is starving on " +
+                            "the shared 8-thread pool instead of running on its own thread."
+                    )
+                } finally {
+                    proxy.release()
+                }
+            }
+        } finally {
+            objects.forEach { it.release() }
+            vtables.forEach { it.release() }
+            // Releasing a connection must stop its loop and free its resources promptly; the 2s
+            // fail-safe in release() must never be hit.
+            var maxReleaseMillis = 0L
+            connections.forEach { conn ->
+                val mark = TimeSource.Monotonic.markNow()
+                conn.release()
+                val elapsed = mark.elapsedNow().inWholeMilliseconds
+                if (elapsed > maxReleaseMillis) maxReleaseMillis = elapsed
+            }
+            println("Max connection release = ${maxReleaseMillis}ms across $servers connections")
+            assertTrue(
+                maxReleaseMillis < 1_000,
+                "A connection release took ${maxReleaseMillis}ms (~2s fail-safe) — a starved " +
+                    "loop never observed its exit notification."
+            )
+        }
+    }
+}

--- a/src/nativeTest/kotlin/integration/EventLoopConcurrencyStressTest.kt
+++ b/src/nativeTest/kotlin/integration/EventLoopConcurrencyStressTest.kt
@@ -20,7 +20,7 @@
  */
 @file:OptIn(ExperimentalForeignApi::class)
 
-package com.monkopedia.sdbus.unit
+package com.monkopedia.sdbus.integration
 
 import com.monkopedia.sdbus.Connection
 import com.monkopedia.sdbus.InterfaceName


### PR DESCRIPTION
Prerequisite for #114 (epic #108). Fixes a native event-loop thread-starvation bug that #114's createObject auto-start would multiply.

## Root cause
Every connection's event loop runs a BLOCKING `poll()` for its whole lifetime, and all loops were launched onto one process-wide `newFixedThreadPoolContext(8, "EventThreads")`. So at most 8 connection loops can run concurrently; the 9th+ coroutine is queued and never reaches `poll()` — a served object on such a connection never answers calls.

Deterministic repro (new `EventLoopConcurrencyStressTest`): 16 independent served objects, each on its own connection+loop; calling each one. On main it FAILS (~5.2s, `org.freedesktop.DBus.Error.Timeout` — object #8's loop never runs). The 8-thread boundary is the exact threshold. (The originally-hypothesized "2s on every release" symptom is release-order-dependent — forward-order release cascades and dodges it — so the test targets the deterministic never-serves behavior instead.)

## Fix — dedicated thread per connection loop
Each `ConnectionImpl` gets its own `newSingleThreadContext("sdbus-eventloop-<id>")`, created lazily on first `startEventLoop` (under the state lock), reused across stop/start. `release()` closes it exactly once, AFTER the loop has stopped (read-and-null under the lock = double-close guard); the 2s fail-safe early-return deliberately leaves it open (its thread may still be parked in poll()); never-started connections create no dispatcher. Removed the now-unused shared `eventPool` (verified single launch site). `@OptIn(DelicateCoroutinesApi)`.

## Verification
- New test: before = FAIL (timeout 5216ms); after = PASS (1607ms, 16 concurrent loops, max release 100ms).
- Full native `:linuxX64Test :cross_test:linuxX64Test`: green + fast (~35s).
- compile linuxX64 + linuxArm64 + jvm; `ktlintCheck` + `apiCheck`: pass. Internal-only — no api dump change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
