### PR TITLE
fix(jvm): guard connection ops against use-after-release (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -292,6 +292,22 @@ class FailurePathParityTest {
         }
     }
 
+    // Every public connection operation must reject use after release() the same way on both
+    // backends. Native guards each with checkNotReleased() (an IllegalArgumentException); the JVM
+    // backend used to leave most ops unguarded (e.g. uniqueName silently returned a value). #141.
+    @Test
+    fun connectionOperationsAfterReleaseThrowOnBothBackends() = runBlocking {
+        val connection = createBusConnection()
+        connection.release()
+
+        assertFailsWith<IllegalArgumentException> { connection.uniqueName }
+        assertFailsWith<IllegalArgumentException> { connection.startEventLoop() }
+        assertFailsWith<IllegalArgumentException> {
+            connection.methodCallTimeout = 100.milliseconds
+        }
+        Unit
+    }
+
     // --- malformed / signature-mismatch handling -------------------------------------------
 
     // Calling a method with the wrong argument types (server expects an Int, client sends a

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -164,6 +164,12 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
     fun isReleased(): Boolean = released.get()
     fun defaultTimeoutMicros(): ULong = timeout.inWholeMicroseconds.coerceAtLeast(0L).toULong()
 
+    // Match the native backend (ConnectionImpl.checkNotReleased): every public connection op
+    // rejects use after release() with the SAME IllegalArgumentException, instead of silently
+    // succeeding (uniqueName / timeout) or throwing an unrelated closed-socket error. Parity #141.
+    private fun checkNotReleased() =
+        require(!released.get()) { "Connection has already been released" }
+
     init {
         LocalJvmServiceRegistry.registerLocalUniqueName(localUniqueName)
         // Serve incoming method calls (epic #93 phase 4 — closes #90): route every METHOD_CALL the
@@ -174,23 +180,35 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
         }
     }
 
-    override fun startEventLoop(): Unit = Unit
+    override fun startEventLoop() = checkNotReleased()
 
-    override suspend fun stopEventLoop(): Unit = Unit
+    override suspend fun stopEventLoop() = checkNotReleased()
 
     override fun currentlyProcessedMessage(): Message =
         JvmCurrentMessageContext.current() ?: createPlainMessage()
 
-    override fun setMethodCallTimeout(timeout: Duration): Unit = run { this.timeout = timeout }
+    override fun setMethodCallTimeout(timeout: Duration): Unit = run {
+        checkNotReleased()
+        this.timeout = timeout
+    }
 
-    override fun getMethodCallTimeout(): Duration = timeout
+    override fun getMethodCallTimeout(): Duration {
+        checkNotReleased()
+        return timeout
+    }
 
-    override fun addObjectManager(objectPath: ObjectPath): Resource =
-        LocalObjectManagerRegistry.register(objectPath.value, localUniqueName)
+    override fun addObjectManager(objectPath: ObjectPath): Resource {
+        checkNotReleased()
+        return LocalObjectManagerRegistry.register(objectPath.value, localUniqueName)
+    }
 
-    override fun uniqueName(): BusName = BusName(localUniqueName.ifEmpty { ":jvm-wire" })
+    override fun uniqueName(): BusName {
+        checkNotReleased()
+        return BusName(localUniqueName.ifEmpty { ":jvm-wire" })
+    }
 
     override fun requestName(name: ServiceName, flags: UInt): RequestNameReply {
+        checkNotReleased()
         val result = runCatching { wire.requestName(name.value, flags) }.getOrElse {
             throw createError(-1, "requestName failed: ${it.message}")
         }
@@ -206,14 +224,17 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
     }
 
     override fun releaseName(name: ServiceName) {
+        checkNotReleased()
         runCatching { wire.releaseName(name.value) }.getOrElse {
             throw createError(-1, "releaseName failed: ${it.message}")
         }
         LocalJvmServiceRegistry.removeAlias(localUniqueName, name.value)
     }
 
-    override fun addMatch(match: String, callback: MessageHandler): Resource =
-        installSignalMatch(wire, match, parseMatchSpec(match), callback)
+    override fun addMatch(match: String, callback: MessageHandler): Resource {
+        checkNotReleased()
+        return installSignalMatch(wire, match, parseMatchSpec(match), callback)
+    }
 
     override fun release() {
         if (!released.compareAndSet(false, true)) return


### PR DESCRIPTION
Parity-hardening wave (#141). Empirically-confirmed divergence (probe: JVM `uniqueName` after release returned `:1.2`; native threw `IllegalArgumentException`).

## Problem

`WireDbusConnection` set `released` but only `WireDbusProxy.callMethod` checked it. Connection ops (`uniqueName`, `startEventLoop`, `setMethodCallTimeout`, `getMethodCallTimeout`, `addObjectManager`, `requestName`, `releaseName`, `addMatch`) ran after `release()` — silently succeeding or throwing an unrelated closed-socket error. Native guards every op with `checkNotReleased()`.

## Fix

Adds a JVM `checkNotReleased()` that throws the **same** `IllegalArgumentException("Connection has already been released")` as native (`ConnectionImpl.checkNotReleased`), applied to each public op.

## Regression test

`FailurePathParityTest.connectionOperationsAfterReleaseThrowOnBothBackends` — asserts `uniqueName` / `startEventLoop` / `methodCallTimeout=` all throw `IllegalArgumentException` after release on **both** backends.

## Verification
- Full `:jvmTest` — **311 tests, 0 failures** (confirms no test relied on calling an op after release, e.g. `stopEventLoop` in teardown — teardown always stops *before* release)
- native `FailurePathParityTest` green; `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)