### PR TITLE
fix(jvm): wrong argument count -> InvalidArgs, not UnknownMethod (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -342,6 +342,49 @@ class FailurePathParityTest {
         }
     }
 
+    // A call to an existing member with the WRONG NUMBER of arguments must surface as InvalidArgs
+    // on both backends (native dispatches by member name and fails arg deserialization → InvalidArgs;
+    // the JVM backend used to key dispatch on arg count and return UnknownMethod). A truly-absent
+    // member must still be UnknownMethod. Parity #141.
+    @Test
+    fun wrongArgumentCountIsInvalidArgsWhileMissingMemberIsUnknownMethod() = runBlocking {
+        val ids = uniqueFixtureIds("argCount")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("WantsInt")) { call { value: Int -> value } }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path, runEventLoopThread = false)
+
+        try {
+            val tooMany = assertFailsWith<SdbusException> {
+                val call = proxy.createMethodCall(ids.iface, MethodName("WantsInt"))
+                call.append(1)
+                call.append(2)
+                proxy.callMethod(call)
+            }
+            assertEquals("org.freedesktop.DBus.Error.InvalidArgs", tooMany.name)
+
+            val tooFew = assertFailsWith<SdbusException> {
+                proxy.callMethod(proxy.createMethodCall(ids.iface, MethodName("WantsInt")))
+            }
+            assertEquals("org.freedesktop.DBus.Error.InvalidArgs", tooFew.name)
+
+            val missing = assertFailsWith<SdbusException> {
+                proxy.callMethod<Int>(ids.iface, MethodName("NoSuchMethod")) { call(1) }
+            }
+            assertEquals("org.freedesktop.DBus.Error.UnknownMethod", missing.name)
+        } finally {
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
     // --- connection teardown behavior ------------------------------------------------------
 
     // Tearing down a live proxy connection (stopEventLoop + release) after a successful call

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmStaticDispatch.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmStaticDispatch.kt
@@ -57,6 +57,22 @@ internal object JvmStaticDispatch {
         destination = destination
     )?.invoke(args)
 
+    // True if a member of this name is registered for the path/interface at ANY argument count
+    // reachable from [destination]. Used to distinguish a wrong-argument-COUNT call (member exists,
+    // no handler for this arity → InvalidArgs, matching native) from a truly-missing member
+    // (→ UnknownMethod). #141.
+    fun hasMember(
+        objectPath: String,
+        interfaceName: String,
+        methodName: String,
+        destination: String? = null
+    ): Boolean = handlers.keys.any { key ->
+        key.objectPath == objectPath &&
+            key.interfaceName == interfaceName &&
+            key.methodName == methodName &&
+            (destination.isNullOrEmpty() || key.destination == destination || key.destination == "")
+    }
+
     fun hasHandler(
         objectPath: String,
         interfaceName: String,

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -315,13 +315,18 @@ internal class WireDbusProxy(
             }
         }
         if (localOwner != null) {
-            // The destination is one of our own connections but nothing serves this member.
-            // We must NOT put the call on the wire: phase 3 does not serve incoming wire calls
-            // (phase 4), so our own peer would never reply and the caller would hang until
-            // timeout. Fail fast with UnknownMethod, the same outcome dbus-java produces by
-            // auto-replying for an unexported member.
+            // The destination is one of our own connections but no handler matched. We must NOT put
+            // the call on the wire (our own peer would never reply and the caller would hang).
+            // Distinguish a wrong-argument-COUNT call (the member exists at another arity → native
+            // returns InvalidArgs) from a truly-missing member (→ UnknownMethod). #141.
+            val memberExists =
+                JvmStaticDispatch.hasMember(path, interfaceName, methodName, dispatchDestination)
             throw com.monkopedia.sdbus.SdbusException(
-                "org.freedesktop.DBus.Error.UnknownMethod",
+                if (memberExists) {
+                    "org.freedesktop.DBus.Error.InvalidArgs"
+                } else {
+                    "org.freedesktop.DBus.Error.UnknownMethod"
+                },
                 "No handler for $path:$interfaceName.$methodName on local destination " +
                     destination.value
             )

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
@@ -58,6 +58,7 @@ internal object WireServe {
     private const val ERROR_UNKNOWN_OBJECT = "org.freedesktop.DBus.Error.UnknownObject"
     private const val ERROR_UNKNOWN_INTERFACE = "org.freedesktop.DBus.Error.UnknownInterface"
     private const val ERROR_UNKNOWN_METHOD = "org.freedesktop.DBus.Error.UnknownMethod"
+    private const val ERROR_INVALID_ARGS = "org.freedesktop.DBus.Error.InvalidArgs"
     private const val ERROR_FAILED = "org.freedesktop.DBus.Error.Failed"
 
     private val standardInterfaces = setOf(
@@ -222,6 +223,10 @@ internal object WireServe {
             !servesPath -> errorReply(message, ERROR_UNKNOWN_OBJECT, "Unknown object $path")
             iface != null && iface !in standardInterfaces && iface !in interfaces.keys ->
                 errorReply(message, ERROR_UNKNOWN_INTERFACE, "Unknown interface $iface on $path")
+            // The member exists at another argument count → a wrong-arg-COUNT call, which native
+            // reports as InvalidArgs (not UnknownMethod). #141.
+            iface != null && JvmStaticDispatch.hasMember(path, iface, member, localUniqueName) ->
+                errorReply(message, ERROR_INVALID_ARGS, "Invalid arguments to $iface.$member")
             else -> errorReply(
                 message,
                 ERROR_UNKNOWN_METHOD,


### PR DESCRIPTION
Parity-hardening wave (#141), 5 of 6. Empirically-confirmed target: native returns `InvalidArgs` for wrong-arg-count, `UnknownMethod` only for a missing member; JVM returned `UnknownMethod` for both.

## Problem

JVM `JvmStaticDispatch.MethodKey` includes `argCount`, so a call to an existing member with the wrong number of arguments misses the handler and is classified `UnknownMethod` (both the local-dispatch and wire-serve paths). Native dispatches by name → deserialization fails → `InvalidArgs`.

## Fix

- `JvmStaticDispatch.hasMember(path, iface, method, destination)` — argCount-agnostic lookup.
- Both classification sites (`WireDbusBackend` local-miss, `WireServe.classifyMissing`) now return `InvalidArgs` when the member exists at another arity, `UnknownMethod` only for a truly-absent member.

## Regression test

`FailurePathParityTest.wrongArgumentCountIsInvalidArgsWhileMissingMemberIsUnknownMethod` — too-many / too-few args → `InvalidArgs`; missing member → `UnknownMethod`; asserted on **both** backends. (Target confirmed via a throwaway probe: native `InvalidArgs`, JVM `UnknownMethod` before.)

## Verification
- clean full `:jvmTest` (`--rerun-tasks`) — **316 tests, 0 failures**
- `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)