### PR TITLE
fix(jvm): escape the raw NUL char literal in WireDbusBackend.kt

### DIFF
--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -782,7 +782,7 @@ private val localProcessWireCredentials: WireSenderCredentials by lazy {
     val unix = runCatching { com.sun.security.auth.module.UnixSystem() }.getOrNull()
     val selinuxContext = runCatching {
         java.nio.file.Files.readString(java.nio.file.Paths.get("/proc/self/attr/current"))
-            .trim(' ', ' ')
+            .trim('\u0000', ' ')
             .ifEmpty { null }
     }.getOrNull()
     WireSenderCredentials(


### PR DESCRIPTION
One-character lexical fix: the SELinux-context trim in `localProcessWireCredentials` used a **raw 0x00 byte** as its first char literal. It is now written as the ordinary Kotlin unicode escape for code point zero (backslash-u-0000), which denotes the same character — so the trim behaves identically. This changes only how the source is encoded, not what it does.

## Why it matters

That one byte made `file(1)` classify the whole 1057-line source file as `data` instead of text:

```
$ file src/jvmMain/.../WireDbusBackend.kt     # before
... : data
$ file src/jvmMain/.../WireDbusBackend.kt     # after
... : Unicode text, UTF-8 text
```

Which means **grep and rg silently print nothing for matches in this file** — binary files suppress line output unless `-a` is passed. An empty grep here reads as "the string is absent" when it is present.

Two concrete costs, both already paid:

1. **The tree-wide doc sweep in #152 missed this file entirely.** That PR removed stale references to the retired dbus-java backend across the repo; this file still carries **ten** of them. `grep -c dbus-java` on it returns 10 now that the file is greppable, and returned nothing before.
2. An earlier review round was nearly dismissed as fabricated citations, on the strength of an empty grep over this file. The citations were correct.

It is the only raw NUL in any tracked *source* file. The other NUL-bearing tracked files are legitimately binary (jars, `.so`, png), confirmed by a byte scan over `git ls-files`.

Worth noting for anyone verifying this: `grep -P '\x00'` is itself unreliable for finding the problem, for the same reason. A `perl -0777 -ne` scan or `od -c` is the dependable check.

## Scope

Deliberately just the one byte. The ten stale dbus-java comments that this fix *reveals* are a separate concern — they are documentation, they need judgment about which references are genuinely stale versus legitimately historical, and folding them in here would obscure a change whose entire value is being trivially verifiable. A follow-up PR completes #152's sweep in this file.

Fixes #155

## Verification

- `compileKotlinJvm`, `ktlintCheck`, `apiCheck` — green
- No `api/` file touched, so no ABI change
- `jvmTest` 320/320 + `cross_test:jvmTest` 64/64, 0 failures, under `dbus-run-session`
- `grep -n localProcessWireCredentials <file>` now resolves (line 780); it returned empty before
