### PR TITLE
fix(build): skip signing on SNAPSHOT in :codegen and :plugin

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -104,10 +104,17 @@ mavenPublishing {
     }
     publishToMavenCentral(automaticRelease = true)
 
-    signAllPublications()
+    // SNAPSHOT builds (e.g. publishToMavenLocal for downstream testing) are not signed:
+    // Maven Central doesn't require signatures for snapshots, and it avoids needing a GPG
+    // key for local cross-project validation.
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
 }
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
+if (!version.toString().endsWith("SNAPSHOT")) {
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -81,10 +81,21 @@ mavenPublishing {
     }
     publishToMavenCentral(automaticRelease = true)
 
-    signAllPublications()
+    // SNAPSHOT builds (e.g. publishToMavenLocal for downstream testing) are not signed:
+    // Maven Central doesn't require signatures for snapshots, and it avoids needing a GPG
+    // key for local cross-project validation.
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
 }
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
+if (!version.toString().endsWith("SNAPSHOT")) {
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
+} else {
+    // com.gradle.plugin-publish registers its own Sign tasks for the plugin publications,
+    // and those fail rather than skip once no signatory is configured.
+    tasks.withType<Sign>().configureEach { enabled = false }
 }


### PR DESCRIPTION
Fixes #163

`publishToMavenLocal` on a SNAPSHOT required a GPG secret key. The root build already guards signing behind a non-SNAPSHOT check, and `CLAUDE.md` documents the policy ("SNAPSHOT versions skip signing (for local `publishToMavenLocal` cross-repo testing); real releases are signed"). This applies that same guard to the modules that diverged from it.

## Two findings that changed the fix from what the issue proposed

**1. Guarding `signAllPublications()` alone does NOT fix it.** The issue asked to confirm this rather than assume it, so I measured it: with only `signAllPublications()` guarded, `:codegen` still fails, because the standalone `signing { useGpgCmd(); sign(publishing.publications) }` block re-registers the task by itself.

```
$ ./gradlew :codegen:publishToMavenLocal -Pversion=1.0.2-SNAPSHOT      # signAllPublications() guarded, signing {} block left alone
> Task :codegen:signMavenPublication FAILED
gpg: no default secret key: No secret key
* What went wrong:
Execution failed for task ':codegen:signMavenPublication' (registered in build file 'codegen/build.gradle.kts').
```

So both spots need the guard — which is exactly what the root build does (`build.gradle.kts:287` and `:353`).

**2. `:plugin` has the identical unguarded pattern, so fixing only `:codegen` would not have fixed the issue's stated impact** ("cannot run a full `publishToMavenLocal`"). With `:codegen` fixed, the full run just moved its failure one module over:

```
$ ./gradlew publishToMavenLocal -Pversion=1.0.2-SNAPSHOT              # :codegen fixed, :plugin untouched
* What went wrong:
Execution failed for task ':plugin:signPluginMavenPublication' (registered in build file 'plugin/build.gradle.kts').
> Process 'command 'gpg'' finished with non-zero exit value 2
```

`:plugin` also needs one step the other modules don't: `com.gradle.plugin-publish` registers Sign tasks for its own publications independently of our config, so with the guard alone they fail differently rather than disappearing —

```
* What went wrong:
Execution failed for task ':plugin:signPluginMavenPublication' (registered by plugin 'com.gradle.plugin-publish').
> Cannot perform signing task ':plugin:signPluginMavenPublication' because it has no configured signatory
```

Disabling `Sign` tasks on the SNAPSHOT branch makes them skip cleanly. Note `:plugin` is published on release — the workflow runs `gradle publish` from the root, which includes it — so its signing had to be preserved, not dropped.

## Verification

`JAVA_HOME=/usr/lib/jvm/java-21-openjdk`, no GPG secret key on this machine (`gpg --list-secret-keys` is empty).

**Repro, before the fix** (unmodified `main` @ ba62857):

```
$ ./gradlew :codegen:publishToMavenLocal -Pversion=1.0.2-SNAPSHOT
> Task :codegen:signMavenPublication FAILED
gpg: no default secret key: No secret key
gpg: signing failed: No secret key
* What went wrong:
Execution failed for task ':codegen:signMavenPublication' (registered in build file 'codegen/build.gradle.kts').
> Process 'command 'gpg'' finished with non-zero exit value 2
BUILD FAILED in 18s
```

Confirming the issue's "bites silently" note: `~/.m2/repository/com/monkopedia/sdbus-kotlin-codegen` did not exist beforehand, while the other four coordinates were present.

**After the fix** — full clean run, all publications:

```
$ rm -rf ~/.m2/repository/com/monkopedia/*/1.0.2-SNAPSHOT ...
$ ./gradlew publishToMavenLocal -Pversion=1.0.2-SNAPSHOT --rerun-tasks
> Task :plugin:signPluginMavenPublication SKIPPED
> Task :plugin:signSdbusPluginPluginMarkerMavenPublication SKIPPED
BUILD SUCCESSFUL in 32s
64 actionable tasks: 64 executed
```

All five coordinates landed (plus the plugin), and no `.asc` files were produced:

```
$ find ~/.m2/repository/com/monkopedia -path "*1.0.2-SNAPSHOT*" \( -name "*.jar" -o -name "*.klib" -o -name "*.pom" \)
sdbus-kotlin/1.0.2-SNAPSHOT/sdbus-kotlin-1.0.2-SNAPSHOT.jar (+ -javadoc, -sources, .pom)
sdbus-kotlin-codegen/1.0.2-SNAPSHOT/sdbus-kotlin-codegen-1.0.2-SNAPSHOT.jar (+ -javadoc, -sources, .pom)
sdbus-kotlin-jvm/1.0.2-SNAPSHOT/sdbus-kotlin-jvm-1.0.2-SNAPSHOT.jar (+ -javadoc, -sources, .pom)
sdbus-kotlin-linuxarm64/1.0.2-SNAPSHOT/sdbus-kotlin-linuxarm64-1.0.2-SNAPSHOT.klib (+ cinterop klib, -javadoc, -sources, .pom)
sdbus-kotlin-linuxx64/1.0.2-SNAPSHOT/sdbus-kotlin-linuxx64-1.0.2-SNAPSHOT.klib (+ cinterop klib, -javadoc, -sources, .pom)
sdbus/plugin/1.0.2-SNAPSHOT/plugin-1.0.2-SNAPSHOT.jar (+ -javadoc, -sources, .pom, + gradle.plugin marker .pom)

$ find ~/.m2/repository/com/monkopedia -path "*1.0.2-SNAPSHOT*" -name "*.asc"
(no output)
```

**Negative case — a non-SNAPSHOT still signs.** Both changed modules still wire signing and still invoke gpg, failing on the missing key exactly as they should on this machine:

```
$ ./gradlew :codegen:publishToMavenLocal -Pversion=1.0.2
> Task :codegen:signMavenPublication FAILED
gpg: no default secret key: No secret key
Execution failed for task ':codegen:signMavenPublication' (registered in build file 'codegen/build.gradle.kts').
BUILD FAILED in 12s

$ ./gradlew :plugin:publishToMavenLocal -Pversion=1.0.2
> Task :plugin:signPluginMavenPublication FAILED
gpg: no default secret key: No secret key
Execution failed for task ':plugin:signPluginMavenPublication' (registered in build file 'plugin/build.gradle.kts').
BUILD FAILED in 1s
```

And the full task graph, release vs. snapshot (`--dry-run`; "SKIPPED" is just the dry-run marker on every line):

```
$ ./gradlew publishToMavenLocal -Pversion=1.0.2 --dry-run | grep -i sign
:codegen:signMavenPublication
:plugin:signPluginMavenPublication
:plugin:signSdbusPluginPluginMarkerMavenPublication
:signJvmPublication
:signKotlinMultiplatformPublication
:signLinuxArm64Publication
:signLinuxX64Publication

$ ./gradlew publishToMavenLocal -Pversion=1.0.2-SNAPSHOT --dry-run | grep -i sign
:plugin:signPluginMavenPublication
:plugin:signSdbusPluginPluginMarkerMavenPublication
```

A release keeps all seven sign tasks. A snapshot has only the two that `plugin-publish` registers unconditionally, and those are disabled (they show `SKIPPED` at execution above).

**Static gates:** `./gradlew ktlintCheck apiCheck` — BUILD SUCCESSFUL, no `api/` diff.

**Cleanup:** all `1.0.2-SNAPSHOT` / `1.0.2` artifacts removed from `~/.m2/repository/com/monkopedia/`, including the `1.0.2-SNAPSHOT` entries the run added to the four `maven-metadata-local.xml` files.

## Not done

No CHANGELOG entry: this changes local build behavior for contributors only, with no effect on published artifacts — matching #162, which was likewise build-tooling-only and added none. Happy to add one if you'd rather it be recorded.

## What I could not verify

That signatures are actually *produced* on a release — this machine has no GPG secret key, so the strongest available evidence is that the sign tasks are still wired and still reach gpg on a non-SNAPSHOT (above). The `.asc` artifacts themselves are unchanged in origin: the guard only decides whether the existing signing config is applied, and the non-SNAPSHOT path is byte-identical to what is on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
