### PR TITLE
fix(jvm): proxy.release() tears down its signal handlers (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/ProxyLifecycleParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/ProxyLifecycleParityTest.kt
@@ -1,0 +1,89 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.onSignal
+import com.monkopedia.sdbus.signal
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Parity regression (#141): releasing a [com.monkopedia.sdbus.Proxy] must stop the signal handlers
+ * registered through it, on both backends. Native's ProxyImpl.release() tears down its floating
+ * signal slots; the JVM WireDbusProxy.release() was a no-op, so handlers kept firing (and leaked)
+ * after the proxy was released. Runs on both targets.
+ */
+class ProxyLifecycleParityTest {
+
+    @Test
+    fun proxyReleaseStopsSignalHandlers() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.prel$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/prel$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.prel$id.Iface")
+        val signalName = SignalName("Tick")
+        val fires = atomic(0)
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+            signal(signalName) { with<Int>("v") }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, path)
+
+        // Register a handler but intentionally KEEP NO reference to the returned resource — so this
+        // asserts that proxy.release() ALONE stops delivery, not an explicit handler release.
+        proxy.onSignal(iface, signalName) {
+            call { _: Int -> fires.incrementAndGet() }
+        }
+
+        try {
+            // 1) Prove the pipe works: emit until the handler is observed to fire.
+            var emitted = 0
+            while (fires.value == 0 && emitted < 50) {
+                obj.emitSignal(iface, signalName) { call(1) }
+                emitted++
+                if (fires.value == 0) delay(20)
+            }
+            assertTrue(fires.value >= 1, "handler should fire before release")
+
+            // 2) Release the proxy and keep emitting; native stops delivery, JVM used to keep firing.
+            val countAtRelease = fires.value
+            proxy.release()
+            repeat(10) {
+                obj.emitSignal(iface, signalName) { call(1) }
+                delay(30)
+            }
+            assertEquals(
+                countAtRelease,
+                fires.value,
+                "no signal must be delivered to a released proxy's handler"
+            )
+        } finally {
+            reg.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -26,6 +26,7 @@ import com.monkopedia.sdbus.createPlainMessage
 import com.monkopedia.sdbus.methodReplyFrom
 import com.monkopedia.sdbus.signalFromMetadata
 import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 import kotlin.time.Duration
@@ -249,6 +250,9 @@ internal class WireDbusProxy(
     private val objectPath: ObjectPath
 ) : JvmDbusProxy {
     private val wire: DBusWireConnection? get() = connection?.wireConnection
+
+    // Signal handlers registered through this proxy, released together on release() (native parity).
+    private val signalRegistrations = CopyOnWriteArrayList<Resource>()
 
     override fun currentlyProcessedMessage(): Message =
         JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
@@ -557,12 +561,23 @@ internal class WireDbusProxy(
             resolvedOwner = owner
         )
         val rule = buildMatchRule(spec)
-        return installSignalMatch(realWire, rule, spec) { message ->
+        val registration = installSignalMatch(realWire, rule, spec) { message ->
             signalHandler(message as com.monkopedia.sdbus.Signal)
+        }
+        signalRegistrations.add(registration)
+        // Parity with native ProxyImpl.release(): releasing the proxy tears down its signal
+        // handlers. Wrap so an explicit release() also removes it from the proxy's set; both the
+        // wrapper and the underlying resource are idempotent, so double-release is safe. #141.
+        return com.monkopedia.sdbus.ActionResource {
+            signalRegistrations.remove(registration)
+            registration.release()
         }
     }
 
-    override fun release(): Unit = Unit
+    override fun release() {
+        signalRegistrations.forEach { runCatching { it.release() } }
+        signalRegistrations.clear()
+    }
 }
 
 /** A parsed signal match used to filter incoming SIGNAL messages on the connection. */


### PR DESCRIPTION
Parity-hardening wave (#141). Red-first confirmed divergence.

## Problem

Native `ProxyImpl.release()` releases the proxy's floating signal slots → handlers stop firing. JVM `WireDbusProxy.release()` was a **no-op**: `registerSignalHandler` returned an independent resource the proxy never collected, so after `proxy.release()` handlers kept firing (and leaked).

## Fix

`WireDbusProxy` collects each signal registration and releases them all on `release()`. `registerSignalHandler` returns a wrapper that also removes the entry on an explicit release; both the wrapper and the underlying `ActionResource` are idempotent (double-release safe). Registrations held in a `CopyOnWriteArrayList` (register/release happen on user threads).

## Regression test

`ProxyLifecycleParityTest.proxyReleaseStopsSignalHandlers` — registers a handler (keeping **no** reference to its resource), proves it fires, then `proxy.release()` and keeps emitting, asserting no further delivery. **Red-first:** native green / JVM red (kept firing at `expected 1, was >1`) before; green on both after.

## Verification
- test 1/1 green on **both** backends
- clean full `:jvmTest` (`--rerun-tasks`) — **315 tests, 0 failures**
- `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)