### PR TITLE
fix(jvm): unicast-route directed signals (Signal.setDestination)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.kt
@@ -5,12 +5,11 @@ package com.monkopedia.sdbus.integration
  * via [com.monkopedia.sdbus.Signal.setDestination] — only to the targeted peer, and re-exposes the
  * destination header to the receiving handler.
  *
- * - **native (sd-bus): `true`** — the bus routes the signal to the destination alone and the
- *   recipient sees the `DESTINATION` header.
- * - **JVM wire backend: `false`** — KNOWN LIMITATION: `setDestination` is accepted but the signal
- *   is still delivered to every matching subscriber (broadcast), and the inbound handler does not
- *   see the destination header. Tracked as a backend follow-up; flip this to `true` when the JVM
- *   backend honors unicast signal routing, at which point
- *   [ExternalApiCoverageTest.directedSignal_isDeliveredOnlyToTargetedProxy] will enforce it.
+ * Both backends are `true` as of #137: native (sd-bus) always did, and the JVM wire backend now
+ * threads the destination onto the outgoing wire message so the daemon unicast-routes it and the
+ * recipient sees the `DESTINATION` header. The flag is retained so
+ * [ExternalApiCoverageTest.directedSignal_isDeliveredOnlyToTargetedProxy] keeps a per-backend lever
+ * (any backend that regressed to broadcast would flip its actual to `false` rather than silently
+ * weaken the assertion).
  */
 internal expect val backendDeliversDirectedSignalsUnicast: Boolean

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -107,9 +107,10 @@ internal class WireDbusBackend : JvmDbusBackend {
         // way a receiver can resolve our sender credentials off the bus.
         val wire = ((connection as? JvmConnection)?.backend as? WireDbusConnection)?.wireConnection
             ?: throw createError(-1, "createObject failed: connection has no wire transport")
-        val emitter = WireSignalEmitter { path, interfaceName, member, signature, payload ->
-            emitWireSignal(wire, path, interfaceName, member, signature, payload)
-        }
+        val emitter =
+            WireSignalEmitter { path, interfaceName, member, signature, payload, destination ->
+                emitWireSignal(wire, path, interfaceName, member, signature, payload, destination)
+            }
         return WireDbusObject(
             objectPath,
             runCatching { connection.uniqueName.value }.getOrNull(),
@@ -120,9 +121,11 @@ internal class WireDbusBackend : JvmDbusBackend {
 
 /**
  * Marshals [payload] (converted from the high-level value model via [toWireBodyValue]) against
- * [signature] and sends it as a broadcast D-Bus SIGNAL on [wire]. The SENDER header is left unset:
- * the bus daemon stamps the authoritative sender (our unique name) and attaches our credentials.
- * An empty/blank signature means a no-argument signal (no body).
+ * [signature] and sends it as a D-Bus SIGNAL on [wire]. The SENDER header is left unset: the bus
+ * daemon stamps the authoritative sender (our unique name) and attaches our credentials. An
+ * empty/blank signature means a no-argument signal (no body). When [destination] is non-null the
+ * signal is unicast to that bus name (the daemon routes it to that peer alone, and the recipient
+ * sees it as [Message.destination]); null leaves it a broadcast.
  */
 private fun emitWireSignal(
     wire: DBusWireConnection,
@@ -130,7 +133,8 @@ private fun emitWireSignal(
     interfaceName: String,
     member: String,
     signature: String?,
-    payload: List<Any?>
+    payload: List<Any?>,
+    destination: String?
 ) {
     val effectiveSignature = signature?.takeUnless { it.isEmpty() }
     val body = if (effectiveSignature == null) emptyList() else payload.map(::toWireBodyValue)
@@ -141,6 +145,7 @@ private fun emitWireSignal(
                 path = path,
                 interfaceName = interfaceName,
                 member = member,
+                destination = destination?.takeUnless { it.isEmpty() },
                 signature = effectiveSignature,
                 body = body
             )

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
@@ -37,7 +37,8 @@ internal fun interface WireSignalEmitter {
         interfaceName: String,
         member: String,
         signature: String?,
-        payload: List<Any?>
+        payload: List<Any?>,
+        destination: String?
     )
 }
 
@@ -260,7 +261,9 @@ internal class WireDbusObject(
             interfaceName = propertiesInterfaceName,
             member = propertiesChangedMemberName,
             signature = propertiesChangedSignature,
-            payload = payload
+            payload = payload,
+            // Standard-interface notification: always broadcast.
+            destination = null
         )
     }
 
@@ -283,7 +286,8 @@ internal class WireDbusObject(
             interfaceName = objectManagerInterfaceName,
             member = interfacesAddedMemberName,
             signature = interfacesAddedSignature,
-            payload = payload
+            payload = payload,
+            destination = null
         )
     }
 
@@ -299,7 +303,8 @@ internal class WireDbusObject(
             interfaceName = objectManagerInterfaceName,
             member = interfacesRemovedMemberName,
             signature = interfacesRemovedSignature,
-            payload = payload
+            payload = payload,
+            destination = null
         )
     }
 
@@ -454,7 +459,9 @@ internal class WireDbusObject(
             interfaceName = interfaceName,
             member = signalName,
             signature = signature,
-            payload = message.payload
+            payload = message.payload,
+            // Honor a unicast destination set via Signal.setDestination; null = broadcast.
+            destination = message.destination?.value
         )
     }
 

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
@@ -1,5 +1,5 @@
 package com.monkopedia.sdbus.integration
 
-// KNOWN LIMITATION: the JVM wire backend accepts setDestination but still broadcasts the signal to
-// all matching subscribers and does not re-expose the destination header. See the expect docs.
-internal actual val backendDeliversDirectedSignalsUnicast: Boolean = false
+// The JVM wire backend now threads Signal.setDestination onto the outgoing wire message, so the
+// daemon unicast-routes the directed signal and the recipient sees the destination header (#137).
+internal actual val backendDeliversDirectedSignalsUnicast: Boolean = true


### PR DESCRIPTION
Fixes #137.

## Root cause

The JVM wire backend accepted `Signal.setDestination` but **dropped the destination before the wire**: `emitWireSignal` (WireDbusBackend.kt) built a `SIGNAL` `WireMessage` with no `DESTINATION` header, so the daemon broadcast it to every matching subscriber and the recipient saw a null `Message.destination`. Native (sd-bus) routes the signal to the targeted peer alone and exposes the header — the two backends diverged.

## Fix

Thread the destination through the emit path (the inbound side already copied `wireMessage.destination` into the message metadata, so the receive half needed no change):

- `WireSignalEmitter.emitSignalOverWire` gains a `destination` parameter.
- `WireDbusObject.emitSignal` passes `message.destination?.value`. The standard-interface notifications (`PropertiesChanged`/`InterfacesAdded`/`InterfacesRemoved`) pass `null` — they stay broadcast.
- `emitWireSignal` sets it on the outgoing `WireMessage` (which already encodes the `DESTINATION` header), so the daemon unicast-routes it. The recipient then sees `Message.destination` for free.

## Verification

Flips `backendDeliversDirectedSignalsUnicast` (jvm) → `true`, so the existing two-proxy regression guard `directedSignal_isDeliveredOnlyToTargetedProxy` (added in #134) now **enforces** unicast delivery + the destination header on **both** backends — the test that previously documented the limitation now proves the fix.

Under `dbus-run-session`:
- full `:jvmTest` — **310 tests, 0 failures** (no regression from the wire-protocol change)
- native `ExternalApiCoverageTest` (6) + `CommonApiIntegrationTest` (34) green
- `ktlintCheck` + `apiCheck` green (no public API change — `WireSignalEmitter` is internal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)