### PR TITLE
fix: valid cross-backend error name for raw handler exceptions (#141)

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Error.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Error.kt
@@ -40,8 +40,14 @@ package com.monkopedia.sdbus
 class SdbusException(val name: String, val errorMessage: String = "") :
     Exception("$name: $errorMessage")
 
-internal fun Throwable.toError() =
-    (this as? SdbusException) ?: SdbusException(message ?: toString(), stackTraceToString())
+// The generic D-Bus error name for a failure with no more specific name. A non-SdbusException from
+// a handler maps to this VALID name so both backends report it identically; the former behavior put
+// the exception message in the name slot, producing an invalid name — native then failed to send a
+// proper error reply (client saw NoReply) while JVM passed the bogus name through. See #141.
+internal const val GENERIC_DBUS_ERROR_NAME = "org.freedesktop.DBus.Error.Failed"
+
+internal fun Throwable.toError(): SdbusException =
+    (this as? SdbusException) ?: SdbusException(GENERIC_DBUS_ERROR_NAME, message ?: toString())
 
 /**
  * Creates an [SdbusException] from a numeric error code and a custom message.

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -55,6 +55,10 @@ class FailurePathParityTest {
         )
     }
 
+    // Always true; indirection keeps the throwing handler's inferred return type Int (a bare
+    // `throw` would infer Nothing, which has no serializer at vtable registration).
+    private val alwaysThrows = true
+
     // --- method-call timeout ---------------------------------------------------------------
 
     // A server method that deliberately sleeps far past the client's per-call timeout must
@@ -246,6 +250,39 @@ class FailurePathParityTest {
                 }
             }
             assertTrue(thrown.name.isNotBlank(), "error should carry a name")
+        } finally {
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
+    // A handler that throws a plain (non-SdbusException) exception must surface the SAME, valid
+    // D-Bus error name on both backends. Regression for the parity sweep (#141): toError() used to
+    // put the exception's *message* in the error-name slot ("boom"), which is not a valid D-Bus
+    // name — native then failed to send a proper error (client saw NoReply) while JVM passed the
+    // bogus name through. Both must now report org.freedesktop.DBus.Error.Failed.
+    @Test
+    fun handlerThrowingRawException_reportsFailedErrorNameOnBothBackends() = runBlocking {
+        val ids = uniqueFixtureIds("rawThrow")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("Boom")) {
+                call { _: Int -> if (alwaysThrows) throw RuntimeException("boom") else 0 }
+            }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path)
+
+        try {
+            val thrown = assertFailsWith<SdbusException> {
+                proxy.callMethod<Int>(ids.iface, MethodName("Boom")) { call(1) }
+            }
+            assertEquals("org.freedesktop.DBus.Error.Failed", thrown.name)
         } finally {
             registration.release()
             proxy.release()


### PR DESCRIPTION
First PR of the pre-1.0 parity-hardening wave (#141). Empirically-confirmed divergence.

## Problem

A handler throwing a non-`SdbusException` went through `Throwable.toError()`, which put the exception **message** in the error-**name** slot (`name="boom"`). That's not a valid D-Bus error name, so the backends diverged:
- **native** failed to send a proper error reply → client saw `org.freedesktop.DBus.Error.NoReply`
- **JVM** passed the bogus `"boom"` through as the name

Either way the documented `SdbusException.name` contract was wrong *and* backend-dependent.

## Fix

`toError()` maps a non-`SdbusException` to `org.freedesktop.DBus.Error.Failed` (the generic D-Bus failure name) with the exception message as the detail. commonMain, so both backends converge.

## Regression test (red-first)

`FailurePathParityTest.handlerThrowingRawException_reportsFailedErrorNameOnBothBackends` — runs on both targets, asserts `.name == org.freedesktop.DBus.Error.Failed`. Verified **red before** (native `NoReply` / JVM `boom`), **green after** on both.

## Verification
- Full `:jvmTest` + `:linuxX64Test` — **591 tests, 0 failures** (no regression from the commonMain change)
- `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)