### PR TITLE
fix(jvm): resolve well-known sender= in Connection.addMatch (#141)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/AddMatchSenderParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/AddMatchSenderParityTest.kt
@@ -1,0 +1,77 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.signal
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Parity regression (#141): Connection.addMatch with a rule specifying a well-known sender= must
+ * receive matching signals on both backends. The daemon resolves the well-known name to its unique
+ * owner and delivers frames stamped with that unique name; the JVM backend's local re-filter used
+ * to compare the unique sender against the well-known name (never resolving the owner) and dropped
+ * every signal. Runs on both targets.
+ */
+class AddMatchSenderParityTest {
+
+    @Test
+    fun addMatchWithWellKnownSenderReceivesSignals() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.am$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/am$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.am$id.Iface")
+        val signalName = SignalName("Tick")
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+            signal(signalName) { with<Int>("v") }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+
+        val fired = CompletableDeferred<Unit>()
+        val rule = "type='signal',sender='${service.value}'," +
+            "interface='${iface.value}',member='${signalName.value}'"
+        val matchReg = client.addMatch(rule) {
+            if (!fired.isCompleted) fired.complete(Unit)
+        }
+
+        try {
+            var emitted = 0
+            while (!fired.isCompleted && emitted < 50) {
+                obj.emitSignal(iface, signalName) { call(1) }
+                emitted++
+                if (!fired.isCompleted) delay(20)
+            }
+            assertNotNull(
+                withTimeoutOrNull(2_000) { fired.await() },
+                "addMatch with a well-known sender= should deliver the matching signal"
+            )
+        } finally {
+            matchReg.release()
+            reg.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -234,7 +234,8 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
 
     override fun addMatch(match: String, callback: MessageHandler): Resource {
         checkNotReleased()
-        return installSignalMatch(wire, match, parseMatchSpec(match), callback)
+        val spec = parseMatchSpec(match).withResolvedOwner(wire)
+        return installSignalMatch(wire, match, spec, callback)
     }
 
     override fun release() {
@@ -670,6 +671,15 @@ private data class MatchSpec(
     val member: String? = null,
     val resolvedOwner: String? = null
 )
+
+// Resolve a well-known sender= to its current unique owner (like registerSignalHandler does), so
+// matches() can compare it against the daemon-stamped unique sender on incoming frames — otherwise
+// a match rule with a well-known sender drops every signal. #141.
+private fun MatchSpec.withResolvedOwner(wire: DBusWireConnection): MatchSpec {
+    val name = sender
+    if (name.isNullOrEmpty() || name.startsWith(":")) return this
+    return copy(resolvedOwner = runCatching { wire.getNameOwner(name) }.getOrNull())
+}
 
 private fun parseMatchSpec(match: String): MatchSpec {
     val values = mutableMapOf<String, String>()


### PR DESCRIPTION
Pre-1.0 correctness fix (fresh-pass audit; #141) — the last of the three. The second consumer-facing item I'd missed in the first wave.

## Problem

A `Connection.addMatch` rule with a well-known `sender=` **dropped every signal** on JVM: `parseMatchSpec` recorded the well-known name but never resolved its owner, so the local re-filter (`WireMessage.matches`) compared the daemon-stamped unique sender (`:1.x`) against the well-known name and rejected all frames. `registerSignalHandler` already resolves the owner; the low-level `addMatch` path didn't.

## Fix

`addMatch` resolves a well-known `sender=` to its current unique owner (`withResolvedOwner` → `getNameOwner`), mirroring `registerSignalHandler`, so `matches()` compares against the resolved owner. A unique-name (`:`) or absent sender is unchanged.

## Regression test

`AddMatchSenderParityTest` — `addMatch` with a rule naming a well-known `sender=` receives the matching signal, both backends. **Red-first:** native green, JVM dropped it (never fired) before; green on both after.

## Verification
- clean full `:jvmTest` — **320 tests, 0 failures**
- `ktlintCheck` + `apiCheck` green (no public API change)

Completes the fresh-pass correctness punch-list (with #148 JvmStaticDispatch race, #149 dontExpectReply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)