### PR TITLE
chore: drop unused kotlinx-datetime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ klib binary-compatibility dumps are identical to 1.0.0), so this is a drop-in up
 - **Kotlin** `2.4.0` → `2.4.10` (toolchain; no klib-ABI shift).
 - **kotlinx-coroutines** `1.10.2` → `1.11.0`.
 - **kotlinx-atomicfu** `0.32.1` → `0.33.0`.
-- **kotlinx-datetime** `0.7.1` → `0.8.0`.
+
+### Removed — dependencies
+
+- **kotlinx-datetime** is no longer a dependency. It was declared but unused (the library uses
+  `kotlin.time` from the standard library), so it has been dropped from the published artifacts —
+  removing it from consumers' transitive runtime classpath. This is `implementation`-scoped and
+  absent from the public API, so it does not affect the binary-compatibility surface.
 
 ### Documentation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,6 @@ kotlin {
                 // kotlinx-serialization types (KSerializer, the serializer companions) are part
                 // of the public API surface (e.g. Variant, UnixFd.Companion), so expose as api.
                 api(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.atomicfu)
             }
         }
@@ -105,7 +104,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 // Owned D-Bus connection (epic #93): the JVM backend talks to the bus over a raw
                 // AF_UNIX socket via junixsocket and our own marshaller/dispatch — no dbus-java.
                 // junixsocket is a direct dependency so the owned connection can use AFUNIXSocket.
@@ -124,7 +122,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
             }
         }

--- a/compile_test/build.gradle.kts
+++ b/compile_test/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.atomicfu)
                 implementation(kotlin("stdlib"))
                 implementation(project(":"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 kotlin = "2.4.10"
 kotlin-coroutines = "1.11.0"
 kotlin-serialization = "1.11.0"
-kotlin-datetime = "0.8.0"
 clikt = "5.1.0"
 kotlin-atomicfu = "0.33.0"
 dokka = "2.2.0"
@@ -25,7 +24,6 @@ kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin-serialization" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlin-datetime" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlin-atomicfu" }
 xmlutil = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "pdvrieze-xmlutil" }
 kotlinpoet = { module = "com.squareup:kotlinpoet-jvm", version.ref = "kotlinpoet" }

--- a/samples/bluez-scan/build.gradle.kts
+++ b/samples/bluez-scan/build.gradle.kts
@@ -34,7 +34,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
                 implementation("com.monkopedia:sdbus-kotlin:1.0.1")
             }

--- a/samples/demo-service/build.gradle.kts
+++ b/samples/demo-service/build.gradle.kts
@@ -37,7 +37,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 implementation(kotlin("stdlib"))
                 // Version is a placeholder: the composite build in settings.gradle.kts
                 // substitutes this with the local sdbus-kotlin source tree.


### PR DESCRIPTION
## What

`kotlinx-datetime` was a declared `implementation` dependency in the library (commonMain / jvmMain / nativeMain), both samples, and `compile_test` — but it is used **nowhere**. The codebase relies on `kotlin.time` (stdlib) for `Duration` and `Clock`; there are zero `kotlinx.datetime` references anywhere in source.

This drops it entirely and removes the two version-catalog entries.

## Why now

Surfaced during the 1.0.1 dependency-refresh review. Rather than bump an unused dep to 0.8.0, remove it — it comes off consumers' transitive runtime classpath, shrinking their dep tree for free.

## Impact

- **ABI: unchanged.** `implementation`-scoped and absent from the public API, so `apiCheck` stays green and both `api/*.api` (JVM) and `api/*.klib.api` (klib) dumps are untouched — this diff touches no file under `api/`.
- **Consumers (blue-falcon):** still a drop-in; they don't reference kotlinx-datetime via this library.

## Verification (all green, local)

- `compileKotlinJvm` + `compileKotlinLinuxX64` + `compileKotlinLinuxArm64` + `:compile_test:compileKotlinLinuxX64`
- `ktlintCheck`
- `apiCheck` — no ABI change
- `jvmTest` 320/320 · `linuxX64Test` 288/288 (under `dbus-run-session`)

Rolls into the 1.0.1 maintenance release (version already bumped on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)