### PR TITLE
fix(jvm): serve Peer/Introspectable for same-process callers (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/StandardInterfaceParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/StandardInterfaceParityTest.kt
@@ -1,0 +1,70 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PeerProxy
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.method
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Parity regression (#141): the standard interfaces org.freedesktop.DBus.Peer (Ping / GetMachineId)
+ * and org.freedesktop.DBus.Introspectable (Introspect) must be answered for a SAME-PROCESS peer on
+ * both backends. Native serves them via sd-bus regardless of same- vs cross-process; the JVM backend
+ * served them on the incoming-wire path but the same-process local short-circuit threw UnknownMethod.
+ * Runs on both targets.
+ */
+class StandardInterfaceParityTest {
+
+    @Test
+    fun sameProcessPeerAndIntrospectAreServed() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.std$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/std$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.std$id.Iface")
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+        }
+        server.startEventLoop()
+        val proxy = createProxy(client, service, path, runEventLoopThread = false)
+
+        try {
+            // Peer.Ping: must not throw (native answers directly; JVM used to 404 same-process).
+            PeerProxy(proxy).ping()
+
+            // Peer.GetMachineId: a non-empty machine id.
+            val machineId = PeerProxy(proxy).getMachineId()
+            assertTrue(machineId.isNotEmpty(), "machine id should be non-empty")
+
+            // Introspectable.Introspect: XML that mentions the served interface.
+            val xml = proxy.callMethod<String>(
+                InterfaceName("org.freedesktop.DBus.Introspectable"),
+                MethodName("Introspect")
+            ) { }
+            assertTrue(
+                xml.contains(iface.value),
+                "introspection XML should list the served interface, got: ${xml.take(200)}"
+            )
+        } finally {
+            reg.release()
+            proxy.release()
+            obj.release()
+            runBlocking { server.stopEventLoop() }
+            client.release()
+            server.release()
+        }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -315,8 +315,25 @@ internal class WireDbusProxy(
             }
         }
         if (localOwner != null) {
-            // The destination is one of our own connections but no handler matched. We must NOT put
-            // the call on the wire (our own peer would never reply and the caller would hang).
+            // Peer / Introspectable are served on the incoming-wire path (WireServe) but are not
+            // registered in local dispatch. Route them over the wire so a same-process caller gets
+            // the same answer native serves via sd-bus, instead of a spurious UnknownMethod. The
+            // wire serve (phase 4) always replies, so this cannot hang. #141.
+            if (interfaceName == WireServe.PEER_INTERFACE ||
+                interfaceName == WireServe.INTROSPECTABLE_INTERFACE
+            ) {
+                val standardWire = wire
+                    ?: throw createError(-1, "callMethod failed: connection has no wire transport")
+                return callRemote(
+                    standardWire,
+                    interfaceName,
+                    methodName,
+                    path,
+                    message,
+                    effectiveTimeout
+                )
+            }
+            // Otherwise the destination is one of our own connections but no user handler matched.
             // Distinguish a wrong-argument-COUNT call (the member exists at another arity → native
             // returns InvalidArgs) from a truly-missing member (→ UnknownMethod). #141.
             val memberExists =


### PR DESCRIPTION
Parity-hardening wave (#141), **6 of 6 — the final fix**. Empirically-confirmed divergence (probe: native answers same-process Peer.Ping/Introspect; JVM threw UnknownMethod).

## Problem

`org.freedesktop.DBus.Peer` (Ping/GetMachineId) and `Introspectable` (Introspect) are served by `WireServe` on the incoming-wire path, but they aren't registered in local dispatch. So a **same-process** call — which short-circuits through `JvmStaticDispatch` — threw `UnknownMethod`, while native serves them via sd-bus regardless of same- vs cross-process. (`Properties`, the third standard interface, already worked same-process because it *is* registered in local dispatch.)

## Fix

When a same-process call targets Peer or Introspectable and no user handler matches, route it over the wire (`callRemote`) so `WireServe.servePeer`/`serveIntrospect` answers it — **reusing the exact cross-process serving path** rather than duplicating the Ping/machine-id/XML logic. The wire serve (phase 4) always replies, so it can't hang (the old "never reply" comment predates incoming-call serving). User-method misses keep the local `InvalidArgs`/`UnknownMethod` classification from #146 (the standard-interface branch is checked first).

## Regression test

`StandardInterfaceParityTest.sameProcessPeerAndIntrospectAreServed` — same-process `Peer.Ping` succeeds, `GetMachineId` non-empty, `Introspect` returns XML naming the served interface; on **both** backends. **Red-first:** native green, JVM `UnknownMethod` before; green on both after.

## Verification
- clean full `:jvmTest` (`--rerun-tasks`) — **317 tests, 0 failures**
- #146 arg-count classification still correct (re-verified)
- `ktlintCheck` + `apiCheck` green (no public API change)

Completes the pre-1.0 parity wave (#141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)