### PR TITLE
KDoc cleanup: remove stale sdbus-c++ doxygen; fix dokka link warnings [#117]

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/MethodInvoker.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/MethodInvoker.kt
@@ -47,7 +47,7 @@ import kotlinx.serialization.serializer
  * val a: Int = ...
  * val b: Int = ...
  * val multiply = MethodName("multiply")
- * val result = object.callMethodAsync(INTERFACE_NAME, multiply) {
+ * val result = proxy.callMethodAsync(INTERFACE_NAME, multiply) {
  *   call(a, b)
  * }
  * println("Got result of multiplying $a and $b: $result")
@@ -125,7 +125,7 @@ internal suspend fun <R : Any> Proxy.callMethodAsyncImpl(
  * val a: Int = ...
  * val b: Int = ...
  * val multiply = MethodName("multiply")
- * val result = object.callMethod(INTERFACE_NAME, multiply) {
+ * val result = proxy.callMethod(INTERFACE_NAME, multiply) {
  *   call(a, b)
  * }
  * println("Got result of multiplying $a and $b: $result")

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Object.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Object.kt
@@ -188,8 +188,8 @@ interface Object : Resource {
      * @return A signal message
      *
      * Serialize signal arguments into the returned message and emit the signal by passing
-     * the message with serialized arguments to the @c emitSignal function.
-     * Alternatively, use higher-level API @c emitSignal(signalName: String) defined below.
+     * the message with serialized arguments to the [emitSignal] function.
+     * Alternatively, use the higher-level API [emitSignal] convenience overloads defined below.
      *
      * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetReply.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetReply.kt
@@ -23,4 +23,8 @@
 
 package com.monkopedia.sdbus
 
+/**
+ * A [Message] into which a property's value is serialized when answering a `Get` request
+ * from the `org.freedesktop.DBus.Properties` interface.
+ */
 expect class PropertyGetReply : Message

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertyGetter.kt
@@ -41,16 +41,17 @@ import kotlinx.serialization.serializer
 /**
  * Gets value of a property of the D-Bus object
  *
+ * @param interfaceName Interface that declares the property
  * @param propertyName Name of the property
- * @return A helper object for convenient getting of property value
+ * @return The property value, deserialized into the reified type [T]
  *
  * This is a high-level, convenience way of reading D-Bus property values that abstracts
- * from the D-Bus message concept. sdbus::Variant is returned which shall then be converted
- * to the real property type (implicit conversion is supported).
+ * from the D-Bus message concept. The returned value is decoded directly into the reified
+ * type [T].
  *
  * Example of use:
  * ```
- * val state = object.getProperty(InterfaceName("com.kistler.foo"), PropertyName("state"))
+ * val state = proxy.getProperty<String>(InterfaceName("com.kistler.foo"), PropertyName("state"))
  * ```
  *
  * @throws [com.monkopedia.sdbus.SdbusException] in case of failure

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/PropertySetCall.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/PropertySetCall.kt
@@ -22,4 +22,8 @@
  */
 package com.monkopedia.sdbus
 
+/**
+ * A [Message] from which a property's new value is deserialized when handling a `Set` request
+ * from the `org.freedesktop.DBus.Properties` interface.
+ */
 expect class PropertySetCall : Message

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
@@ -24,21 +24,17 @@ package com.monkopedia.sdbus
 
 import kotlin.time.Duration
 
-/********************************************/
 /**
- * @class IProxy
- *
- * IProxy class represents a proxy object, which is a convenient local object created
+ * Represents a proxy object, which is a convenient local object created
  * to represent a remote D-Bus object in another process.
  * The proxy enables calling methods on remote objects, receiving signals from remote
  * objects, and getting/setting properties of remote objects.
  *
- * All IProxy member methods throw @c [com.monkopedia.sdbus.SdbusException] in case of D-Bus or sdbus-kotlin error.
- * The IProxy class has been designed as thread-aware. However, the operation of
- * creating and sending method calls (both synchronously and asynchronously) is
+ * All [Proxy] member methods throw [com.monkopedia.sdbus.SdbusException] in case of D-Bus or
+ * sdbus-kotlin error. The [Proxy] interface has been designed as thread-aware. However, the
+ * operation of creating and sending method calls (both synchronously and asynchronously) is
  * thread-safe by design.
- *
- ***********************************************/
+ */
 interface Proxy : Resource {
 
     /**
@@ -76,8 +72,8 @@ interface Proxy : Resource {
      * @return A method call message
      *
      * Serialize method arguments into the returned message and invoke the method by passing
-     * the message with serialized arguments to the @c callMethod function.
-     * Alternatively, use higher-level API @c callMethod(const & methodName: String) defined below.
+     * the message with serialized arguments to the [callMethod] function.
+     * Alternatively, use the higher-level API [callMethod] convenience overloads defined below.
      *
      * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */
@@ -149,14 +145,13 @@ interface Proxy : Resource {
      * Calls method on the D-Bus object asynchronously
      *
      * @param message Message representing an async method call
-     * @param Tag denoting a std::future-based overload
-     * @return Future object providing access to the future method reply message
+     * @return The method reply message
      *
-     * This is a std::future-based way of asynchronously calling a remote D-Bus method.
+     * This is a suspending way of asynchronously calling a remote D-Bus method. The coroutine
+     * suspends until the reply arrives; it does not block the underlying bus connection.
      *
-     * The call itself is non-blocking. It doesn't wait for the reply. Once the reply arrives,
-     * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.SdbusException]
-     * in case the remote method threw an exception).
+     * Once the reply arrives, the call resumes with the reply message, or throws
+     * [com.monkopedia.sdbus.SdbusException] if the remote method returned an error.
      *
      * The default D-Bus method call timeout is used. See [Connection.methodCallTimeout].
      *
@@ -171,14 +166,14 @@ interface Proxy : Resource {
      *
      * @param message Message representing an async method call
      * @param timeout Method call timeout
-     * @param Tag denoting a std::future-based overload
-     * @return Future object providing access to the future method reply message
+     * @return The method reply message
      *
-     * This is a std::future-based way of asynchronously calling a remote D-Bus method.
+     * This is a suspending way of asynchronously calling a remote D-Bus method. The coroutine
+     * suspends until the reply arrives; it does not block the underlying bus connection.
      *
-     * The call itself is non-blocking. It doesn't wait for the reply. Once the reply arrives,
-     * the provided future object will be set to contain the reply (or [com.monkopedia.sdbus.SdbusException]
-     * in case the remote method threw an exception, or the call timed out).
+     * Once the reply arrives, the call resumes with the reply message, or throws
+     * [com.monkopedia.sdbus.SdbusException] if the remote method returned an error or the call
+     * timed out.
      *
      * If timeout is [Duration.ZERO], the default D-Bus method call timeout is used.
      * See [Connection.methodCallTimeout].
@@ -378,7 +373,7 @@ fun Proxy.getAllProperties(): AllPropertiesGetter = AllPropertiesGetter(this)
  *
  * Example of use:
  * ```
- * val props = object.getAllPropertiesAsync().onInterface(InterfaceName("com.kistler.foo"))
+ * val props = proxy.getAllPropertiesAsync().onInterface(InterfaceName("com.kistler.foo"))
  *   getResult();
  * ```
  *
@@ -403,7 +398,7 @@ fun Proxy.getAllPropertiesAsync(): AsyncAllPropertiesGetter = AsyncAllProperties
  * separate, internally managed thread (the default). Pass false to create a light-weight
  * proxy for synchronous-only use, in which case the caller is responsible for running an
  * event loop on the connection if signals or async replies are to be received.
- * @return Pointer to the proxy object instance
+ * @return The proxy object instance
  *
  * The provided connection will be used by the proxy to issue calls against the object,
  * and signals, if any, will be subscribed to on this connection. The caller still
@@ -434,7 +429,7 @@ expect fun createProxy(
  * @param runEventLoopThread Whether the proxy starts its connection's I/O event loop in a
  * separate, internally managed thread (the default). Pass false to create a light-weight
  * proxy for synchronous-only use.
- * @return Pointer to the object proxy instance
+ * @return The object proxy instance
  *
  * No D-Bus connection is provided here, so the object proxy will create and manage
  * his own connection, and will automatically start an event loop upon that connection

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/SignalSubscriber.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/SignalSubscriber.kt
@@ -29,26 +29,27 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 /**
- * Registers signal handler for a given signal of the D-Bus object
+ * Registers a signal handler for a given signal of the D-Bus object
  *
+ * @param interfaceName Name of the interface that the signal belongs to
  * @param signalName Name of the signal
- * @return A helper object for convenient registration of the signal handler
+ * @param builder Configures how the signal payload is decoded and handled via
+ * [SignalSubscriber.call]
+ * @return A [Resource] handle to the registration; release it to unsubscribe
  *
  * This is a high-level, convenience way of registering to D-Bus signals that abstracts
- * from the D-Bus message concept. Signal arguments are automatically serialized
- * in a message and D-Bus signatures automatically deduced from the parameters
- * of the provided native signal callback.
+ * from the D-Bus message concept. The signal arguments are automatically deserialized and
+ * passed to the handler bound inside the [builder] block.
  *
  * A signal can be subscribed to and unsubscribed from at any time during proxy
  * lifetime. The subscription is active immediately after the call.
  *
  * Example of use:
- * @code
- * object_.uponSignal("stateChanged").onInterface("com.kistler.foo").call([this](int arg1, double arg2){ this->onStateChanged(arg1, arg2); });
- * sdbus::InterfaceName foo{"com.kistler.foo"};
- * sdbus::SignalName levelChanged{"levelChanged"};
- * object_.uponSignal(levelChanged).onInterface(foo).call([this](uint16_t level){ this->onLevelChanged(level); });
- * @endcode
+ * ```
+ * val registration = proxy.onSignal(InterfaceName("com.kistler.foo"), SignalName("stateChanged")) {
+ *     call { arg1: Int, arg2: Double -> onStateChanged(arg1, arg2) }
+ * }
+ * ```
  *
  * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
  */

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
@@ -180,13 +180,9 @@ class Variant constructor() {
     }
 }
 
-/********************************************/
 /**
- * @class ObjectPath
- *
  * Strong type representing the D-Bus object path
- *
- ***********************************************/
+ */
 @Serializable(ObjectPath.Companion::class)
 @kotlin.jvm.JvmInline
 value class ObjectPath(
@@ -208,13 +204,9 @@ value class ObjectPath(
     }
 }
 
-/********************************************/
 /**
- * @class BusName
- *
  * Strong type representing the D-Bus bus/service/connection name
- *
- ***********************************************/
+ */
 @Serializable(BusName.Companion::class)
 @kotlin.jvm.JvmInline
 value class BusName(

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/VTableBuilder.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/VTableBuilder.kt
@@ -25,14 +25,14 @@ package com.monkopedia.sdbus
 /**
  * Adds a declaration of methods, properties and signals of the object at a given interface
  *
- * @param vtable Individual instances of VTable item structures stored in a vector
+ * @param interfaceName Name of the interface the vtable is registered under
+ * @param builder Configures the vtable, declaring methods, properties, signals and flags
  * @return Resource handle to release registration
  *
  * This method is used to declare attributes for the object under the given interface.
- * Parameter `vtable' represents a vtable definition that may contain method declarations
- * (using MethodVTableItem struct), property declarations (using PropertyVTableItem
- * struct), signal declarations (using SignalVTableItem struct), or global interface
- * flags (using InterfaceFlagsVTableItem struct).
+ * The [builder] block defines a vtable that may contain method declarations (via [method]),
+ * property declarations (via [prop]), signal declarations (via [signal]), or global interface
+ * flags.
  *
  * An interface can have any number of vtables attached to it.
  *

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Message.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Message.native.kt
@@ -114,20 +114,16 @@ private inline fun debugPrint(msg: () -> String) {
     if (false) println(msg())
 }
 
-/********************************************/
 /**
- * @class Message
- *
- * Message represents a D-Bus message, which can be either method call message,
+ * Represents a D-Bus message, which can be either method call message,
  * method reply message, signal message, or a plain message.
  *
  * Serialization and deserialization functions are provided for types supported
  * by D-Bus.
  *
  * You mostly don't need to work with this class directly if you use high-level
- * APIs of @c IObject and @c IProxy.
- *
- ***********************************************/
+ * APIs of [Object] and [Proxy].
+ */
 actual sealed class Message(
     internal val msg: CPointer<sd_bus_message>?,
     internal val sdbus: ISdBus,

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/PendingAsyncCall.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/PendingAsyncCall.native.kt
@@ -29,17 +29,13 @@ import com.monkopedia.sdbus.internal.ProxyImpl
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.WeakReference
 
-/********************************************/
 /**
- * @class PendingAsyncCall
- *
- * PendingAsyncCall represents a simple handle type to cancel the delivery
+ * Represents a simple handle type to cancel the delivery
  * of the asynchronous D-Bus call result to the application.
  *
  * The handle is lifetime-independent from the originating Proxy object.
  * It's safe to call its methods even after the Proxy has gone.
- *
- ***********************************************/
+ */
 internal actual class PendingAsyncCall internal constructor(
     private val target: WeakReference<AsyncCallInfo>
 ) : Resource {

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/UnixFd.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/UnixFd.kt
@@ -37,16 +37,13 @@ import platform.posix.dup
 import platform.posix.errno
 
 /**
- * @struct UnixFd
- *
- * UnixFd is a representation of file descriptor D-Bus type that owns
+ * A representation of the file descriptor D-Bus type that owns
  * the underlying fd, provides access to it, and closes the fd when
- * the UnixFd goes out of scope.
+ * the UnixFd is released.
  *
  * UnixFd can be default constructed (owning invalid fd), or constructed from
  * an explicitly provided fd by either duplicating ([UnixFd] primary constructor)
  * or adopting that fd as-is ([UnixFd.adopt]).
- *
  */
 @OptIn(ExperimentalNativeApi::class)
 @Serializable(UnixFd.Companion::class)

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/PollData.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/PollData.kt
@@ -25,8 +25,6 @@ package com.monkopedia.sdbus.internal
 import kotlin.time.Duration
 
 /**
- * @struct PollData
- *
  * Carries poll data needed for integration with external event loop implementations.
  *
  * See getEventLoopPollData() for more info.
@@ -58,7 +56,7 @@ internal data class PollData internal constructor(
     /**
      * Returns the timeout as relative value from now.
      *
-     * Returned value is std::chrono::microseconds::max() if the timeout is indefinite.
+     * Returned value is [Duration.INFINITE] if the timeout is indefinite.
      *
      * @return Relative timeout as a time duration
      */


### PR DESCRIPTION
Closes #117. Group 7 (final) of the 0.6.0 wave (epic #108). KDoc-only cleanup — removes stale sdbus-c++ doxygen from the public surface and clears the public dokka link warnings. No code/signature/api change.

## Fixed
- `Proxy.callMethodAsync` (both overloads + actuals): dropped `std::future`/`@param Tag`/`@return Future`; documents the real `suspend`→`MethodReply`. Clears the `[Tag]` link warnings.
- `Proxy.onSignal`: replaced the C++ `uponSignal(...).onInterface(...).call([]{})` example with the Kotlin `onSignal(iface, signal) { call { ... } }`.
- `getProperty`: dropped the untrue "implicit conversion" line.
- `@class`/`@c`/`@struct` doxygen tags removed across Proxy.kt, Object.kt, Types.kt, Message.native.kt, PendingAsyncCall.native.kt, UnixFd.kt, PollData.kt → proper `[Symbol]` KDoc links.
- "Pointer to …" / `std::chrono::…` / C++ `object.`-receiver examples → Kotlin (`proxy.`, `[Duration.INFINITE]`, etc.).
- `addVTable` inline overload `@param vtable` → `@param builder` (matches the real param). Clears the `[vtable]` link warning.
- Added one-line KDoc to `PropertyGetReply` and `PropertySetCall` (the only undocumented public symbols).

## Verification
- compile jvm + linuxX64 + linuxArm64: green.
- `dokkaGenerate`: the 5 targeted public "Couldn't resolve link" warnings ([Tag]×3, [vtable]) are GONE. Remaining link warnings are in non-public jvmdbus internals + :codegen — out of this ticket's scope.
- `ktlintCheck` + `apiCheck`: pass, api dump UNCHANGED (comments only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
