### PR TITLE
docs: prep 1.0.0 release (version bump + CHANGELOG + doc corrections)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to sdbus-kotlin are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-07-04
+
+1.0 **freezes the public API.** It removes the names deprecated in 0.6.0 and lands a wave of
+cross-backend behavioral parity fixes so the native (sd-bus) and JVM (junixsocket wire) backends
+agree on the consumer-facing surface. Every fix ships with a cross-backend regression test.
 
 ### Removed (breaking) — the 0.6.0 deprecations
-
-The symbols deprecated in 0.6.0 (kept as warnings that release) are now removed. This is the
-final freeze cleanup targeted at 1.0.
 
 - **The fluent property layer** — `AsyncPropertyGetter`, `AsyncPropertySetter`, `AllPropertiesGetter`,
   `AsyncAllPropertiesGetter`, and the single-argument `Proxy.getPropertyAsync(propertyName)` /
@@ -20,6 +21,39 @@ final freeze cleanup targeted at 1.0.
   `setPropertyAsync(interfaceName, propertyName, value)`, `getAllProperties(interfaceName)`,
   `getAllPropertiesAsync(interfaceName)`.
 - **`typealias Error`** — use `SdbusException` directly.
+
+### Fixed — cross-backend parity (JVM backend)
+
+- **Directed signals** now unicast-route on JVM; `Signal.setDestination` was broadcast. (#138)
+- **Error name**: a handler throwing a non-`SdbusException` now surfaces
+  `org.freedesktop.DBus.Error.Failed` on both backends — the JVM backend previously put the
+  exception message in the error-name slot, and native produced `NoReply`. This changes the
+  observable `SdbusException.name` for that case. (#142)
+- **ObjectManager `InterfacesAdded` and no-argument `PropertiesChanged`** now carry the object's
+  current property values on JVM (were emitted with empty maps). (#143)
+- **Use-after-release**: JVM connection operations now throw the same error as native after
+  `release()` instead of silently succeeding. (#144)
+- **`proxy.release()`** now tears down the proxy's signal handlers on JVM (was a no-op). (#145)
+- **Wrong argument count** → `org.freedesktop.DBus.Error.InvalidArgs` on JVM (was `UnknownMethod`);
+  a genuinely-missing member stays `UnknownMethod`. (#146)
+- **Same-process `Peer` (Ping/GetMachineId) and `Introspectable` (Introspect)** calls are now
+  served on JVM (the local short-circuit returned `UnknownMethod`). (#147)
+- **`JvmStaticDispatch`** dispatch table made thread-safe (data race between object
+  registration and concurrent dispatch). (#148)
+- **`dontExpectReply`** (fire-and-forget calls) honored on JVM — no ~30s wait for a reply, and no
+  error surfaced for a missing target. (#149)
+- **`Connection.addMatch`** with a well-known `sender=` now receives matching signals on JVM
+  (the local re-filter was dropping them). (#150)
+
+### Added
+
+- Serve-worker-pool saturation watchdog for non-compensated nested blocking. (#133)
+- Substantial external-integration test coverage of the 0.6.0 surface and the cross-backend
+  contracts, plus a coverage baseline at [`docs/TEST_COVERAGE.md`](docs/TEST_COVERAGE.md).
+  (#134–#136, #139)
+
+See [`docs/BACKENDS.md`](docs/BACKENDS.md) for the small set of same-process / direct-connection
+differences that remain documented rather than matched (none on the cross-process path).
 
 ## [0.6.0] - 2026-06-18
 
@@ -245,6 +279,8 @@ Platform-specific surface (#87, issue #82):
 - Add cross-runtime interop and stress test modules.
 - Codegen: package override support and stronger generation tests.
 
+[1.0.0]: https://github.com/Monkopedia/sdbus-kotlin/releases/tag/v1.0.0
+[0.6.0]: https://github.com/Monkopedia/sdbus-kotlin/releases/tag/v0.6.0
 [0.5.0]: https://github.com/Monkopedia/sdbus-kotlin/releases/tag/v0.5.0
 [0.4.5]: https://github.com/Monkopedia/sdbus-kotlin/releases/tag/v0.4.5
 [0.4.4]: https://github.com/Monkopedia/sdbus-kotlin/releases/tag/v0.4.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for agents working on sdbus-kotlin.
 
 ## What this is
 
-A Kotlin Multiplatform D-Bus client (a port of sdbus-c++), targeting **jvm + linuxX64 + linuxArm64**. The native targets wrap `sd-bus` via cinterop; the JVM target is backed by dbus-java. It also ships a code generator (`:codegen`, XML → Kotlin BlueZ proxies/adaptors) and a Gradle plugin (`:plugin`, id `com.monkopedia.sdbus.plugin`).
+A Kotlin Multiplatform D-Bus client (a port of sdbus-c++), targeting **jvm + linuxX64 + linuxArm64**. The native targets wrap `sd-bus` via cinterop; the JVM target is backed by an owned junixsocket connection with a pure-Kotlin marshaller and dispatcher (since 0.5.0 — no dbus-java, no native code). It also ships a code generator (`:codegen`, XML → Kotlin BlueZ proxies/adaptors) and a Gradle plugin (`:plugin`, id `com.monkopedia.sdbus.plugin`).
 
 Modules: root (the library), `:codegen`, `:plugin`, `:cross_test`, `:stress_test`, `samples/bluez-scan`.
 
@@ -18,7 +18,7 @@ Modules: root (the library), `:codegen`, `:plugin`, `:cross_test`, `:stress_test
 
 ## Releasing
 
-1. Bump the version in `gradle.properties`, the README install snippets, and `samples/bluez-scan/build.gradle.kts`.
+1. Bump the version everywhere it is hardcoded: `gradle.properties`, the README install snippets, `samples/bluez-scan/build.gradle.kts`, `samples/demo-service/build.gradle.kts`, and the API-stability prose in `README.md` + `dokka/moduledoc.md`. Move the `CHANGELOG.md` `[Unreleased]` heading to the new version + date and add its link ref at the bottom.
 2. Create a GitHub release `vX.Y.Z` → the `publish.yaml` workflow publishes to Maven Central via vanniktech with `automaticRelease = true` (no manual Sonatype Portal step). All 5 coordinates (root, `-jvm`, `-linuxx64`, `-linuxarm64`, `-codegen`) deploy as one atomic deployment.
 3. SNAPSHOT versions skip signing (for local `publishToMavenLocal` cross-repo testing); real releases are signed.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ It is published for three targets, all sharing the same common API:
 
 ## API stability
 
-0.6.0 is the **1.0-polish** release — a post-0.5.0 review applied a final wave of renames and
-deprecations to the public surface (see the [CHANGELOG](CHANGELOG.md) migration guide). 1.0 will
-freeze that surface, dropping the names deprecated in 0.6.0. Compatibility is enforced in CI with
+**1.0 freezes the public API.** A post-0.5.0 review applied a final wave of renames and deprecations
+(see the [CHANGELOG](CHANGELOG.md) migration guide), and 1.0 removes the names that were deprecated
+in 0.6.0. From here the surface is stable. Compatibility is enforced in CI with
 [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
 (JVM and klib API dumps are checked in under `api/`), so any change to the public surface is an
 explicit, reviewed event.
@@ -61,7 +61,7 @@ introspection XML files, conventionally placed in `src/dbusMain`.
 ```
 plugins {
     ...
-    id("com.monkopedia.sdbus.plugin") version "0.6.0"
+    id("com.monkopedia.sdbus.plugin") version "1.0.0"
 }
 
 sdbus {
@@ -95,7 +95,7 @@ module with implementations for `jvm`, `linuxX64`, and `linuxArm64`. Add the dep
 ```
 val nativeMain by getting {
     dependencies {
-       implementation("com.monkopedia:sdbus-kotlin:0.6.0")
+       implementation("com.monkopedia:sdbus-kotlin:1.0.0")
     }
 }
 ```

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -271,7 +271,8 @@ There are 11 `create*Connection` entry points — 10 declared in the common API
 - The two **fd-based factories** are native-only. The JVM actuals are marked
   `@Deprecated(level = ERROR)` (`src/jvmMain/.../Connection.jvm.kt`), so calling them from
   JVM-compiled code is a **compile-time error**; if invoked anyway (e.g. reflectively), the
-  JVM backend throws (`PureJavaDbusBackend.createConnection` rejects `DIRECT_FD`/`SERVER_FD`).
+  JVM backend rejects the fd-based bus types (`JvmBusType.DIRECT_FD`/`SERVER_FD`, in
+  `WireDbusBackend.createConnection`).
   On native they adopt the descriptor as documented in their KDoc.
 - `createRemoteSystemBusConnection(host)` is **native-only and not declared in the common
   or JVM API** (it lives in `src/nativeMain/.../Connection.native.kt`). It opens the system
@@ -292,7 +293,7 @@ that need connection plumbing without a real bus, but it is an **explicit intern
 implicitly by any factory.
 
 - Proven by: `src/jvmTest/.../JvmUnreachableBusTest.kt` (unreachable session/direct addresses
-  throw `Error`) and `PureJavaDbusBackendTest.createConnection_throwsWhenEndpointMissing`.
+  throw `SdbusException`).
 
 ## Event loop semantics
 
@@ -352,5 +353,24 @@ You can still call it explicitly after registering handlers on a bare connection
    `FailurePathParityTest.connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout`
    and `JvmUnreachableBusTest`.
 
-Everything not listed above is contract-level parity, enforced by the commonTest and
-cross_test suites on every CI run.
+The **cross-process** surface (the real consumer path, e.g. talking to BlueZ) is contract-level
+parity, enforced by the commonTest and cross_test suites on every CI run — including the parity
+wave that closed the error-name contract, ObjectManager/PropertiesChanged payloads, use-after-release
+guards, `proxy.release()` teardown, wrong-argument-count classification, same-process standard
+interfaces, `dontExpectReply`, and `addMatch` well-known-sender resolution (#141, all pinned by
+cross-backend regression tests).
+
+A few **same-process / direct-connection** edges remain JVM-specific and are documented rather than
+matched (they don't affect cross-process usage):
+
+- Two brokerless **direct** connections in one JVM share a synthetic `uniqueName` (`":jvm-wire"`),
+  and objects they export at the same path can clobber each other in the local dispatch table.
+- `startEventLoop()` is a no-op on JVM (the reader thread auto-starts at connect), where native
+  requires it to receive — a JVM proxy can receive signals without it; native cannot.
+- `Properties.GetAll` on an interface the object doesn't implement returns an empty `a{sv}` on JVM,
+  where native returns an error.
+- A same-process `UnixFd` argument is passed by reference (not dup'd) on the local short-circuit,
+  where native dups the descriptor.
+- `currentlyProcessedMessage` is not guarded against use after `release()` on JVM (native is).
+
+These are tracked as post-1.0 items; none is on the cross-process path.

--- a/dokka/moduledoc.md
+++ b/dokka/moduledoc.md
@@ -49,9 +49,9 @@ server-side example, see [`samples/demo-service`](https://github.com/Monkopedia/
 
 ## API stability
 
-0.6.0 is the **1.0-polish** release — a post-0.5.0 review applied a final wave of renames and
-deprecations to the public surface; 1.0 will freeze it, dropping the names deprecated in 0.6.0.
-Compatibility is enforced in CI with
+**1.0 freezes the public API** — a post-0.5.0 review applied a final wave of renames and
+deprecations, and 1.0 removes the names that were deprecated in 0.6.0. Compatibility is enforced
+in CI with
 [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
 (JVM and klib API dumps are checked in under `api/`), so any change to the public surface is an
 explicit, reviewed event. The per-release migration notes are in the

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m
-version=0.6.0
+version=1.0.0
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.mpp.enableCInteropCommonization=true

--- a/samples/bluez-scan/build.gradle.kts
+++ b/samples/bluez-scan/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization)
                 implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
-                implementation("com.monkopedia:sdbus-kotlin:0.6.0")
+                implementation("com.monkopedia:sdbus-kotlin:1.0.0")
             }
         }
         val nativeTest by getting {

--- a/samples/demo-service/README.md
+++ b/samples/demo-service/README.md
@@ -30,10 +30,10 @@ produce `DemoService1`, `DemoService1Adaptor`, and `DemoService1Proxy` into the 
 This sample is part of the sdbus-kotlin repository and must demonstrate the **current** API
 (post-0.5.0: `startEventLoop`/`stopEventLoop`, `withGetter`/`withSetter`, typed property flows,
 `Duration` timeouts, etc.). That API does **not** exist in the artifact published to Maven Central
-(0.6.0). So, exactly like `bluez-scan`, [`settings.gradle.kts`](settings.gradle.kts) uses a Gradle
+(1.0.0). So, exactly like `bluez-scan`, [`settings.gradle.kts`](settings.gradle.kts) uses a Gradle
 **composite build** (`includeBuild("../..")`). Gradle automatically substitutes the
 `com.monkopedia:sdbus-kotlin` dependency declared in `build.gradle.kts` with the local source tree,
-so the version coordinate there (`0.6.0`) is only a placeholder and the sample always compiles
+so the version coordinate there (`1.0.0`) is only a placeholder and the sample always compiles
 against the library checked out next to it. No `publishToMavenLocal` step is required.
 
 ## Running
@@ -117,9 +117,10 @@ busctl --user call $SVC /com/monkopedia/demo \
 - **linuxX64 (native)** is backed by `sd-bus` and runs as a fully-fledged D-Bus server: external
   processes (`busctl`, a separate `client` run, a JVM client) can introspect, call methods, read/
   write properties, and receive signals over the wire.
-- **JVM** is backed by dbus-java. It runs as a first-class **client** against any server (e.g.
-  `./gradlew runJvm --args="client"` against the native server works end-to-end, including
-  receiving `Tick` signals). The JVM `server` mode also runs — it claims the name, exports the
-  object, and emits signals — but the dbus-java backend routes exported objects through an
-  in-process dispatch table, so serving arbitrary method calls to *separate processes* is limited.
-  For a production D-Bus **service**, run the native target.
+- **JVM** is backed by an owned junixsocket connection with a pure-Kotlin marshaller and dispatcher
+  (no `dbus-java`, no native code). Since 0.5.0 the JVM `server` mode serves exported objects over
+  the wire — external processes (`busctl`, a separate `client` run, the native client) can
+  introspect, call methods, read/write properties, and receive signals from it, just like the
+  native target; `./gradlew runJvm --args="client"` against the native server also works end-to-end.
+  Both backends are interchangeable for serving; the remaining differences are
+  same-process/direct-connection edges documented in [docs/BACKENDS.md](../../docs/BACKENDS.md).

--- a/samples/demo-service/build.gradle.kts
+++ b/samples/demo-service/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
                 implementation(kotlin("stdlib"))
                 // Version is a placeholder: the composite build in settings.gradle.kts
                 // substitutes this with the local sdbus-kotlin source tree.
-                implementation("com.monkopedia:sdbus-kotlin:0.6.0")
+                implementation("com.monkopedia:sdbus-kotlin:1.0.0")
             }
         }
     }


### PR DESCRIPTION
**Release-cut prep for v1.0.0 — non-code only. This does NOT tag or publish**; creating the `v1.0.0` GitHub release (→ publish.yaml → Maven Central) stays the owner's trigger.

## Version bumps (0.6.0 → 1.0.0)

`gradle.properties`, README install snippets (plugin + dependency), `samples/bluez-scan` + `samples/demo-service` build files, and the API-stability prose in `README.md` + `dokka/moduledoc.md` (rewritten: 0.6.0-"1.0-polish" → **1.0 is the freeze**). Historical "0.6.0" mentions in the CHANGELOG are left intact.

## CHANGELOG

`[Unreleased]` → `[1.0.0]` with the full entry — the deprecated-alias removals plus the cross-backend **parity wave** (#138, #142–#150) and the coverage/hardening work (#133–#136, #139). Added the missing `[1.0.0]` and `[0.6.0]` link refs.

## Doc corrections (audit-flagged factual errors)

- `CLAUDE.md` and `samples/demo-service/README.md` no longer say the JVM backend is "backed by dbus-java" (junixsocket since 0.5.0). The demo-service README also **wrongly claimed JVM can't serve cross-process** — corrected to reflect the shipped WireServe capability.
- `docs/BACKENDS.md`: stale `PureJavaDbusBackend` → `JvmDbusBackend`; the "everything else is parity" claim now scopes to the cross-process surface and documents the remaining same-process/direct-connection edges (with a note they're off the consumer path).
- `CLAUDE.md` release checklist step 1 completed (it omitted the demo-service sample + the prose).

## Verification
- `ktlintCheck` + `apiCheck` green (docs only, no code/API change)
- No stale `0.6.0` coordinate or `dbus-java`/`PureJavaDbusBackend` reference remains

After merge, the repo is ready to tag `v1.0.0` whenever you pull the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)