### PR TITLE
fix(jvm): honor dontExpectReply / fire-and-forget calls (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/NoReplyParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/NoReplyParityTest.kt
@@ -1,0 +1,80 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.method
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Parity regression (#141): a dontExpectReply (fire-and-forget) call must NOT wait for or require a
+ * reply and must NOT throw for a missing target, on both backends. Native does sd_bus_send with no
+ * reply; the JVM backend used to ignore the flag (wait up to 30s for a reply) and threw
+ * UnknownMethod for a missing member. Runs on both targets.
+ */
+class NoReplyParityTest {
+
+    @Test
+    fun dontExpectReplyDeliversWithoutWaitingOrThrowing() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.nr$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/nr$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.nr$id.Iface")
+        val hits = atomic(0)
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Bump")) {
+                call { _: Int ->
+                    hits.incrementAndGet()
+                    Unit
+                }
+            }
+        }
+        server.startEventLoop()
+        val proxy = createProxy(client, service, path)
+
+        try {
+            // 1) A no-reply call to an existing method delivers the side effect and returns promptly
+            // (must not block ~30s waiting for a reply).
+            withTimeout(5_000) {
+                proxy.callMethod<Unit>(iface, MethodName("Bump")) {
+                    call(1)
+                    dontExpectReply = true
+                }
+            }
+            withTimeout(2_000) { while (hits.value == 0) delay(20) }
+            assertTrue(hits.value >= 1, "no-reply call should still deliver the side effect")
+
+            // 2) A no-reply call to a MISSING member must not throw (native fire-and-forgets).
+            withTimeout(5_000) {
+                proxy.callMethod<Unit>(iface, MethodName("NoSuchMethod")) {
+                    call(1)
+                    dontExpectReply = true
+                }
+            }
+        } finally {
+            reg.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -293,6 +293,36 @@ internal class WireDbusProxy(
         // wildcard ("") and single-candidate registrations resolve exactly as dbus-java's do.
         val localOwner = localDispatchOwnerOrNull()
         val dispatchDestination = localOwner ?: destination.value
+
+        if (message.dontExpectReply) {
+            // Fire-and-forget parity with native sd_bus_send(no-reply): deliver the call for its
+            // side effects but never wait for or surface a reply, and never throw for a missing
+            // target. Previously the JVM client ignored the flag and blocked ~30s on callBlocking
+            // (and threw UnknownMethod for a missing member). #141.
+            runCatching {
+                val handled = JvmStaticDispatch.hasHandler(
+                    path,
+                    interfaceName,
+                    methodName,
+                    message.payload,
+                    dispatchDestination
+                )
+                when {
+                    handled -> callLocalDispatch(
+                        message,
+                        interfaceName,
+                        methodName,
+                        path,
+                        dispatchDestination
+                    )
+                    localOwner == null ->
+                        wire?.let { sendNoReply(it, interfaceName, methodName, path, message) }
+                    // A same-process member that doesn't exist: a no-reply caller sees nothing.
+                }
+            }
+            return emptyReply()
+        }
+
         if (JvmStaticDispatch.hasHandler(
                 path,
                 interfaceName,
@@ -453,6 +483,36 @@ internal class WireDbusProxy(
                 empty = values.isEmpty()
             ),
             values
+        )
+    }
+
+    // A valid, empty reply for a fire-and-forget (dontExpectReply) call, which never surfaces a
+    // real reply to the caller.
+    private fun emptyReply(): MethodReply =
+        methodReplyFrom(Message.Metadata(valid = true, empty = true), emptyList())
+
+    // Sends a METHOD_CALL over the wire with NO_REPLY_EXPECTED and does not wait for a reply
+    // (native sd_bus_send parity).
+    private fun sendNoReply(
+        realWire: DBusWireConnection,
+        interfaceName: String,
+        methodName: String,
+        path: String,
+        message: MethodCall
+    ) {
+        val payload = message.payload.toList()
+        val signature = wireBodySignature(payload, message.declaredBodySignature.toString())
+        realWire.send(
+            WireMessage(
+                type = WireMessageType.METHOD_CALL,
+                flags = WireMessageFlags.NO_REPLY_EXPECTED,
+                destination = destination.value.ifEmpty { null },
+                path = path,
+                interfaceName = interfaceName,
+                member = methodName,
+                signature = signature,
+                body = if (signature == null) emptyList() else payload.map(::toWireBodyValue)
+            )
         )
     }
 


### PR DESCRIPTION
Pre-1.0 correctness fix (fresh-pass audit; #141). One of the two consumer-facing items I'd missed in the first wave.

## Problem

The JVM client **ignored** `MethodCall.dontExpectReply`: it ran `callBlocking` and waited up to ~30s for a reply a no-reply peer won't send, and threw `UnknownMethod` for a no-reply call to a missing member. Native does `sd_bus_send` with no reply — deliver for side effects, never wait, never surface an error for a missing target.

## Fix

`WireDbusProxy.callMethod` short-circuits when `dontExpectReply` is set: run the local handler for side effects if one is registered, else send over the wire with `NO_REPLY_EXPECTED` and don't wait; a missing same-process member is silently dropped. Returns an empty reply.

## Regression test

`NoReplyParityTest` — a no-reply call delivers the handler side effect without blocking, and a no-reply call to a missing member does not throw; both backends. **Red-first:** native green, JVM threw `UnknownMethod` before; green on both after.

## Verification
- clean full `:jvmTest` — **319 tests, 0 failures**
- `ktlintCheck` + `apiCheck` green (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)