### PR TITLE
Release 0.6.0: CHANGELOG + version bump + doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,98 @@ All notable changes to sdbus-kotlin are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-18
+
+0.6.0 is the **1.0-polish** release. A post-0.5.0 review of the public surface (epic #108)
+produced a coordinated cleanup wave — renames, deprecations, and a few new first-class APIs —
+so that 1.0 can ship a final, well-named surface. It also lands several real bug fixes found
+along the way.
+
+Deprecations introduced here are kept as warnings for this release and **removed at 1.0**.
+(Note: the 0.5.0 changelog called itself the "1.0 API-freeze"; the post-0.5.0 review reopened a
+handful of names, so 0.6.0 is the last shaping pass and **1.0** is the actual freeze.)
+
+This entry is the migration guide. Most breaking changes are renames with identical behavior.
+
+### Bug fixes
+
+Memory leaks in served objects and connections (#119) — both backends:
+- Every served object leaked after `release()`: the native vtable teardown never dropped the
+  registered method/property/signal callbacks (which capture the adaptor), and on the JVM the
+  `Properties` dispatch handlers were never unregistered from the process-wide dispatch table.
+  A property-bearing served object (the common BlueZ case) leaked for the process lifetime.
+- Native connections leaked once objects/signal subscriptions were registered: several cleanup
+  closures captured the connection (`this@ConnectionImpl`) via member access and were retained
+  by their GC cleaner. Fixed at five sites. (The compiler's non-capturing-`createCleaner` check
+  cannot catch this because the capture launders through a `Reference` parameter.)
+
+Native event-loop thread starvation (#128) — connection event loops shared one bounded 8-thread
+pool, so more than 8 concurrently-running loops would starve (a served object whose loop never
+got a thread could not answer calls). Each connection now gets its own dedicated loop thread.
+
+### Breaking changes
+
+Naming sweep (#113) — behavior-identical renames, **no compatibility aliases** (update call sites):
+- `acall` → `asyncCall`, `createACall` → `createAsyncCall` (vtable method DSL; generated adaptors regenerated).
+- `SdbusSig` → `TypeSignature` (in `Variant.get`/`Typed`/`signatureOf`/property accessors).
+- `Message.path` → `Message.objectPath`.
+- `SignalEmitter.typedMethodArguments` → `arguments`; `SignalSubscriber.methodCall` → `handler`.
+- `PlainMessage.Companion.createPlainMessage()` → top-level `createPlainMessage()` (matches `createObject`/`createProxy`).
+- `Flags.test(flag)` → `Flags.has(flag)`; also adds an `in` operator (`flag in flags`).
+- `Connection.addMatchAsync(...)` — **removed** (had no users; the async match-install machinery is gone too). Use `addMatch`.
+- `MethodReply`'s accidentally-public constructors — now `internal`.
+
+`requestName` now reports its outcome and accepts flags (#112):
+- `fun requestName(name: ServiceName)` → `fun requestName(name: ServiceName, vararg flags: RequestNameFlag): RequestNameReply`.
+- New `enum RequestNameFlag { ALLOW_REPLACEMENT, REPLACE_EXISTING, DO_NOT_QUEUE }` and
+  `enum RequestNameReply { PRIMARY_OWNER, IN_QUEUE, EXISTS, ALREADY_OWNER }`.
+- Source-compatible: `requestName(name)` still compiles (the return is simply now ignorable). Behavior
+  note: requesting a name already owned by another peer now **queues** by default and returns `IN_QUEUE`
+  on both backends (the native and JVM flag handling were made consistent), rather than throwing — pass
+  `DO_NOT_QUEUE` to fail fast with `EXISTS`.
+
+fd-based connection factories are native-only (#111):
+- `createDirectBusConnection(fd: UnixFd)` and `createServerBusConnection(fd: UnixFd)` are removed from the
+  common (multiplatform) surface — they were `@Deprecated(level=ERROR)` JVM stubs — and are now plain
+  native-only functions. Address-based `createDirectBusConnection(String)` stays common.
+
+Mechanical reductions (#116):
+- `Resource` now extends `AutoCloseable` (usable in `use { }`; `close()` delegates to `release()`).
+- `Typed`, the VTable item types, etc. are no longer `data` classes (no `copy()`/`componentN()`).
+- `Flags.Count`, `maybeDegrouped`, and `PropertyDelegate.name` are removed/internalized.
+
+### Deprecations (removed at 1.0)
+
+- `Error` → renamed `SdbusException` (#109). `Error` remains as a deprecated `typealias` (source-compatible; warns).
+- The fluent property layer (#110) — `AsyncPropertyGetter`/`AsyncPropertySetter`/`AllPropertiesGetter` and their
+  `onInterface`/`toValue`/`getResult` chains are deprecated in favor of the new direct accessors below.
+
+### New API
+
+- `SdbusException` (the renamed exception type).
+- `RequestNameReply` / `RequestNameFlag` (see `requestName` above).
+- Direct typed property accessors (replacing the fluent layer): `suspend Proxy.getPropertyAsync<T>(iface, prop)`,
+  `suspend Proxy.setPropertyAsync<T>(iface, prop, value)`, `Proxy.getAllProperties(iface)`,
+  `suspend Proxy.getAllPropertiesAsync(iface)`.
+- `Object.notifying(iface, prop, initial): ReadWriteProperty` — a property delegate that emits
+  `PropertiesChanged` on change (skipping no-op sets).
+- `createObject(connection, objectPath, runEventLoopThread = true)` — server-side event-loop symmetry with
+  `createProxy`; `startEventLoop()` is now idempotent. Source-compatible (the parameter defaults).
+- `Flags.has(flag)` and the `flag in flags` operator.
+
+### Behavioral improvements
+
+- Generated adaptors now auto-emit `PropertiesChanged` (#115), honoring the
+  `org.freedesktop.DBus.Property.EmitsChangedSignal` annotation — a remote `Set` or a server-side set both emit,
+  so clients' property-change flows fire by default.
+- The JVM serve worker pool is now bounded and deadlock-free under nested same-connection calls (#101),
+  replacing the previously-unbounded cached thread pool.
+
+### Docs
+
+- KDoc cleanup (#117): removed stale sdbus-c++ doxygen (`@class`/`@c`/`std::future`/C++ examples) from the public
+  surface and fixed the public dokka "couldn't resolve link" warnings.
+
 ## [0.5.0] - 2026-06-13
 
 0.5.0 is the **1.0 API-freeze** release. It does two big things:

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ It is published for three targets, all sharing the same common API:
 
 | Target | Backend |
 | --- | --- |
-| `jvm` | [dbus-java](https://github.com/hypfvieh/dbus-java) — pure-Java transport, no native code |
+| `jvm` | own D-Bus connection over [junixsocket](https://github.com/kohlschutter/junixsocket) — pure-Kotlin marshaller + dispatch, no native code |
 | `linuxX64` | sd-bus via libsystemd (cinterop) |
 | `linuxArm64` | sd-bus via libsystemd (cinterop) |
 
 ## API stability
 
-The public API is frozen as of 0.5.0 and is the API that 1.0 will ship. Compatibility is
-enforced in CI with [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
+0.6.0 is the **1.0-polish** release — a post-0.5.0 review applied a final wave of renames and
+deprecations to the public surface (see the [CHANGELOG](CHANGELOG.md) migration guide). 1.0 will
+freeze that surface, dropping the names deprecated in 0.6.0. Compatibility is enforced in CI with
+[binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
 (JVM and klib API dumps are checked in under `api/`), so any change to the public surface is an
 explicit, reviewed event.
 
@@ -30,10 +32,11 @@ explicit, reviewed event.
 
 Application code is the same on every target — the choice is about deployment:
 
-- **JVM**: backed by dbus-java; `dbus-java-core` and `dbus-java-transport-junixsocket` come in
-  transitively with the `jvm` artifact. No native toolchain and no linker flags — it works
-  anywhere a JVM and a D-Bus socket are available. Choose this when you are already on the JVM
-  (server-side services, desktop apps, existing JVM codebases).
+- **JVM**: owns its D-Bus connection over a [junixsocket](https://github.com/kohlschutter/junixsocket)
+  unix-socket transport, with a pure-Kotlin marshaller and dispatcher (mirroring the native sd-bus
+  backend); `junixsocket` comes in transitively with the `jvm` artifact. No native toolchain and no
+  linker flags — it works anywhere a JVM and a D-Bus socket are available. Choose this when you are
+  already on the JVM (server-side services, desktop apps, existing JVM codebases).
 - **Native** (`linuxX64`, `linuxArm64`): wraps sd-bus directly and links against libsystemd,
   producing self-contained binaries with no JVM requirement. Choose this for small CLI tools and
   daemons, or when you want sd-bus itself doing the I/O.
@@ -58,7 +61,7 @@ introspection XML files, conventionally placed in `src/dbusMain`.
 ```
 plugins {
     ...
-    id("com.monkopedia.sdbus.plugin") version "0.5.0"
+    id("com.monkopedia.sdbus.plugin") version "0.6.0"
 }
 
 sdbus {
@@ -92,7 +95,7 @@ module with implementations for `jvm`, `linuxX64`, and `linuxArm64`. Add the dep
 ```
 val nativeMain by getting {
     dependencies {
-       implementation("com.monkopedia:sdbus-kotlin:0.5.0")
+       implementation("com.monkopedia:sdbus-kotlin:0.6.0")
     }
 }
 ```
@@ -111,8 +114,8 @@ For a full example build file, see the [bluez-scan sample](samples/bluez-scan).
 
 ### Kotlin/JVM
 
-No further setup is needed on JVM. The `jvm` artifact pulls in the pure-Java dbus-java
-transport transitively and connects through the standard D-Bus unix sockets — no linker flags
+No further setup is needed on JVM. The `jvm` artifact pulls in the junixsocket transport
+transitively and connects through the standard D-Bus unix sockets — no linker flags
 and no native libraries involved. The [bluez-scan sample](samples/bluez-scan) runs on JVM with:
 
 ```

--- a/dokka/moduledoc.md
+++ b/dokka/moduledoc.md
@@ -49,9 +49,10 @@ server-side example, see [`samples/demo-service`](https://github.com/Monkopedia/
 
 ## API stability
 
-The public API is frozen as of 0.5.0 and is the API that 1.0 will ship. Compatibility is
-enforced in CI with
+0.6.0 is the **1.0-polish** release — a post-0.5.0 review applied a final wave of renames and
+deprecations to the public surface; 1.0 will freeze it, dropping the names deprecated in 0.6.0.
+Compatibility is enforced in CI with
 [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
 (JVM and klib API dumps are checked in under `api/`), so any change to the public surface is an
-explicit, reviewed event. The migration notes for the 0.5.0 freeze are in the
+explicit, reviewed event. The per-release migration notes are in the
 [CHANGELOG](https://github.com/Monkopedia/sdbus-kotlin/blob/main/CHANGELOG.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.5.0
+version=0.6.0
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/samples/bluez-scan/build.gradle.kts
+++ b/samples/bluez-scan/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization)
                 implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
-                implementation("com.monkopedia:sdbus-kotlin:0.5.0")
+                implementation("com.monkopedia:sdbus-kotlin:0.6.0")
             }
         }
         val nativeTest by getting {

--- a/samples/demo-service/README.md
+++ b/samples/demo-service/README.md
@@ -30,10 +30,10 @@ produce `DemoService1`, `DemoService1Adaptor`, and `DemoService1Proxy` into the 
 This sample is part of the sdbus-kotlin repository and must demonstrate the **current** API
 (post-0.5.0: `startEventLoop`/`stopEventLoop`, `withGetter`/`withSetter`, typed property flows,
 `Duration` timeouts, etc.). That API does **not** exist in the artifact published to Maven Central
-(0.5.0). So, exactly like `bluez-scan`, [`settings.gradle.kts`](settings.gradle.kts) uses a Gradle
+(0.6.0). So, exactly like `bluez-scan`, [`settings.gradle.kts`](settings.gradle.kts) uses a Gradle
 **composite build** (`includeBuild("../..")`). Gradle automatically substitutes the
 `com.monkopedia:sdbus-kotlin` dependency declared in `build.gradle.kts` with the local source tree,
-so the version coordinate there (`0.5.0`) is only a placeholder and the sample always compiles
+so the version coordinate there (`0.6.0`) is only a placeholder and the sample always compiles
 against the library checked out next to it. No `publishToMavenLocal` step is required.
 
 ## Running

--- a/samples/demo-service/build.gradle.kts
+++ b/samples/demo-service/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
                 implementation(kotlin("stdlib"))
                 // Version is a placeholder: the composite build in settings.gradle.kts
                 // substitutes this with the local sdbus-kotlin source tree.
-                implementation("com.monkopedia:sdbus-kotlin:0.5.0")
+                implementation("com.monkopedia:sdbus-kotlin:0.6.0")
             }
         }
     }


### PR DESCRIPTION
Release prep for **0.6.0** (the 1.0-polish wave, epic #108 — all 10 tickets already merged to main). Docs + version only; no code.

## Changes
- **CHANGELOG**: new `[0.6.0]` migration-guide entry covering the renames (clean breaks), deprecations (→ removed at 1.0), new API (RequestNameReply/flags, `Object.notifying`, direct property accessors, `Resource: AutoCloseable`, `Flags.has`/`in`), behavioral improvements (PropertiesChanged auto-emit, bounded serve pool, native loop-starvation fix), and the served-object/connection **memory-leak fixes** (#119) that folded in.
- **Version bump** `0.5.0` → `0.6.0`: `gradle.properties`, README install snippets, `samples/bluez-scan` + `samples/demo-service` coordinates.
- **README / moduledoc framing fix**: the "public API is frozen as of 0.5.0" line was superseded by the post-0.5.0 review — now states 0.6.0 is the 1.0-polish pass and 1.0 is the freeze.
- **README backend correction**: the JVM backend was described as `dbus-java` (stale since 0.5.0 retired it). Corrected to the junixsocket-based owned connection (pure-Kotlin marshaller + dispatch) in the backend table, the "Choosing a backend" section, and the Kotlin/JVM getting-started note.

After merge: cut the `v0.6.0` GitHub release → `publish.yaml` ships all coordinates to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
