### PR TITLE
Test coverage for the 0.6.0 surface (requestName reply, notifying delegate, direct accessors)

### DIFF
--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockAdaptorPropertiesChangedTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockAdaptorPropertiesChangedTest.kt
@@ -31,14 +31,17 @@ import com.monkopedia.sdbus.addVTable
 import com.monkopedia.sdbus.createBusConnection
 import com.monkopedia.sdbus.createObject
 import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.getProperty
 import com.monkopedia.sdbus.notifying
 import com.monkopedia.sdbus.prop
 import com.monkopedia.sdbus.setProperty
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * A minimal server-side property holder mirroring what the codegen emits for a writable
@@ -48,6 +51,16 @@ import kotlinx.coroutines.withTimeout
  */
 private class LevelService(obj: Object, iface: InterfaceName, property: PropertyName) {
     var level: Int by obj.notifying(iface, property, 0)
+}
+
+/**
+ * A plain server-side property holder mirroring what codegen emits for a writable property whose
+ * `org.freedesktop.DBus.Property.EmitsChangedSignal` annotation IS `false`/`const`: a plain backing
+ * field with NO [notifying] delegate, so neither a remote `Properties.Set` nor a server-side
+ * assignment emits `PropertiesChanged`.
+ */
+private class PlainLevelHolder {
+    var level: Int = 0
 }
 
 /**
@@ -121,4 +134,138 @@ class DbusmockAdaptorPropertiesChangedTest {
             serverConnection.release()
         }
     }
+
+    /**
+     * Focused coverage of the [notifying] delegate contract (issue #115): a change emits
+     * `PropertiesChanged` EXACTLY ONCE; re-setting the SAME value is a no-op (skip-on-unchanged, no
+     * spurious signal); and reading the delegate (server-side getter AND a remote `Properties.Get`)
+     * returns the stored value. Runs on both backends via commonTest.
+     */
+    @Test
+    fun notifyingDelegate_emitsOnceOnChange_skipsUnchanged_andReadsBack() =
+        withDbusmockPeer("NotifyingProp") {
+            val id = Random.nextInt(100_000, 999_999)
+            val serviceName = ServiceName("com.monkopedia.sdbus.notifyingprop$id")
+            val path = ObjectPath("/com/monkopedia/sdbus/notifyingprop$id")
+            val iface = InterfaceName("com.monkopedia.sdbus.NotifyingProp")
+            val property = PropertyName("Level")
+
+            val serverConnection = createBusConnection(serviceName)
+            val obj = createObject(serverConnection, path)
+            val service = LevelService(obj, iface, property)
+            val registration = obj.addVTable(iface) {
+                prop(property) {
+                    with(service::level)
+                }
+            }
+            serverConnection.startEventLoop()
+
+            val proxy = createProxy(connection, serviceName, path)
+            val events =
+                Channel<Pair<Map<PropertyName, Variant>, List<PropertyName>>>(Channel.UNLIMITED)
+            PropertiesProxy(proxy).registerPropertiesProxy {
+                    changedInterface,
+                    changed,
+                    invalidated
+                ->
+                if (changedInterface == iface) events.trySend(changed to invalidated)
+            }
+
+            try {
+                // A real change emits exactly once, carrying the new value...
+                service.level = 5
+                val first = withTimeout(10_000) { events.receive() }
+                assertEquals(5, first.first[property]?.get<Int>(), "change must emit the new value")
+                // ...and nothing more (exactly-once).
+                assertNull(
+                    withTimeoutOrNull(750) { events.receive() },
+                    "a single change must not emit twice"
+                )
+
+                // Re-setting the SAME value is skipped — no PropertiesChanged at all.
+                service.level = 5
+                assertNull(
+                    withTimeoutOrNull(750) { events.receive() },
+                    "re-setting an unchanged value must not emit"
+                )
+
+                // The delegate read returns the stored value, both server-side and via remote Get.
+                assertEquals(5, service.level, "server-side read returns the stored value")
+                assertEquals(
+                    5,
+                    proxy.getProperty<Int>(iface, property),
+                    "remote Get returns the stored value"
+                )
+
+                // A subsequent real change emits again (the delegate is still live after the skip).
+                service.level = 8
+                val second = withTimeout(10_000) { events.receive() }
+                assertEquals(8, second.first[property]?.get<Int>())
+            } finally {
+                proxy.release()
+                registration.release()
+                obj.release()
+                serverConnection.stopEventLoop()
+                serverConnection.release()
+            }
+        }
+
+    /**
+     * Coverage for the `EmitsChangedSignal=false`/`const` codegen path (issue #115): a writable
+     * property backed by a PLAIN field (no [notifying] delegate, exactly as codegen emits when the
+     * annotation is `false`/`const`) must NOT emit `PropertiesChanged` on a remote `Properties.Set`,
+     * even though the value really changes. Complements
+     * [propertiesChangedFires_onRemoteSet_andServerSideSet] (the default-emits case). Both backends.
+     */
+    @Test
+    fun plainProperty_withoutNotifyingDelegate_doesNotEmitOnRemoteSet() =
+        withDbusmockPeer("PlainProp") {
+            val id = Random.nextInt(100_000, 999_999)
+            val serviceName = ServiceName("com.monkopedia.sdbus.plainprop$id")
+            val path = ObjectPath("/com/monkopedia/sdbus/plainprop$id")
+            val iface = InterfaceName("com.monkopedia.sdbus.PlainProp")
+            val property = PropertyName("Level")
+
+            val serverConnection = createBusConnection(serviceName)
+            val obj = createObject(serverConnection, path)
+            val holder = PlainLevelHolder()
+            val registration = obj.addVTable(iface) {
+                prop(property) {
+                    with(holder::level)
+                }
+            }
+            serverConnection.startEventLoop()
+
+            val proxy = createProxy(connection, serviceName, path)
+            val events =
+                Channel<Pair<Map<PropertyName, Variant>, List<PropertyName>>>(Channel.UNLIMITED)
+            PropertiesProxy(proxy).registerPropertiesProxy {
+                    changedInterface,
+                    changed,
+                    invalidated
+                ->
+                if (changedInterface == iface) events.trySend(changed to invalidated)
+            }
+
+            try {
+                // Remote Set writes the plain backing field...
+                proxy.setProperty(iface, property, 7)
+                assertEquals(
+                    7,
+                    proxy.getProperty<Int>(iface, property),
+                    "the value must really change"
+                )
+                // ...but with no notifying delegate, no PropertiesChanged is ever emitted.
+                assertNull(
+                    withTimeoutOrNull(1_000) { events.receive() },
+                    "a plain (EmitsChangedSignal=false/const) property must not auto-emit"
+                )
+            } finally {
+                proxy.release()
+                registration.release()
+                obj.release()
+                serverConnection.stopEventLoop()
+                serverConnection.release()
+            }
+        }
 }

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -7,6 +7,8 @@ import com.monkopedia.sdbus.ObjectPath
 import com.monkopedia.sdbus.PendingAsyncCall
 import com.monkopedia.sdbus.PropertiesProxy
 import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.RequestNameFlag
+import com.monkopedia.sdbus.RequestNameReply
 import com.monkopedia.sdbus.SdbusException
 import com.monkopedia.sdbus.ServiceName
 import com.monkopedia.sdbus.SignalName
@@ -18,9 +20,14 @@ import com.monkopedia.sdbus.createBusConnection
 import com.monkopedia.sdbus.createObject
 import com.monkopedia.sdbus.createProxy
 import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.getAllProperties
+import com.monkopedia.sdbus.getAllPropertiesAsync
+import com.monkopedia.sdbus.getProperty
+import com.monkopedia.sdbus.getPropertyAsync
 import com.monkopedia.sdbus.method
 import com.monkopedia.sdbus.onSignal
 import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.setPropertyAsync
 import com.monkopedia.sdbus.signal
 import kotlin.random.Random
 import kotlin.test.Test
@@ -1117,6 +1124,98 @@ class CommonApiIntegrationTest {
             match.release()
             objectManager.release()
             connection.release()
+        }
+    }
+
+    // Coverage for #112: requestName now reports a RequestNameReply for each outcome. This lives in
+    // commonTest, so the IDENTICAL assertions run on BOTH backends — native sd-bus (linuxX64Test)
+    // and the JVM wire backend (jvmTest). Each platform asserting the same expected enum for every
+    // scenario IS the cross-backend-consistency regression guard for the 0.6.0 fix that made the two
+    // backends agree on these reply codes.
+    @Test
+    fun requestName_reportsConsistentReplyCodesAcrossBackends() {
+        val ids = uniqueFixtureIds("requestName")
+        val name = ServiceName("${ids.service.value}.Owned")
+        val owner = createBusConnection()
+        val queued = createBusConnection()
+        val rejected = createBusConnection()
+
+        try {
+            // A fresh, unowned name → the caller becomes the primary owner.
+            assertEquals(RequestNameReply.PRIMARY_OWNER, owner.requestName(name))
+
+            // The SAME connection re-requesting its own name → already the owner.
+            assertEquals(RequestNameReply.ALREADY_OWNER, owner.requestName(name))
+
+            // A SECOND connection, no flags → queued behind the current owner (default queueing).
+            assertEquals(RequestNameReply.IN_QUEUE, queued.requestName(name))
+
+            // A different connection with DO_NOT_QUEUE → refused outright rather than queued.
+            assertEquals(
+                RequestNameReply.EXISTS,
+                rejected.requestName(name, RequestNameFlag.DO_NOT_QUEUE)
+            )
+        } finally {
+            runCatching { owner.releaseName(name) }
+            runCatching { queued.releaseName(name) }
+            owner.release()
+            queued.release()
+            rejected.release()
+        }
+    }
+
+    // Coverage for #110: the direct two-arg property accessors on Proxy
+    // (getPropertyAsync / setPropertyAsync / getAllProperties / getAllPropertiesAsync). Confirms the
+    // async variants agree with the sync getProperty/setProperty results and that the Variant unwrap
+    // yields the typed value. Runs on both backends via commonTest.
+    @Test
+    fun directPropertyAccessors_matchSyncResultsAndUnwrapVariant() = runBlocking {
+        val ids = uniqueFixtureIds("directProps")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val levelProperty = PropertyName("level")
+        var level = 3
+        val obj = createObject(serverConnection, ids.path)
+        val registration = obj.addVTable(ids.iface) {
+            prop(levelProperty) {
+                withGetter { level }
+                withSetter<Int> { value -> level = value }
+            }
+        }
+        serverConnection.startEventLoop()
+        proxyConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path)
+
+        try {
+            // Async get matches sync get, and both unwrap the Variant to the typed value.
+            val sync = proxy.getProperty<Int>(ids.iface, levelProperty)
+            val async = proxy.getPropertyAsync<Int>(ids.iface, levelProperty)
+            assertEquals(3, sync)
+            assertEquals(sync, async)
+
+            // Async set round-trips; subsequent sync and async reads both reflect the new value.
+            proxy.setPropertyAsync(ids.iface, levelProperty, 11)
+            assertEquals(11, level)
+            assertEquals(11, proxy.getProperty<Int>(ids.iface, levelProperty))
+            assertEquals(11, proxy.getPropertyAsync<Int>(ids.iface, levelProperty))
+
+            // getAllProperties (sync) and getAllPropertiesAsync agree, with correct Variant unwrap.
+            val all = proxy.getAllProperties(ids.iface)
+            val allAsync = proxy.getAllPropertiesAsync(ids.iface)
+            assertEquals(11, all[levelProperty]?.get<Int>())
+            assertEquals(11, allAsync[levelProperty]?.get<Int>())
+            assertEquals(
+                all.mapValues { it.value.get<Int>() },
+                allAsync.mapValues { it.value.get<Int>() }
+            )
+        } finally {
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.stopEventLoop()
+            serverConnection.stopEventLoop()
+            proxyConnection.release()
+            serverConnection.release()
         }
     }
 


### PR DESCRIPTION
Non-gated post-0.6.0 test coverage (spare-quota). Tests only — no production code, apiCheck unchanged. No bugs found.

- **#112 requestName reply codes** (`CommonApiIntegrationTest`, commonTest → runs on BOTH backends): PRIMARY_OWNER (fresh) / ALREADY_OWNER (same conn re-requests) / IN_QUEUE (2nd conn, no flags) / EXISTS (2nd conn, DO_NOT_QUEUE). Living in commonTest means native and JVM assert the SAME enum per scenario — a cross-backend-consistency regression guard for the 0.6.0 flag-handling fix.
- **#110 direct property accessors**: `getPropertyAsync`/`setPropertyAsync`/`getAllProperties`/`getAllPropertiesAsync` round-trip against a served object; agree with sync getProperty/setProperty + correct Variant unwrap.
- **#115 notifying delegate** (cross_test dbusmock): emits PropertiesChanged exactly once on change, nothing on same-value set (skip-on-unchanged), reads back the stored value.
- **#115 plain property no-emit**: the EmitsChangedSignal=false/const path — a plain (non-notifying) writable property must NOT emit on a remote Set even though the value changes.

dbusmock tests verified genuinely run (negative control: `DBUSMOCK_PYTHON=/usr/bin/false` → 3 SKIP lines; real venv → 0 SKIP, passing). Full suite green under dbus-run-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
