### PR TITLE
test: external-bus coverage — sender credentials (native + JVM)

### DIFF
--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCredentialsTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCredentialsTest.kt
@@ -10,11 +10,12 @@ import kotlinx.coroutines.withTimeout
 
 /**
  * External (real-bus) coverage for the sender-credential surface on [Message] over the JVM wire
- * backend. The bus stamps the authoritative sender on an emitted signal and the receiver resolves
- * the sender's credentials (filled from the local process for a same-process sender). The JVM
- * backend resolves pid/uid/euid/gid/egid/supplementary-gids; only [Message.seLinuxContext] is
- * unavailable over junixsocket and must throw the documented [SdbusException] (the native backend
- * covers SELinux's happy path, where labelled, in CredentialsIntegrationTest).
+ * backend, read from a received signal whose sender is this same process (so the credentials
+ * resolve to the running process). The JVM backend yields pid/uid/euid/gid/egid/supplementary-gids
+ * as non-throwing values (euid/egid equal uid/gid for a non-setuid process); [Message.seLinuxContext]
+ * is host-dependent — a label where SELinux is enforcing, or a thrown [SdbusException] otherwise.
+ * The native backend covers the same surface against the live POSIX identity in
+ * CredentialsIntegrationTest.
  */
 class JvmCredentialsTest {
 
@@ -49,7 +50,7 @@ class JvmCredentialsTest {
         val gidSeen = CompletableDeferred<UInt>()
         val egidSeen = CompletableDeferred<UInt>()
         val supplementaryReadable = CompletableDeferred<Boolean>()
-        val seLinuxThrewSdbus = CompletableDeferred<Boolean>()
+        val seLinuxDefiniteOutcome = CompletableDeferred<Boolean>()
 
         val obj = createObject(serverConnection, objectPath)
         serverConnection.startEventLoop()
@@ -65,10 +66,13 @@ class JvmCredentialsTest {
                 supplementaryReadable.complete(
                     runCatching { message.credsSupplementaryGids }.isSuccess
                 )
-                // SELinux context is unavailable over junixsocket — must raise the library's
-                // SdbusException specifically, not return a bogus value or some unrelated error.
-                seLinuxThrewSdbus.complete(
-                    runCatching { message.seLinuxContext }.exceptionOrNull() is SdbusException
+                // SELinux context is host-dependent: a label where SELinux is enforcing, or a
+                // thrown SdbusException where it is unavailable (e.g. the typical junixsocket/CI
+                // case, which reports AccessDenied). Either is a valid contract outcome; what must
+                // NOT happen is a leaked non-SdbusException. (Observed locally: AccessDenied.)
+                seLinuxDefiniteOutcome.complete(
+                    runCatching { message.seLinuxContext }
+                        .fold({ true }, { it is SdbusException })
                 )
             }
         }
@@ -86,7 +90,9 @@ class JvmCredentialsTest {
             assertEquals(expectedGid, withTimeout(2_000) { gidSeen.await() })
             assertEquals(expectedGid, withTimeout(2_000) { egidSeen.await() })
             assertTrue(withTimeout(2_000) { supplementaryReadable.await() })
-            assertTrue(withTimeout(2_000) { seLinuxThrewSdbus.await() })
+            // seLinuxContext yielded a label or the documented SdbusException — never a leaked
+            // unrelated exception type.
+            assertTrue(withTimeout(2_000) { seLinuxDefiniteOutcome.await() })
         } finally {
             signalRegistration.release()
             proxy.release()

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCredentialsTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCredentialsTest.kt
@@ -1,0 +1,100 @@
+package com.monkopedia.sdbus
+
+import com.sun.security.auth.module.UnixSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * External (real-bus) coverage for the sender-credential surface on [Message] over the JVM wire
+ * backend. The bus stamps the authoritative sender on an emitted signal and the receiver resolves
+ * the sender's credentials (filled from the local process for a same-process sender). The JVM
+ * backend resolves pid/uid/euid/gid/egid/supplementary-gids; only [Message.seLinuxContext] is
+ * unavailable over junixsocket and must throw the documented [SdbusException] (the native backend
+ * covers SELinux's happy path, where labelled, in CredentialsIntegrationTest).
+ */
+class JvmCredentialsTest {
+
+    private fun connectOrNull(connect: () -> Connection): Connection? = try {
+        connect()
+    } catch (e: Exception) {
+        null
+    }
+
+    @Test
+    fun receivedSignalResolvesSupportedCredentialsAndRejectsUnsupported() = runBlocking {
+        val suffix = "creds${System.nanoTime()}"
+        val service = ServiceName("com.monkopedia.sdbus.jvmcreds.$suffix")
+        val objectPath = ObjectPath("/com/monkopedia/sdbus/jvmcreds$suffix")
+        val interfaceName = InterfaceName("com.monkopedia.sdbus.jvmcreds.$suffix.Interface")
+        val signalName = SignalName("Ping")
+        val expectedPid = ProcessHandle.current().pid().toInt()
+        val unix = UnixSystem()
+        val expectedUid = unix.uid.toUInt()
+        val expectedGid = unix.gid.toUInt()
+
+        val serverConnection = connectOrNull { createSessionBusConnection(service) }
+            ?: return@runBlocking
+        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
+            serverConnection.release()
+            return@runBlocking
+        }
+
+        val pidSeen = CompletableDeferred<Int>()
+        val uidSeen = CompletableDeferred<UInt>()
+        val euidSeen = CompletableDeferred<UInt>()
+        val gidSeen = CompletableDeferred<UInt>()
+        val egidSeen = CompletableDeferred<UInt>()
+        val supplementaryReadable = CompletableDeferred<Boolean>()
+        val seLinuxThrewSdbus = CompletableDeferred<Boolean>()
+
+        val obj = createObject(serverConnection, objectPath)
+        serverConnection.startEventLoop()
+        proxyConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, service, objectPath)
+        val signalRegistration = proxy.registerSignalHandler(interfaceName, signalName) { message ->
+            if (!pidSeen.isCompleted) {
+                pidSeen.complete(message.credsPid)
+                uidSeen.complete(message.credsUid)
+                euidSeen.complete(message.credsEuid)
+                gidSeen.complete(message.credsGid)
+                egidSeen.complete(message.credsEgid)
+                supplementaryReadable.complete(
+                    runCatching { message.credsSupplementaryGids }.isSuccess
+                )
+                // SELinux context is unavailable over junixsocket — must raise the library's
+                // SdbusException specifically, not return a bogus value or some unrelated error.
+                seLinuxThrewSdbus.complete(
+                    runCatching { message.seLinuxContext }.exceptionOrNull() is SdbusException
+                )
+            }
+        }
+
+        try {
+            val signal = obj.createSignal(interfaceName, signalName)
+            signal.append(1)
+            signal.send()
+
+            // Resolved to this same process. euid/egid equal the real uid/gid for a non-setuid
+            // process, which the test runner is.
+            assertEquals(expectedPid, withTimeout(2_000) { pidSeen.await() })
+            assertEquals(expectedUid, withTimeout(2_000) { uidSeen.await() })
+            assertEquals(expectedUid, withTimeout(2_000) { euidSeen.await() })
+            assertEquals(expectedGid, withTimeout(2_000) { gidSeen.await() })
+            assertEquals(expectedGid, withTimeout(2_000) { egidSeen.await() })
+            assertTrue(withTimeout(2_000) { supplementaryReadable.await() })
+            assertTrue(withTimeout(2_000) { seLinuxThrewSdbus.await() })
+        } finally {
+            signalRegistration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.stopEventLoop()
+            serverConnection.stopEventLoop()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+}

--- a/src/nativeTest/kotlin/integration/CredentialsIntegrationTest.kt
+++ b/src/nativeTest/kotlin/integration/CredentialsIntegrationTest.kt
@@ -1,0 +1,112 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.SdbusException
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.method
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.runBlocking
+import platform.posix.getegid
+import platform.posix.geteuid
+import platform.posix.getgid
+import platform.posix.getpid
+import platform.posix.getuid
+
+/**
+ * External (real-bus) coverage for the sender-credential surface on [com.monkopedia.sdbus.Message]
+ * (`credsPid`/`credsUid`/`credsEuid`/`credsGid`/`credsEgid`/`credsSupplementaryGids`/
+ * `seLinuxContext`), read from inside a served method handler via
+ * [com.monkopedia.sdbus.Object.currentlyProcessedMessage]. The caller is a second connection in
+ * this same process, so sd-bus resolves the credentials to this process and they can be checked
+ * against the live POSIX identity. Native-only: euid/egid/SELinux are not implemented on the JVM
+ * backend (covered there by JvmCredentialsTest).
+ */
+class CredentialsIntegrationTest {
+
+    private class CapturedCredentials {
+        var pid: Int? = null
+        var uid: UInt? = null
+        var euid: UInt? = null
+        var gid: UInt? = null
+        var egid: UInt? = null
+        var supplementaryGidsReadable: Boolean = false
+
+        // sd_bus_creds_get_selinux_context fails (throws) on a host without SELinux labelling, and
+        // succeeds with a non-empty label where SELinux is active. Both are valid contract outcomes.
+        var seLinuxReadOutcome: Boolean? = null
+    }
+
+    @Test
+    fun servedMethodSeesCallerCredentials() {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.creds$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/creds$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.creds$id.Interface")
+        val methodName = MethodName("Whoami")
+        val captured = CapturedCredentials()
+
+        val serverConnection = createBusConnection(service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, path)
+        val registration = obj.addVTable(iface) {
+            method(methodName) {
+                call { token: Int ->
+                    val message = obj.currentlyProcessedMessage
+                    captured.pid = message.credsPid
+                    captured.uid = message.credsUid
+                    captured.euid = message.credsEuid
+                    captured.gid = message.credsGid
+                    captured.egid = message.credsEgid
+                    captured.supplementaryGidsReadable = runCatching {
+                        message.credsSupplementaryGids
+                    }.isSuccess
+                    captured.seLinuxReadOutcome = try {
+                        message.seLinuxContext.isNotEmpty()
+                    } catch (e: SdbusException) {
+                        // No SELinux labelling on this host — the call path still executed.
+                        false
+                    }
+                    token
+                }
+            }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, service, path, runEventLoopThread = false)
+
+        try {
+            assertEquals(7, proxy.callMethod<Int>(iface, methodName) { call(7) })
+
+            // The caller is this process (a second bus connection), so the bus-resolved
+            // credentials must match the live POSIX identity.
+            assertEquals(getpid(), captured.pid)
+            assertEquals(getuid(), captured.uid)
+            assertEquals(geteuid(), captured.euid)
+            assertEquals(getgid(), captured.gid)
+            assertEquals(getegid(), captured.egid)
+            // Supplementary GIDs may be an empty list, but the accessor must succeed.
+            assertTrue(captured.supplementaryGidsReadable)
+            // seLinuxContext must have produced a definite outcome (value or documented throw).
+            assertTrue(captured.seLinuxReadOutcome != null)
+        } finally {
+            runBlocking { serverConnection.stopEventLoop() }
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+}


### PR DESCRIPTION
## What

Second of two PRs lifting external-integration API coverage into the 90s. Adds caller-credential coverage over a real bus — the one genuinely-uncovered, integration-only surface (credentials require a live peer; they can't be unit-tested):

- **`CredentialsIntegrationTest`** (nativeTest): a served method reads `Object.currentlyProcessedMessage` and checks all **seven** members — `credsPid/Uid/Euid/Gid/Egid/SupplementaryGids/seLinuxContext` — against the live POSIX identity (`getpid`/`getuid`/`geteuid`/`getgid`/`getegid`). `seLinuxContext` accepts either a label or the documented throw on a host without SELinux labelling.
- **`JvmCredentialsTest`** (jvmTest): reads creds off a received signal. The JVM backend yields pid/uid/euid/gid/egid/supplementary-gids as correct non-throwing values; `seLinuxContext` is host-dependent (a label under SELinux, else `SdbusException` — observed `AccessDenied` locally). Both outcomes accepted; only a leaked non-`SdbusException` fails.

## Verified contract (empirically, via a throwaway probe)

`pid/uid/euid/gid/egid` all resolve to the running process on both backends; `euid==uid`/`egid==egid` for a non-setuid process; supplementary GIDs are readable; `seLinuxContext` is the only host-dependent member. (An earlier draft over-claimed euid/egid as "unsupported on JVM" — corrected.)

## Verification

Both backends green under `dbus-run-session`, stable across reruns:
- `:linuxX64Test` `CredentialsIntegrationTest` — 1 passed
- `:jvmTest` `JvmCredentialsTest` — 1 passed (×3 reruns)
- `ktlintCheck` + `apiCheck` green (test-only, no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)