### PR TITLE
fix(jvm): emit current property values in InterfacesAdded / no-arg PropertiesChanged (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/SignalPayloadParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/SignalPayloadParityTest.kt
@@ -1,0 +1,137 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectManagerProxy
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertiesProxy
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.onSignal
+import com.monkopedia.sdbus.prop
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Parity regression (#141): the ObjectManager `InterfacesAdded` payload and the no-argument
+ * `PropertiesChanged` signal must carry the object's CURRENT property values on both backends.
+ * Native (sd-bus) fills them via sd_bus_emit_*; the JVM wire backend used to emit empty property
+ * maps, so an ObjectManager consumer that reads initial device state from these signals (the
+ * standard BlueZ pattern) got nothing on JVM. Runs on both targets.
+ */
+class SignalPayloadParityTest {
+
+    private class Holder(var value: Int)
+
+    @Test
+    fun interfacesAddedCarriesCurrentPropertyValues() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.iap$id")
+        val managerPath = ObjectPath("/com/monkopedia/sdbus/iap$id")
+        val childPath = ObjectPath("/com/monkopedia/sdbus/iap$id/child")
+        val iface = InterfaceName("com.monkopedia.sdbus.iap$id.Iface")
+        val levelProp = PropertyName("Level")
+        val holder = Holder(42)
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val managerObj = createObject(server, managerPath)
+        val manager = managerObj.addObjectManager()
+        val obj = createObject(server, childPath)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+            prop(levelProp) { with(holder::value) }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, managerPath)
+
+        val seenLevel = CompletableDeferred<Int?>()
+        val sigReg = proxy.onSignal(
+            ObjectManagerProxy.INTERFACE_NAME,
+            SignalName("InterfacesAdded")
+        ) {
+            call { _: ObjectPath, ifaces: Map<InterfaceName, Map<PropertyName, Variant>> ->
+                if (!seenLevel.isCompleted) {
+                    seenLevel.complete(ifaces[iface]?.get(levelProp)?.get<Int>())
+                }
+            }
+        }
+
+        try {
+            obj.emitInterfacesAddedSignal(listOf(iface))
+            // The InterfacesAdded payload must report the property's current value, not an empty map.
+            assertEquals(42, withTimeout(2_000) { seenLevel.await() })
+        } finally {
+            sigReg.release()
+            reg.release()
+            manager.release()
+            managerObj.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+
+    @Test
+    fun noArgPropertiesChangedCarriesAllInterfaceProperties() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.pcall$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/pcall$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.pcall$id.Iface")
+        val levelProp = PropertyName("Level")
+        val holder = Holder(42)
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+            prop(levelProp) { with(holder::value) }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, path)
+
+        val seenLevel = CompletableDeferred<Int?>()
+        val sigReg = proxy.onSignal(
+            PropertiesProxy.INTERFACE_NAME,
+            SignalName("PropertiesChanged")
+        ) {
+            call { _: InterfaceName, changed: Map<PropertyName, Variant>, _: List<PropertyName> ->
+                if (!seenLevel.isCompleted) {
+                    seenLevel.complete(changed[levelProp]?.get<Int>())
+                }
+            }
+        }
+
+        try {
+            // No-argument form: native emits every property of the interface; JVM used to emit none.
+            obj.emitPropertiesChangedSignal(iface)
+            assertEquals(42, withTimeout(2_000) { seenLevel.await() })
+        } finally {
+            sigReg.release()
+            reg.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
@@ -268,7 +268,11 @@ internal class WireDbusObject(
     }
 
     override fun emitPropertiesChangedSignal(interfaceName: InterfaceName) {
-        emitPropertiesChangedSignal(interfaceName, emptyList())
+        // No-argument form mirrors sd_bus_emit_properties_changed_strv(..., names=null): emit ALL
+        // of the interface's properties (readable ones into changed_properties with their current
+        // value, write-only ones into invalidated_properties), not an empty payload.
+        val allProps = propertiesByInterface[interfaceName.value].orEmpty().keys.map(::PropertyName)
+        emitPropertiesChangedSignal(interfaceName, allProps)
     }
 
     override fun emitInterfacesAddedSignal() {
@@ -277,9 +281,12 @@ internal class WireDbusObject(
 
     override fun emitInterfacesAddedSignal(interfaces: List<InterfaceName>) {
         val signalPath = LocalObjectManagerRegistry.resolveFor(objectPath.value) ?: objectPath.value
+        // Each added interface must report its current property values (mirrors
+        // sd_bus_emit_interfaces_added), so an ObjectManager consumer reading initial state from
+        // this signal — the standard BlueZ pattern — sees them; previously this was an empty map.
         val payload = listOf(
             objectPath,
-            interfaces.associateWith { emptyMap<PropertyName, Variant>() }
+            interfaces.associateWith { snapshotInterfaceProperties(it.value) }
         )
         wireSignalEmitter.emitSignalOverWire(
             path = signalPath,


### PR DESCRIPTION
Parity-hardening wave (#141). **BlueZ-critical** — this is the one with a real consumer (blue-falcon).

## Problem

The JVM wire backend emitted **empty** property maps for:
- ObjectManager `InterfacesAdded` (`interfaces.associateWith { emptyMap() }`)
- the no-argument `emitPropertiesChangedSignal(interface)` (passed `emptyList()`)

Native (sd-bus) fills current values in both. An ObjectManager consumer that reads initial object/device state from these signals — the standard BlueZ pattern **blue-falcon** uses — got nothing on JVM.

## Fix (JVM only; native already correct)

- `emitInterfacesAddedSignal` serializes each interface's current property values via the existing `snapshotInterfaceProperties()` helper.
- no-arg `emitPropertiesChangedSignal(interface)` resolves **all** the interface's properties (readable → `changed` with value, write-only → `invalidated`), mirroring `sd_bus_emit_properties_changed_strv(..., names=null)`.

## Regression test (red-first)

`SignalPayloadParityTest` (both backends) decodes the signal payloads with typed handlers and asserts the property value arrives. **Red-first confirmed:** native 2/2 green, JVM 2/2 red (payload value `null`) before; green on both after.

## Verification
- `SignalPayloadParityTest` — 2/2 green on **both** backends under `dbus-run-session`
- Dbusmock ObjectManager/PropertiesChanged + `CommonApiIntegrationTest` suites unaffected
- `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)