### PR TITLE
fix(jvm): make JvmStaticDispatch thread-safe (data race)

### DIFF
--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmStaticDispatch.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmStaticDispatch.kt
@@ -1,6 +1,7 @@
 package com.monkopedia.sdbus.internal.jvmdbus
 
 import com.monkopedia.sdbus.MethodReply
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * JVM-side static dispatch table for method calls.
@@ -20,7 +21,11 @@ internal object JvmStaticDispatch {
         val argCount: Int
     )
 
-    private val handlers = mutableMapOf<MethodKey, (List<Any?>) -> Any?>()
+    // Concurrent: mutated on user threads (addVTable/release) while dispatch reads run on
+    // serve-worker/reader/caller threads. ConcurrentHashMap gives atomic put/remove and
+    // weakly-consistent iteration (the resolve/hasMember scans), matching the synchronized
+    // wrapping the sibling registries use. #141.
+    private val handlers = ConcurrentHashMap<MethodKey, (List<Any?>) -> Any?>()
 
     fun register(
         objectPath: String,

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmStaticDispatchTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmStaticDispatchTest.kt
@@ -1,10 +1,61 @@
 package com.monkopedia.sdbus.internal.jvmdbus
 
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class JvmStaticDispatchTest {
+
+    // The dispatch table is mutated on user threads (addVTable/release) while dispatch reads
+    // (hasHandler/hasMember/invokeOrNull) run concurrently on serve-worker, reader and caller
+    // threads. With an unsynchronized map, register/unregister racing a resolve that iterates the
+    // key set throws ConcurrentModificationException (or returns a spurious null). This guards the
+    // fix. #141.
+    @Test
+    fun concurrentRegisterUnregisterAndResolveIsRaceFree() {
+        val threadCount = 8
+        val iterations = 4000
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val pool = Executors.newFixedThreadPool(threadCount)
+        val done = CountDownLatch(threadCount)
+        repeat(threadCount) { t ->
+            pool.execute {
+                try {
+                    repeat(iterations) { i ->
+                        val path = "/race/${(t * iterations + i) % 40}"
+                        if (i % 2 == 0) {
+                            JvmStaticDispatch.register(path, "org.race.I", "M", 1, "dest") { it }
+                            JvmStaticDispatch.hasMember(path, "org.race.I", "M", "dest")
+                            JvmStaticDispatch.invokeOrNull(
+                                path,
+                                "org.race.I",
+                                "M",
+                                listOf(1),
+                                "dest"
+                            )
+                            JvmStaticDispatch.unregister(path, "org.race.I", "M", 1, "dest")
+                        } else {
+                            JvmStaticDispatch.hasHandler(path, "org.race.I", "M", listOf(1), "dest")
+                            JvmStaticDispatch.hasMember(path, "org.race.I", "M", "dest")
+                        }
+                    }
+                } catch (e: Throwable) {
+                    errors.add(e)
+                } finally {
+                    done.countDown()
+                }
+            }
+        }
+        assertTrue(done.await(60, TimeUnit.SECONDS), "workers did not finish")
+        pool.shutdownNow()
+        assertTrue(errors.isEmpty(), "concurrent dispatch access threw: ${errors.firstOrNull()}")
+    }
+
     @Test
     fun invokeOrNull_returnsHandlerResultForRegisteredKey() {
         JvmStaticDispatch.register(


### PR DESCRIPTION
Pre-1.0 correctness fix (found by the fresh-pass audit; tracked on #141).

## Problem

`JvmStaticDispatch.handlers` was a plain `HashMap` — the **only** one of the five shared JVM registries left unsynchronized. It's mutated on user threads (`addVTable`/`release`) while dispatch reads (`hasHandler`/`hasMember`/`invokeOrNull`) run concurrently on serve-worker, reader, and caller threads. Exporting an object while another is being served can throw `ConcurrentModificationException` (the resolve/hasMember scans iterate the key set) or return a spurious `null` (a handler "vanishes" → misclassified `UnknownMethod`/`InvalidArgs`).

## Fix

`ConcurrentHashMap` — atomic put/remove, weakly-consistent iteration — matching the `synchronized` wrapping the sibling registries already use.

## Regression test

`JvmStaticDispatchTest.concurrentRegisterUnregisterAndResolveIsRaceFree` — 8 threads × 4000 iterations registering/unregistering while resolving. **Reliably reproduced the race: threw `ConcurrentModificationException` 3/3 runs before the fix, green 5/5 after.**

## Verification
- full `:jvmTest` — **318 tests, 0 failures**
- `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)