### PR TITLE
Harden serve worker pool: saturation watchdog for non-compensated nested blocking

### DIFF
--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -883,7 +883,10 @@ private class ServeWorkerPool {
             return
         }
         val stale = System.nanoTime() - lastProgressNanos.get() >= STALL_THRESHOLD_NANOS
-        val allBusy = executor.activeCount >= executor.poolSize
+        // Only intervene once the base pool is fully spun up (poolSize >= bound). Below that the
+        // executor can still grow on its own, and an idle connection (poolSize == 0) would otherwise
+        // read as "all busy" (0 >= 0) and spuriously add a worker on the first burst after idling.
+        val allBusy = executor.poolSize >= bound && executor.activeCount >= executor.poolSize
         if (stale && allBusy) {
             synchronized(poolLock) {
                 if (watchdogExtra < maxExtra) {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.thread
 import kotlinx.coroutines.future.await
 import org.newsclub.net.unix.AFUNIXSocket
@@ -706,13 +707,33 @@ internal class DBusWireConnection private constructor(
  * Surplus compensating workers retire once idle (`allowCoreThreadTimeOut`), shrinking the pool back
  * to [bound] after a nested-dispatch storm subsides.
  *
- * SCOPE / CONSTRAINT on serve handlers: compensation only covers a worker that blocks *on its own
- * thread* inside [call]/[callBlocking] (where [beginNestedBlock] runs). A serve handler that instead
- * (a) offloads its nested same-connection call to a DIFFERENT thread/dispatcher (e.g.
- * `withContext(Dispatchers.IO) { connection.call(...) }`) while keeping the worker parked, or
- * (b) blocks on a non-same-connection dependency (a shared lock, another handler's result), is NOT
- * compensated and can starve the bounded pool. Serve handlers must perform any nested same-connection
- * call synchronously on the worker thread, and must not block the worker on unrelated work.
+ * SCOPE of same-thread compensation: [beginNestedBlock] only covers a worker that blocks *on its own
+ * thread* inside [call]/[callBlocking]. A serve handler that instead (a) offloads its nested
+ * same-connection call to a DIFFERENT thread/dispatcher (e.g. `withContext(Dispatchers.IO) {
+ * connection.call(...) }`) while keeping the worker parked, or (b) blocks the worker on a
+ * non-same-connection dependency (a shared lock, or a result that only ANOTHER served call on this
+ * connection can produce), runs off the marked worker thread, so [beginNestedBlock] returns false and
+ * no fast-path compensation fires. Handlers SHOULD still do nested same-connection calls synchronously
+ * on the worker thread; that remains the cheap, exact path.
+ *
+ * WATCHDOG backstop for the cases same-thread compensation misses (issue #101 follow-up). A single
+ * daemon thread periodically samples forward progress: if the queue is non-empty AND no task has
+ * *started or completed* for [STALL_THRESHOLD_NANOS] (a forward-progress stall), it spawns one
+ * compensating worker (raising `corePoolSize`, prestarting a thread), up to a hard cap of [maxExtra]
+ * extra workers, and retires them again once the queue drains. This rescues (a) and (b): the new
+ * worker runs a queued task that can release the parked workers (e.g. the lock holder, or the
+ * other-served-call the parked workers await), restoring progress.
+ *
+ * Why the watchdog cannot grow unbounded under a LEGITIMATE flood of independent slow handlers — the
+ * exact false-positive that a naive "all workers busy + queue non-empty" trigger would suffer: such a
+ * flood keeps making forward progress (handlers keep STARTING and COMPLETING as workers cycle), so the
+ * progress timestamp stays fresh and the stall test never trips. Only a genuine stall — where every
+ * worker is parked and not one task is starting or finishing — goes stale. And even if a pathological
+ * legitimately-slow flood (every handler individually slower than the threshold) did trip it, growth is
+ * clamped at [maxExtra]: the watchdog adds at most a bounded number of workers and then stops, never a
+ * thread-per-call. Deadlock-freedom is preserved trivially: the watchdog only ever ADDS runnable
+ * capacity (or removes idle capacity), and the queue/[execute] never block or reject, so more threads
+ * can never introduce a new deadlock.
  */
 private class ServeWorkerPool {
     /** Steady-state worker count: ~2x CPUs, clamped so it is neither starved nor wildly large. */
@@ -724,10 +745,27 @@ private class ServeWorkerPool {
     private val onWorkerThread = ThreadLocal.withInitial { false }
     private val threadCounter = AtomicInteger(0)
 
-    // Guards corePoolSize mutations and [parked]; the invariant corePoolSize == bound + parked is
-    // maintained only under this lock so concurrent nested blocks compose correctly.
+    // Guards corePoolSize mutations, [parked] and [watchdogExtra]; the invariant
+    // corePoolSize == bound + parked + watchdogExtra is maintained only under this lock so concurrent
+    // nested blocks and watchdog spawns compose correctly.
     private val poolLock = Any()
     private var parked = 0
+
+    // Extra workers the saturation watchdog has spawned (see [watchdogTick]); clamped at [maxExtra].
+    private var watchdogExtra = 0
+
+    // Hard cap on watchdog-spawned compensating workers: even a pathological legitimately-slow flood
+    // can grow the pool by at most this much, never a thread-per-call.
+    private val maxExtra = bound
+
+    // Last time a serve task STARTED or COMPLETED (nanos). The watchdog reads this to tell a genuine
+    // forward-progress stall (this goes stale while work is queued) from a busy-but-progressing flood
+    // (workers keep cycling, so it stays fresh). Seeded at construction so an idle pool is never
+    // mistaken for stalled.
+    private val lastProgressNanos = AtomicLong(System.nanoTime())
+
+    @Volatile
+    private var running = true
 
     private val executor = ThreadPoolExecutor(
         bound,
@@ -756,10 +794,38 @@ private class ServeWorkerPool {
         allowCoreThreadTimeOut(true)
     }
 
+    // Single daemon thread that samples forward progress and spawns bounded compensating workers when
+    // the pool is genuinely stalled; see [watchdogTick] and the class doc's WATCHDOG section.
+    private val watchdog = thread(
+        start = true,
+        isDaemon = true,
+        name = "sdbus-jvm-wire-serve-watchdog"
+    ) {
+        while (running) {
+            try {
+                Thread.sleep(WATCHDOG_INTERVAL_MILLIS)
+            } catch (_: InterruptedException) {
+                break
+            }
+            if (!running) break
+            runCatching { watchdogTick() }
+        }
+    }
+
     val largestPoolSize: Int get() = executor.largestPoolSize
 
     fun execute(task: () -> Unit) {
-        executor.execute(task)
+        // Bracket every task with progress timestamps: a task STARTING and COMPLETING are both
+        // forward progress, so a busy-but-progressing flood keeps [lastProgressNanos] fresh and is
+        // never mistaken by the watchdog for a stall (where neither happens).
+        executor.execute {
+            lastProgressNanos.set(System.nanoTime())
+            try {
+                task()
+            } finally {
+                lastProgressNanos.set(System.nanoTime())
+            }
+        }
     }
 
     /**
@@ -771,7 +837,7 @@ private class ServeWorkerPool {
         if (!onWorkerThread.get()) return false
         synchronized(poolLock) {
             parked++
-            executor.corePoolSize = bound + parked
+            recomputeCorePoolSize()
             // Make a replacement worker live now (even before the nested METHOD_CALL is queued) so
             // it is ready to pick the nested task up the instant the reader submits it.
             executor.prestartCoreThread()
@@ -783,11 +849,55 @@ private class ServeWorkerPool {
     fun endNestedBlock() {
         synchronized(poolLock) {
             parked--
-            executor.corePoolSize = bound + parked
+            recomputeCorePoolSize()
+        }
+    }
+
+    // Must hold [poolLock]. The single point that enforces corePoolSize == bound + parked +
+    // watchdogExtra so the nested-block and watchdog compensations compose without clobbering.
+    private fun recomputeCorePoolSize() {
+        executor.corePoolSize = bound + parked + watchdogExtra
+    }
+
+    /**
+     * One watchdog sample. Spawns at most one compensating worker per call (so growth ramps gently
+     * and re-checks real progress between additions) and only when:
+     *  - there is queued work (otherwise nothing is starved), AND
+     *  - every worker is busy (no idle worker would already be draining the queue), AND
+     *  - no task has started or completed for [STALL_THRESHOLD_NANOS] (a true forward-progress stall,
+     *    not a flood whose workers keep cycling).
+     * When the queue has drained it releases all watchdog compensation so the pool shrinks back toward
+     * [bound] (the surplus idle threads then time out via `allowCoreThreadTimeOut`).
+     */
+    private fun watchdogTick() {
+        if (executor.queue.isEmpty()) {
+            // No pending work: drop any compensation we added so we return to bound (+ nested parked).
+            if (watchdogExtra > 0) {
+                synchronized(poolLock) {
+                    if (watchdogExtra > 0) {
+                        watchdogExtra = 0
+                        recomputeCorePoolSize()
+                    }
+                }
+            }
+            return
+        }
+        val stale = System.nanoTime() - lastProgressNanos.get() >= STALL_THRESHOLD_NANOS
+        val allBusy = executor.activeCount >= executor.poolSize
+        if (stale && allBusy) {
+            synchronized(poolLock) {
+                if (watchdogExtra < maxExtra) {
+                    watchdogExtra++
+                    recomputeCorePoolSize()
+                    executor.prestartCoreThread()
+                }
+            }
         }
     }
 
     fun shutdownNow() {
+        running = false
+        watchdog.interrupt()
         executor.shutdownNow()
     }
 
@@ -795,6 +905,13 @@ private class ServeWorkerPool {
         private const val MIN_BOUND = 4
         private const val MAX_BOUND = 64
         private const val WORKER_KEEPALIVE_SECONDS = 30L
+        private const val WATCHDOG_INTERVAL_MILLIS = 250L
+
+        // How long the pool must show NO task start/completion (while work is queued) before the
+        // watchdog treats it as stalled. Comfortably above any reasonable serve-handler burst cadence
+        // so an ordinary slow-but-progressing flood (which refreshes progress as workers cycle) never
+        // trips it; only a truly wedged pool goes this stale.
+        private val STALL_THRESHOLD_NANOS = TimeUnit.SECONDS.toNanos(1)
     }
 }
 

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
@@ -5,6 +5,8 @@ import com.monkopedia.sdbus.UnixFd
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -396,6 +398,121 @@ class DBusWireConnectionTest {
                     "unbounded threads"
             )
         } finally {
+            client.close()
+            server.close()
+        }
+    }
+
+    /**
+     * Watchdog backstop for the case the same-thread nested compensation MISSES (issue #101
+     * follow-up): a served handler that blocks its worker on a dependency satisfied only by ANOTHER
+     * served call on this connection. Here `bound` "Gate" handlers each park their worker on a shared
+     * latch; the only thing that can open that latch is a separate "Open" call — which, once every
+     * worker is parked, has no worker to run on and sits in the queue. [beginNestedBlock] never fires
+     * (no worker is inside [DBusWireConnection.call]/[callBlocking]), so without the saturation
+     * watchdog this deadlocks: the pool is fully parked, the queue is non-empty, and NO task is making
+     * forward progress. The watchdog detects the forward-progress stall (queue non-empty + no task
+     * start/completion for the stall window) and spawns a bounded compensating worker, which runs
+     * "Open", releases the latch, and lets every "Gate" — and "Open" itself — complete. On the
+     * pre-watchdog code the client [withTimeout] fires first and the test FAILS FAST instead of
+     * hanging. One compensating worker suffices regardless of width: the single "Open" releases all
+     * waiters, so this stays bounded.
+     */
+    @Test
+    fun externalLatchDependency_underBoundedPool_isRescuedByWatchdog() = runBlocking {
+        val server = connectOrNull() ?: return@runBlocking
+        val client = connectOrNull() ?: run {
+            server.close()
+            return@runBlocking
+        }
+        val busName = "com.monkopedia.sdbus.wire.gate.s${System.nanoTime()}"
+        val path = "/com/monkopedia/sdbus/wire/gate"
+        val iface = "com.monkopedia.sdbus.wire.Gate"
+
+        val bound = server.serveBound
+        // Counts down as each Gate handler enters and is about to park: lets the test fire "Open"
+        // only once every worker is genuinely parked, making the starvation deterministic.
+        val allParked = CountDownLatch(bound)
+        // Opened solely by the "Open" handler — which itself needs a worker the parked pool lacks.
+        val gate = CountDownLatch(1)
+
+        server.setIncomingCallHandler { message ->
+            when (message.member) {
+                "Gate" -> {
+                    allParked.countDown()
+                    // Park this worker until "Open" releases the gate. A generous internal timeout so
+                    // that on BROKEN code the client-side withTimeout below fires first (fail fast),
+                    // not this await returning a spurious false.
+                    val released = gate.await(60, TimeUnit.SECONDS)
+                    server.send(
+                        WireMessage(
+                            type = WireMessageType.METHOD_RETURN,
+                            replySerial = message.serial,
+                            destination = message.sender,
+                            signature = "b",
+                            body = listOf(released)
+                        )
+                    )
+                }
+
+                "Open" -> {
+                    gate.countDown()
+                    server.send(
+                        WireMessage(
+                            type = WireMessageType.METHOD_RETURN,
+                            replySerial = message.serial,
+                            destination = message.sender,
+                            signature = "b",
+                            body = listOf(true)
+                        )
+                    )
+                }
+            }
+        }
+
+        try {
+            assertEquals(1, server.requestName(busName), "server should own $busName")
+            // Saturate every worker with a parked Gate handler.
+            val gateReplies = (1..bound).map {
+                async(Dispatchers.IO) {
+                    client.call(
+                        WireMessage(
+                            type = WireMessageType.METHOD_CALL,
+                            destination = busName,
+                            path = path,
+                            interfaceName = iface,
+                            member = "Gate"
+                        )
+                    )
+                }
+            }
+            // Only once every worker is parked is "Open" guaranteed to be queued with no free worker —
+            // the exact starvation the watchdog must rescue.
+            assertTrue(
+                allParked.await(10, TimeUnit.SECONDS),
+                "all $bound Gate handlers should park before Open is sent"
+            )
+            val openReply = async(Dispatchers.IO) {
+                client.call(
+                    WireMessage(
+                        type = WireMessageType.METHOD_CALL,
+                        destination = busName,
+                        path = path,
+                        interfaceName = iface,
+                        member = "Open"
+                    )
+                )
+            }
+
+            // On broken (pre-watchdog) code Open never runs, the gate never opens, and this times out.
+            val replies = withTimeout(15_000) { (gateReplies + openReply).awaitAll() }
+            assertEquals(bound + 1, replies.size)
+            assertTrue(
+                replies.all { it.body.firstOrNull() == true },
+                "every Gate must observe the gate opened, and Open must succeed"
+            )
+        } finally {
+            gate.countDown()
             client.close()
             server.close()
         }


### PR DESCRIPTION
Non-gated post-0.6.0 robustness (spare-quota). Closes a review-flagged latent gap in the bounded JVM serve worker pool (#101). Internal only — apiCheck unchanged.

## Gap (confirmed with a repro)
The #101 same-thread nested-block COMPENSATION only fires when a worker blocks inside `call`/`callBlocking`. A handler that (a) offloads its nested same-connection call to another dispatcher while the worker parks, or (b) blocks the worker on a non-same-connection dependency, gets NO compensation → the bounded pool can starve (all workers blocked, queue non-empty, zero forward progress). Reproduced on current code (case b: workers park on a shared latch only a queued call can open) — fails fast under timeout.

## Fix — saturation watchdog
A single daemon thread samples forward progress every 250ms and spawns ONE compensating worker only when ALL hold: queue non-empty AND every worker busy AND no task has started/completed for a 1s stall window. Capped at `maxExtra = bound`; releases extras when the queue drains. `corePoolSize` invariant is now `bound + parked + watchdogExtra` (recomputed under the lock; composes with the existing fast-path nested compensation).

**No false-fire:** the discriminator is *forward progress* (start/finish timestamps), so a legitimate flood — workers keep cycling — never trips it (the existing flood test still passes at exactly `bound`). **Bounded:** even a pathological all-slow flood is clamped at `maxExtra`, never thread-per-call. **Deadlock-free:** the watchdog only adds runnable capacity / removes idle; execute never blocks/rejects.

Regression test `externalLatchDependency_underBoundedPool_isRescuedByWatchdog` (fails fast pre-watchdog, completes with it). Existing pool tests still pass (stable across 3 reruns).

## Caveat (flagged, not baked in)
A very WIDE case-(a) offloaded-nested storm can need ~N workers to fully drain (the irreducible "N concurrently-parked handlers need ~N threads"); the watchdog caps at `bound` extra, so wide offloaded storms are mitigated but not guaranteed fully drained. Guaranteeing that would be a deliberate "unbounded-while-stalled" policy choice. The guidance that serve handlers should do nested same-connection calls synchronously still stands.

Verified: compileKotlinJvm, full :jvmTest green (3 reruns), ktlintCheck, apiCheck (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
