### PR TITLE
docs: describe the JVM backend by what it is, not "no dbus-java"

### DIFF
--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockBluezTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockBluezTest.kt
@@ -108,7 +108,7 @@ import kotlinx.coroutines.withTimeout
  * the `assertFailsWith<SdbusException>` part always runs on both backends.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Skips cleanly when
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`). Skips cleanly when
  * python3-dbusmock is not installed (see [DbusmockHarness]).
  */
 class DbusmockBluezTest {

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockForeignErrorTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockForeignErrorTest.kt
@@ -37,7 +37,7 @@ import kotlin.test.assertFailsWith
  * message preserved verbatim.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`) — the independent-peer
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`) — the independent-peer
  * counterpart of the own-server error-mapping parity coverage. Skips cleanly when
  * python3-dbusmock is not installed (see [DbusmockHarness]).
  */

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockObjectManagerTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockObjectManagerTest.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.withTimeout
  * converge on the same view.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Skips cleanly when
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`). Skips cleanly when
  * python3-dbusmock is not installed (see [DbusmockHarness]).
  */
 class DbusmockObjectManagerTest {

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPropertiesChangedTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPropertiesChangedTest.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.withTimeout
  * `PropertyDelegate.changes()`/`changesOrNull()`/`values()`/`valuesOrNull()` flows.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`) — settling the JVM-vs-native
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`) — settling the JVM-vs-native
  * parity question for changed-value payloads from an independent emitter. Skips cleanly when
  * python3-dbusmock is not installed (see [DbusmockHarness]).
  */

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSecretServiceTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSecretServiceTest.kt
@@ -65,7 +65,7 @@ import kotlinx.serialization.Serializable
  * Secret Service API.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Known JVM backend gaps are
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`). Known JVM backend gaps are
  * gated, not re-tripped:
  * - issue #71 ([peerStructMarshallingSupported]): @Serializable structs cannot be marshalled
  *   to/from a real remote peer, which covers every `(oayays)` Secret transfer.

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSignalTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSignalTest.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.withTimeout
  * (Python/GDBus) stack, and the subscribe/unsubscribe lifecycle.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`). Skips cleanly when
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`). Skips cleanly when
  * python3-dbusmock is not installed (see [DbusmockHarness]).
  */
 class DbusmockSignalTest {

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSmokeTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSmokeTest.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.runBlocking
 /**
  * Smoke test for the python-dbusmock independent-peer harness ([DbusmockHarness]).
  *
- * This proves the end-to-end loop on whichever backend the test compiles for (JVM dbus-java
+ * This proves the end-to-end loop on whichever backend the test compiles for (JVM wire
  * via `jvmTest`, native sd-bus via `linuxX64Test`): our client scripts a generic dbusmock
  * object, then calls a method and reads a property on it and asserts the results round-trip
  * through the foreign (Python/GDBus) serializer.

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockTypeMatrixTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockTypeMatrixTest.kt
@@ -48,7 +48,7 @@ import kotlinx.serialization.Serializable
  * stack to decode it and re-encode an equivalent reply.
  *
  * Lives in commonTest so the exact same assertions run against BOTH the native sd-bus backend
- * (`linuxX64Test`) and the JVM dbus-java backend (`jvmTest`).
+ * (`linuxX64Test`) and the JVM wire backend (`jvmTest`).
  *
  * Skips cleanly when python3 / python3-dbusmock is not installed (e.g. the ARM CI job). See
  * [DbusmockHarness] for installation instructions.

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -3,8 +3,8 @@
 sdbus-kotlin ships one common API with two implementations: the **native** backend
 (`linuxX64`/`linuxArm64`, sd-bus via libsystemd) and the **JVM** backend, which owns its D-Bus
 connection over a [junixsocket](https://github.com/kohlschutter/junixsocket) transport with a
-pure-Kotlin marshaller and dispatcher (no `dbus-java`, no native code — junixsocket is the only
-transitive dependency). This document is the contract for what behaves identically on both
+pure-Kotlin marshaller and dispatcher (no native code — junixsocket is the only transitive
+dependency). This document is the contract for what behaves identically on both
 backends and where they differ, as of the frozen 1.0 API surface.
 
 Every row below is pinned by tests on current `main`, not by intention:

--- a/dokka/moduledoc.md
+++ b/dokka/moduledoc.md
@@ -10,7 +10,7 @@ The same common API is published for three targets:
 
 | Target | Backend |
 | --- | --- |
-| `jvm` | An owned D-Bus connection — [junixsocket](https://github.com/kohlschutter/junixsocket) transport with a pure-Kotlin marshaller and dispatcher (as of 0.5.0; no `dbus-java`, no native code) |
+| `jvm` | An owned D-Bus connection — [junixsocket](https://github.com/kohlschutter/junixsocket) transport with a pure-Kotlin marshaller and dispatcher, no native code (since 0.5.0) |
 | `linuxX64` | sd-bus via libsystemd (cinterop) |
 | `linuxArm64` | sd-bus via libsystemd (cinterop) |
 

--- a/samples/demo-service/README.md
+++ b/samples/demo-service/README.md
@@ -118,7 +118,7 @@ busctl --user call $SVC /com/monkopedia/demo \
   processes (`busctl`, a separate `client` run, a JVM client) can introspect, call methods, read/
   write properties, and receive signals over the wire.
 - **JVM** is backed by an owned junixsocket connection with a pure-Kotlin marshaller and dispatcher
-  (no `dbus-java`, no native code). Since 0.5.0 the JVM `server` mode serves exported objects over
+  (no native code). Since 0.5.0 the JVM `server` mode serves exported objects over
   the wire — external processes (`busctl`, a separate `client` run, the native client) can
   introspect, call methods, read/write properties, and receive signals from it, just like the
   native target; `./gradlew runJvm --args="client"` against the native server also works end-to-end.

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TypeMatrixRoundTripTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TypeMatrixRoundTripTest.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.Serializable
  * Each test stands up a real bus connection with a server object exposing an `Echo` method that
  * returns its argument unchanged, then calls it through a proxy and asserts the returned value
  * equals the value sent. Because this lives in commonTest, the exact same assertions run against
- * BOTH the native sd-bus backend (linuxX64Test) and the JVM dbus-java backend (jvmTest), so any
+ * BOTH the native sd-bus backend (linuxX64Test) and the JVM wire backend (jvmTest), so any
  * marshalling divergence between the two backends shows up as a test failure on one of them.
  *
  * The values cross a real bus rather than short-circuiting in-process, so wire-serialization bugs

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
@@ -170,7 +170,7 @@ class JvmMessageSupportTest {
         assertFailsWith<SdbusException> { message.seLinuxContext }
     }
 
-    // Regression: D-Bus `ay` (e.g. a GATT characteristic value) arrives from dbus-java as
+    // Regression: D-Bus `ay` (e.g. a GATT characteristic value) arrives as
     // signed java.lang.Byte values, but the declared type is List<UByte>. Deserialization
     // must box each element into UByte; otherwise reading it throws
     // "class java.lang.Byte cannot be cast to class kotlin.UByte".

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -235,7 +235,7 @@ class JvmRealBusIntegrationTest {
         // Exercised on BOTH backends now (epic #93 phase 3b): the wire backend emits the signal over
         // the wire, so the bus stamps the authoritative sender and the receiver resolves the
         // sender's credentials (filled from the local process for a same-process sender), just as
-        // the dbus-java backend does.
+        // the dbus-java backend did (before it was replaced).
         val suffix = "c${System.nanoTime()}"
         val service = ServiceName("com.monkopedia.sdbus.jvmreal.$suffix")
         val objectPath = ObjectPath("/com/monkopedia/sdbus/jvmreal$suffix/credentials")


### PR DESCRIPTION
## What

Post-1.0 doc/comment cleanup. The JVM backend replaced dbus-java back in 0.5.0, but a scattering of docs and test comments still framed it negatively ("no dbus-java") or, worse, mislabeled our own pure-Kotlin junixsocket backend AS "the JVM dbus-java backend".

## Changes

- **User-facing docs** (`docs/BACKENDS.md`, `dokka/moduledoc.md`, `samples/demo-service/README.md`): drop the "no dbus-java" aside and describe the backend by what it is (owned junixsocket connection, pure-Kotlin marshaller/dispatcher). Kept the real attribute "no native code".
- **cross_test `Dbusmock*` / `TypeMatrix` comments**: `the JVM dbus-java backend (jvmTest)` → `the JVM wire backend (jvmTest)` — it is not dbus-java.
- **`JvmMessageSupportTest` / `JvmRealBusIntegrationTest`**: drop stale "from dbus-java" phrasing; the old backend "did (before it was replaced)".

## Deliberately kept

Legitimate references are untouched:
- `cross_test/build.gradle.kts`'s real `dbus-java` dependency — used as an independent interop peer for cross-runtime tests.
- The "old dbus-java backend" regression-history notes (issues #35/#36).
- The epic #93 migration narrative in `WireSignalEmissionExternalTest`.

## Verification

Comment/doc-only changes; `compileTestKotlinJvm` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)