### PR TITLE
Docs accuracy (BACKENDS dbus-java->junixsocket + 0.6.0/server-export) + remove dead FFI binding

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -1,8 +1,10 @@
 # JVM ↔ native backend parity matrix
 
 sdbus-kotlin ships one common API with two implementations: the **native** backend
-(`linuxX64`/`linuxArm64`, sd-bus via libsystemd) and the **JVM** backend (dbus-java,
-pure-Java transport). This document is the contract for what behaves identically on both
+(`linuxX64`/`linuxArm64`, sd-bus via libsystemd) and the **JVM** backend, which owns its D-Bus
+connection over a [junixsocket](https://github.com/kohlschutter/junixsocket) transport with a
+pure-Kotlin marshaller and dispatcher (no `dbus-java`, no native code — junixsocket is the only
+transitive dependency). This document is the contract for what behaves identically on both
 backends and where they differ, as of the frozen 1.0 API surface.
 
 Every row below is pinned by tests on current `main`, not by intention:
@@ -28,16 +30,17 @@ Every row below is pinned by tests on current `main`, not by intention:
 | Error propagation: named D-Bus errors round-trip name + message verbatim | ✅ | ✅ | Incl. foreign (non-sdbus) peers; JVM fixed in #72 |
 | errno → D-Bus error-name mapping for locally created errors | ✅ | ✅ | JVM pinned to native output |
 | Call-after-release fails with `IllegalArgumentException("Connection has already been released")` | ✅ | ✅ | |
-| Properties: `Get`/`Set`/`GetAll`, property delegates (`values()`/`changes()`) — **as a client** | ✅ | ✅ | Client-verified; JVM *serving* properties to an external peer is in-process only — see "Server-side object export" |
-| `PropertiesChanged` emission incl. getter resolution | ✅ | ✅ | JVM fixed in #28; JVM emits to the real bus, but external reception is not test-verified |
-| Signals: emission, subscription, `signalFlow` | ✅ | ✅ | JVM emission goes to the real bus; subscription/`signalFlow` are cross-process-verified as a client |
-| ObjectManager: `GetManagedObjects`, `InterfacesAdded`/`Removed`, `ObjectManagerProxy` flows — **as a client** | ✅ | ✅ | Client-verified; JVM *serving* `GetManagedObjects` to an external peer is in-process only — see "Server-side object export" |
-| **Serving exported objects to external processes** (incoming method calls, `Properties.Get`/`Set`/`GetAll`, `GetManagedObjects`) | ⚠️ in-process only | ✅ | **JVM gap (#90):** the JVM backend dispatches incoming calls through an in-process table (`JvmStaticDispatch`); an external client (busctl, another process) gets `UnknownObject`. Native is a full server backend — see "Server-side object export" |
+| `requestName(name, vararg flags)` → `RequestNameReply` | ✅ | ✅ | Native/JVM flag handling made consistent (#112): a name owned by another peer **queues** (`IN_QUEUE`) by default; pass `DO_NOT_QUEUE` to fail fast (`EXISTS`) |
+| Properties: `Get`/`Set`/`GetAll`, property delegates (`values()`/`changes()`) — client **and** server | ✅ | ✅ | Verified as a client and as a server on both backends; JVM *serving* `Get`/`Set`/`GetAll` to an external peer now works over the wire (#90 closed) — see "Server-side object export" |
+| `PropertiesChanged` emission incl. getter resolution | ✅ | ✅ | JVM fixed in #28; emission reaches external subscribers (pinned by `WireSignalEmissionExternalTest`); generated adaptors auto-emit honoring `EmitsChangedSignal` (#115) |
+| Signals: emission, subscription, `signalFlow` | ✅ | ✅ | Emission and subscription/`signalFlow` both cross-process-verified; JVM external emission pinned by `WireSignalEmissionExternalTest` |
+| ObjectManager: `GetManagedObjects`, `InterfacesAdded`/`Removed`, `ObjectManagerProxy` flows — client **and** server | ✅ | ✅ | Verified as a client and as a server; JVM *serving* `GetManagedObjects` to an external peer now works over the wire (#90 closed) — see "Server-side object export" |
+| **Serving exported objects to external processes** (incoming method calls, `Properties.Get`/`Set`/`GetAll`, `GetManagedObjects`) | ✅ | ✅ | **#90 closed (0.5.0):** the JVM backend serves incoming calls over its owned wire connection (`WireServe`), so an external client (busctl, another process) reaches a JVM-exported object exactly as on native — see "Server-side object export". Same-JVM calls still take an in-process shortcut (`JvmStaticDispatch`) |
 | `UnixFd` type semantics (dup constructor vs `adopt`, `release` closes) | ✅* | ✅ | *JVM dup needs junixsocket native support |
 | Unix FD passing over the wire | ⚠️ untested | ✅ | JVM has the conversion path but no independent-peer test |
 | Connection factories (11 total) | 9 of 11 | 11 of 11 | fd-based factories are native-only |
 | Behavior when the bus is unreachable | ✅ throws `Error` | ✅ throws `Error` | JVM fixed in #81; the in-process stub backend is an explicit internal test opt-in only |
-| Event loop (`startEventLoop`/`stopEventLoop`) | no-op (always running) | required for dispatch | Same calling pattern works on both |
+| Event loop (`startEventLoop`/`stopEventLoop`) | no-op (always running) | required for dispatch; `createObject`/`createProxy` auto-start it | Same calling pattern works on both; `startEventLoop` is idempotent (#114), and each native connection gets its own loop thread (#128) |
 | Strict deserialization (signature mismatch rejected) | ✅ | ✅ | Same `System.Error.ENXIO` error |
 
 ✅ = identical observable behavior, asserted on both backends.
@@ -67,14 +70,14 @@ backends (issue #74, fixed in PR #78).
   `Unlock`/`Lock (ao → ao, o)` and other real multi-out shapes).
 
 **One JVM-only dispatch note:** when the call destination is served by the *same JVM process*,
-the JVM backend dispatches in-process (`JvmStaticDispatch`/`LocalJvmServiceRegistry`) instead
-of going through the daemon. Results are asserted equivalent by the commonTest suites, but
-such calls do not exercise the wire. Cross-process behavior *as a client* is what the
-`cross_test` dbusmock suites pin.
+the JVM backend takes an in-process shortcut (`JvmStaticDispatch`) instead of going through the
+daemon. Results are asserted equivalent by the commonTest suites, but such calls do not exercise
+the wire. Cross-process behavior *as a client* is what the `cross_test` dbusmock suites pin.
 
-This in-process table is also, today, the **only** path by which a JVM-hosted object serves
-incoming method/property calls — see "Server-side object export" below for the consequence
-(#90): an *external* process calling a JVM-exported object is not served.
+The in-process table is a same-JVM optimization, not the only serving path: an object exported
+via `addVTable` is registered once and is reachable **both** in-process and over the wire, so an
+*external* process calling a JVM-exported object is served by `WireServe` (#90 closed in 0.5.0) —
+see "Server-side object export" below.
 
 ## Timeouts
 
@@ -91,8 +94,8 @@ calls made *without* an explicit per-call timeout: on native it maps to
 `sd_bus_set/get_method_call_timeout` (sd_bus resolves a 0 per-call timeout through the
 connection default inside `sd_bus_call`); the JVM call paths consult the stored value the same
 way (issue #80). An explicit per-call timeout always wins over the connection default; if
-neither is set, each backend's own default reply timeout applies (sd-bus's 25 s default /
-dbus-java's default reply timeout).
+neither is set, each backend's own default reply timeout applies (sd-bus's 25 s default / the
+JVM wire backend's own default reply timeout).
 
 - Proven by: `FailurePathParityTest.connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout`
   (both backends: connection default expires a slow call made with no per-call timeout, and an
@@ -149,11 +152,19 @@ parity in issue #28 / PR #47.
   historical name, it now *asserts* JVM signal emission and `PropertiesChanged` emission are
   supported — it pins the closure of those former gaps).
 
-> **Serving caveat:** `Properties.Get`/`Set`/`GetAll` *served by a JVM object* are answered
-> from the in-process dispatch table, not over the wire (see "Server-side object export"). An
-> external process performing `Properties.Get` against a JVM-hosted object gets `UnknownObject`
-> (#90). `PropertiesChanged` *emission* does go to the real bus, but external reception is not
-> CI-verified. On native all of these are reachable cross-process.
+**Generated adaptors auto-emit** `PropertiesChanged` (#115): a property annotated
+`org.freedesktop.DBus.Property.EmitsChangedSignal` is bound through `Object.notifying(...)`, so
+both a remote `Set` and a server-side assignment fire the signal (no-op sets are skipped) on
+both backends — client property-change flows therefore update by default.
+
+- Proven by: `cross_test/.../DbusmockAdaptorPropertiesChangedTest.propertiesChangedFires_onRemoteSet_andServerSideSet`.
+
+> **Serving note:** `Properties.Get`/`Set`/`GetAll` *served by a JVM object* are answered over
+> the owned wire connection (`WireServe`), so an external process performing `Properties.Get`
+> against a JVM-hosted object is served exactly as on native (#90 closed in 0.5.0); same-JVM
+> callers take the in-process shortcut. `PropertiesChanged` *emission* reaches external
+> subscribers (pinned by `WireSignalEmissionExternalTest`). On native all of these are reachable
+> cross-process too.
 
 ## Signals
 
@@ -177,49 +188,43 @@ consumption, and the `ObjectManagerProxy` reactive state flows behave identicall
   round-trip + proxy flow convergence), and `cross_test/.../DbusmockBluezTest.kt`
   (ObjectManager discovery over the dbusmock `bluez5` template).
 
-> **Serving caveat:** the verified `GetManagedObjects` round-trips above exercise sdbus-kotlin
-> *as a client* against a foreign emitter, plus JVM in-process own-server. A JVM object
-> *serving* `GetManagedObjects` to an **external** process answers from the in-process registry
-> and is not reachable cross-process (#90); `InterfacesAdded`/`Removed` *emission* does reach
-> the bus. On native, serving `GetManagedObjects` cross-process works fully. See "Server-side
-> object export".
+> **Serving note:** the verified `GetManagedObjects` round-trips above exercise sdbus-kotlin
+> *as a client* against a foreign emitter, plus own-server round-trips on both backends. A JVM
+> object *serving* `GetManagedObjects` to an **external** process is now answered over the wire
+> (`WireServe`), reachable cross-process exactly as on native (#90 closed in 0.5.0; pinned by
+> `WireServeExternalTest`); `InterfacesAdded`/`Removed` *emission* also reaches the bus. See
+> "Server-side object export".
 
-## Server-side object export (JVM limitation)
+## Server-side object export
 
-This is the one place the two backends are **not** at parity, and the matrix rows above are
-scoped accordingly.
+Both backends are full server backends. This was the last JVM gap (#90); it closed in 0.5.0
+when the JVM target gained its own D-Bus connection (epic #93), so the matrix rows above are at
+parity for serving as well as for consuming.
 
-**Native** is a full server backend: `createObject(path).addVTable(...)` registers the object
-with sd-bus, so methods, `org.freedesktop.DBus.Properties` (`Get`/`Set`/`GetAll`), and
-`ObjectManager.GetManagedObjects` are callable by **any** peer on the bus — busctl, a native
-client, a JVM client, another process — exactly as you'd expect from a D-Bus service.
+**Native:** `createObject(path).addVTable(...)` registers the object with sd-bus, so methods,
+`org.freedesktop.DBus.Properties` (`Get`/`Set`/`GetAll`), `org.freedesktop.DBus.Introspectable`,
+and `ObjectManager.GetManagedObjects` are callable by **any** peer on the bus — busctl, a native
+client, a JVM client, another process.
 
-**JVM** is fully capable as a *client*, and it emits signals (incl. `PropertiesChanged`,
-`InterfacesAdded`/`Removed`) to the real bus via dbus-java's `sendMessage`, so external
-subscribers do receive them. But its server side routes **incoming** method and property calls
-through an in-process dispatch table (`JvmStaticDispatch` / `LocalJvmSignalBus` /
-`LocalManagedObjectsRegistry` in `PureJavaDbusBackend.kt`) rather than registering the object
-with dbus-java's real export mechanism (`DBusConnection.exportObject` / `ExportedObject`).
+**JVM:** `addVTable` registers the object once into the shared dispatch registries, and the
+owned wire connection's serve path (`WireServe`) answers **incoming** method calls,
+`Properties.Get`/`Set`/`GetAll`, `Introspect`, `Peer.Ping`/`GetMachineId`, and
+`ObjectManager.GetManagedObjects` over the wire — so an external process reaches a JVM-exported
+object exactly as it would a native one. Signals (incl. `PropertiesChanged`,
+`InterfacesAdded`/`Removed`) are emitted as real D-Bus signals the bus routes to every
+subscriber. Each incoming call runs on a bounded, deadlock-free serve worker pool (#101), off
+the reader thread, so a slow or re-entrant handler cannot stall I/O. Same-JVM client→server
+calls still take an in-process shortcut (`JvmStaticDispatch`) for speed, but that is an
+optimization over the same registration, not a separate code path.
 
-Consequence (issue #90): a JVM-hosted service claims its bus name, exports, emits, and shuts
-down cleanly, and in-process JVM clients reach it — but a call from a **separate process**
-(busctl, another client) to one of its methods or properties gets `UnknownObject`. The
-exported objects are invisible to external method/property callers on the actual bus.
+- Proven cross-process by: `cross_test/.../jvmTest/.../WireServeExternalTest.kt`
+  (`externalBusctl_reachesServedObject` — an external `busctl` invokes a JVM-served object's
+  methods, `Properties.Get`/`Set`/`GetAll`, `Introspect`, and `GetManagedObjects`) and
+  `WireSignalEmissionExternalTest.kt` (`emittedSignal_reachesExternalDbusMonitor`). The
+  `samples/demo-service` sample (#88) is a runnable server exercising the same path.
 
-Why this is not a one-line fix: dbus-java's `exportObject` dispatches incoming calls by
-**reflecting a statically-typed `DBusInterface`** — it deserializes arguments from the wire
-using the Java *method's* declared parameter types, invokes the method reflectively, and
-serializes the reply from the method's return type (`ConnectionMethodInvocation`,
-`ExportedObject`). sdbus-kotlin's vtable is dynamic (signatures + callbacks resolved at
-runtime) and carries its own wire codec. dbus-java exposes no lower-level "raw incoming
-method-call" hook, so bridging the two requires either generating a typed `DBusInterface` per
-vtable at runtime (reconciling dbus-java's marshalling with sdbus-kotlin's codec) or
-intercepting the reader/transport below dbus-java's public API. Both are substantial; the fix
-is tracked in #90.
-
-**Until then:** use the **native** backend for any service that must be reachable by external
-D-Bus consumers. The JVM backend is recommended for *client* use and for in-process JVM↔JVM
-serving.
+Both backends are now interchangeable for *serving* as well as *consuming*; the choice of
+backend is purely a deployment decision (JVM runtime vs. self-contained native binary).
 
 ## Unix file descriptors
 
@@ -241,7 +246,7 @@ Backend differences:
   does **not** duplicate (it wraps the same fd) and `release()` cannot close it —
   `src/jvmTest/.../JvmUnixFdTest.kt` gates its dup assertion on
   `supportsFdDuplicationSemantics` for exactly this reason. On the wire, `UnixFd` converts
-  to/from dbus-java's `FileDescriptor` (`PureJavaDbusBackend.kt`), but the independent-peer
+  to/from a junixsocket `FileDescriptor` (`DBusWireConnection.kt`), but the independent-peer
   fd round-trip is skipped on JVM (test code cannot mint raw pipe fds portably under JPMS —
   see `cross_test/src/jvmTest/.../DbusmockFdSupport.jvm.kt`), so JVM wire fd passing is
   **not CI-verified**. Treat it as best-effort; prefer the native backend for fd-heavy
@@ -271,15 +276,15 @@ There are 11 `create*Connection` entry points — 10 declared in the common API
 - `createRemoteSystemBusConnection(host)` is **native-only and not declared in the common
   or JVM API** (it lives in `src/nativeMain/.../Connection.native.kt`). It opens the system
   bus of a remote host over ssh via sd-bus (`sd_bus_open_system_remote`, which spawns
-  `ssh … systemd-stdio-bridge`); dbus-java has no equivalent transport, and the former JVM
-  declaration wrongly treated the host as a dbus-java bus *address*, so it was removed
+  `ssh … systemd-stdio-bridge`); the JVM backend has no equivalent transport, and the former
+  JVM declaration wrongly treated the host as a bus *address*, so it was removed
   (#82). To connect to a TCP-exposed bus on JVM, use the address-based factories instead.
 
 **Bus-unreachable behavior:** when opening the bus fails (e.g. no
 `DBUS_SESSION_BUS_ADDRESS`, or an address that points nowhere), **both backends throw
 `com.monkopedia.sdbus.Error`** (issue #81; previously the JVM backend silently fell back to
 an in-process stub that faked success). The exact error *name* is not pinned across backends
-— native carries the errno from `sd_bus_open_*`, while dbus-java does not expose an errno —
+— native carries the errno from `sd_bus_open_*`, while the JVM backend does not expose an errno —
 but the type and the throw are the contract. The in-process stub backend
 (`StubJvmDbusBackend` in `src/jvmMain/.../JvmDbusBackend.kt`) still exists for unit tests
 that need connection plumbing without a real bus, but it is an **explicit internal opt-in**
@@ -294,18 +299,23 @@ implicitly by any factory.
 The calling pattern is the same on both backends — call `startEventLoop()` after registering
 objects/handlers, `stopEventLoop()` (suspend) before release — but the machinery differs:
 
-- **Native**: `startEventLoop()` launches the sd-bus I/O loop on an internally managed
-  thread; incoming method calls, signals, and async replies are only dispatched while it
-  runs. `stopEventLoop()` signals the loop to exit and joins it. Releasing the connection
-  also stops the loop. (`ConnectionImpl.kt`; teardown bounds pinned by
-  `FailurePathParityTest`.)
-- **JVM**: dbus-java runs its own reader/dispatch threads from the moment the connection is
-  built, so `startEventLoop()`/`stopEventLoop()` are **no-ops** (`PureJavaDbusConnection`).
-  Dispatch is effectively always on.
+- **Native**: `startEventLoop()` launches the sd-bus I/O loop on a **dedicated per-connection
+  thread** (#128 — each connection owns its own loop thread rather than sharing a bounded
+  pool, so many concurrent connections can no longer starve one another); incoming method
+  calls, signals, and async replies are only dispatched while it runs. `createObject(...)` and
+  `createProxy(...)` auto-start the loop (`runEventLoopThread = true` by default, #114), and a
+  redundant `startEventLoop()` afterwards is **idempotent** — never a second thread.
+  `stopEventLoop()` signals the loop to exit and joins it; releasing the connection also stops
+  it. (`ConnectionImpl.kt`; teardown bounds pinned by `FailurePathParityTest`.)
+- **JVM**: the owned wire connection runs its own reader/dispatch threads from the moment the
+  connection is built, so `startEventLoop()`/`stopEventLoop()` are **no-ops** (trivially
+  idempotent). Dispatch is effectively always on.
 
-Consequence: code that forgets `startEventLoop()` appears to work on JVM and silently
-receives nothing on native. Always call `startEventLoop()` — it is free on JVM and required
-on native. `currentlyProcessedMessage` is valid inside handlers on both backends
+Consequence: explicit `startEventLoop()` is no longer a footgun — `createObject`/`createProxy`
+auto-start it on native and it is a free no-op on JVM, while a redundant call is idempotent on
+both (`EventLoopStartIdempotencyTest.createObjectAutoStartsLoop_andRepeatedStartEventLoopIsIdempotent`).
+You can still call it explicitly after registering handlers on a bare connection.
+`currentlyProcessedMessage` is valid inside handlers on both backends
 (`CommonApiIntegrationTest.signalHandler_exposesCurrentlyProcessedMessageOnProxy`,
 `propertySetter_exposesCurrentlyProcessedMessageOnObject`).
 

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ISdBus.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ISdBus.kt
@@ -169,15 +169,6 @@ internal interface ISdBus {
         userdata: CValuesRef<*>?
     ): Int
 
-    fun sd_bus_add_match_async(
-        bus: CValuesRef<sd_bus>?,
-        slot: CValuesRef<CPointerVar<sd_bus_slot>>?,
-        match: String?,
-        callback: sd_bus_message_handler_t?,
-        install_callback: sd_bus_message_handler_t?,
-        userdata: CValuesRef<*>?
-    ): Int
-
     fun sd_bus_match_signal(
         bus: CValuesRef<sd_bus>?,
         ret: CValuesRef<CPointerVar<sd_bus_slot>>?,

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/SdBus.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/SdBus.kt
@@ -410,17 +410,6 @@ internal class SdBus : ISdBus {
         return sdbus.sd_bus_add_match(bus, slot, match, callback, userdata)
     }
 
-    override fun sd_bus_add_match_async(
-        bus: CValuesRef<sd_bus>?,
-        slot: CValuesRef<CPointerVar<sd_bus_slot>>?,
-        match: String?,
-        callback: sd_bus_message_handler_t?,
-        install_callback: sd_bus_message_handler_t?,
-        userdata: CValuesRef<*>?
-    ): Int = lock.withLock {
-        return sdbus.sd_bus_add_match_async(bus, slot, match, callback, install_callback, userdata)
-    }
-
     override fun sd_bus_match_signal(
         bus: CValuesRef<sd_bus>?,
         ret: CValuesRef<CPointerVar<sd_bus_slot>>?,

--- a/src/nativeTest/kotlin/mocks/SdBusMock.kt
+++ b/src/nativeTest/kotlin/mocks/SdBusMock.kt
@@ -212,16 +212,6 @@ internal class SdBusMock :
         userdata: CValuesRef<*>?
     ): Int = invoke("sd_bus_add_match", bus, slot, match, callback, userdata)
 
-    override fun sd_bus_add_match_async(
-        bus: CValuesRef<sd_bus>?,
-        slot: CValuesRef<CPointerVar<sd_bus_slot>>?,
-        match: String?,
-        callback: sd_bus_message_handler_t?,
-        install_callback: sd_bus_message_handler_t?,
-        userdata: CValuesRef<*>?
-    ): Int =
-        invoke("sd_bus_add_match_async", bus, slot, match, callback, install_callback, userdata)
-
     override fun sd_bus_match_signal(
         bus: CValuesRef<sd_bus>?,
         ret: CValuesRef<CPointerVar<sd_bus_slot>>?,


### PR DESCRIPTION
Non-gated post-0.6.0 cleanup (spare-quota). Docs accuracy + a dead-code removal. No public API change.

- **docs/BACKENDS.md**: corrected the stale dbus-java description of the JVM backend → junixsocket owned connection (pure-Kotlin marshaller + dispatch), matching the README. Also rewrote the "server-side object export (JVM limitation)" section — that #90 gap **closed in 0.5.0 (#100)**: the JVM backend now serves external method/property/introspect/ObjectManager calls over the owned wire connection (pinned by `WireServeExternalTest`/`WireSignalEmissionExternalTest`) — flipped the relevant matrix rows from ⚠️ to ✅.
- **0.6.0 deltas** folded into the matrix: bounded/deadlock-free JVM serve pool (#101); native per-connection event-loop thread + createObject auto-start + idempotent startEventLoop (#128/#114); PropertiesChanged auto-emit (#115); requestName→RequestNameReply (#112).
- **dokka/moduledoc.md**: left unchanged (its only dbus-java hit is the accurate "no dbus-java" negative).
- **Dead code**: removed the now-unused `sd_bus_add_match_async` FFI binding (`ISdBus.kt`/`SdBus.kt` + test mock) — its only caller, `addMatchAsync`, was removed in #113. Internal, so apiCheck unchanged.

Known residual (flagged, out of scope): further pre-0.5.0 staleness in BACKENDS.md (PureJavaDbusBackend→JvmDbusBackend naming, removed test refs, the fd-factory bullet) — follow-up.

Verified: compile x3, linuxX64Test, ktlintCheck, apiCheck (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
