### PR TITLE
refactor(codegen): parse introspection XML through one shared config

### DIFF
--- a/codegen/src/main/kotlin/Xml2Kotlin.kt
+++ b/codegen/src/main/kotlin/Xml2Kotlin.kt
@@ -80,14 +80,6 @@ import com.github.ajalt.clikt.parameters.types.file
 import java.io.File
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
-import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
-import nl.adaptivity.xmlutil.QName
-import nl.adaptivity.xmlutil.XmlReader
-import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
-import nl.adaptivity.xmlutil.serialization.InputKind
-import nl.adaptivity.xmlutil.serialization.XML
-import nl.adaptivity.xmlutil.serialization.XML.ParsedData
-import nl.adaptivity.xmlutil.serialization.structure.XmlDescriptor
 
 fun main(args: Array<String>) = Xml2Kotlin().main(args)
 
@@ -108,21 +100,9 @@ class Xml2Kotlin : CliktCommand() {
         help = "Override Kotlin package for generated files"
     )
 
-    @OptIn(ExperimentalXmlUtilApi::class)
     override fun run() {
         val packageOverride = outputPackage?.trim()?.takeUnless { it.isEmpty() }
-        val xml = XML {
-            isUnchecked = true
-            policy = object : DefaultXmlSerializationPolicy(policy) {
-                override fun handleUnknownContentRecovering(
-                    input: XmlReader,
-                    inputKind: InputKind,
-                    descriptor: XmlDescriptor,
-                    name: QName?,
-                    candidates: Collection<Any>
-                ): List<ParsedData<*>> = emptyList()
-            }
-        }.decodeFromString<XmlRootNode>(input.readText())
+        val xml = introspectionXml.decodeFromString<XmlRootNode>(input.readText())
         if (!keep) {
             output.deleteRecursively()
         }

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -24,9 +24,41 @@ package com.monkopedia.sdbus
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
+import nl.adaptivity.xmlutil.QName
+import nl.adaptivity.xmlutil.XmlReader
+import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
+import nl.adaptivity.xmlutil.serialization.InputKind
+import nl.adaptivity.xmlutil.serialization.XML
+import nl.adaptivity.xmlutil.serialization.XML.ParsedData
 import nl.adaptivity.xmlutil.serialization.XmlElement
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
 import nl.adaptivity.xmlutil.serialization.XmlValue
+import nl.adaptivity.xmlutil.serialization.structure.XmlDescriptor
+
+/**
+ * The single parser for D-Bus introspection XML, shared by the [Xml2Kotlin] CLI and the tests so
+ * the golden fixtures assert against the configuration the tool actually ships. Unknown content
+ * is dropped rather than failing, so vendor extensions don't break generation.
+ *
+ * `XML.compat` is deprecated in xmlutil 1.0, but its replacements deliberately change the parsing
+ * defaults and xmlutil offers no non-deprecated route back to the old ones. Switching is a
+ * behaviour change needing its own review, so the compat defaults stay pinned here.
+ */
+@OptIn(ExperimentalXmlUtilApi::class)
+@Suppress("DEPRECATION")
+internal val introspectionXml: XML = XML.compat {
+    isUnchecked = true
+    policy = object : DefaultXmlSerializationPolicy(policy) {
+        override fun handleUnknownContentRecovering(
+            input: XmlReader,
+            inputKind: InputKind,
+            descriptor: XmlDescriptor,
+            name: QName?,
+            candidates: Collection<Any>
+        ): List<ParsedData<*>> = emptyList()
+    }
+}
 
 @Serializable
 @XmlSerialName("node")

--- a/codegen/src/test/kotlin/GeneratorTest.kt
+++ b/codegen/src/test/kotlin/GeneratorTest.kt
@@ -25,36 +25,16 @@ package com.monkopedia.sdbus
 import com.squareup.kotlinpoet.FileSpec
 import java.io.File
 import kotlinx.serialization.decodeFromString
-import nl.adaptivity.xmlutil.QName
-import nl.adaptivity.xmlutil.XmlReader
-import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
-import nl.adaptivity.xmlutil.serialization.InputKind
-import nl.adaptivity.xmlutil.serialization.XML
-import nl.adaptivity.xmlutil.serialization.XML.ParsedData
-import nl.adaptivity.xmlutil.serialization.structure.XmlDescriptor
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 class GeneratorTest {
-    val xml = XML {
-        isUnchecked = true
-        policy = object : DefaultXmlSerializationPolicy(policy) {
-            override fun handleUnknownContentRecovering(
-                input: XmlReader,
-                inputKind: InputKind,
-                descriptor: XmlDescriptor,
-                name: QName?,
-                candidates: Collection<Any>
-            ): List<ParsedData<*>> = emptyList()
-        }
-    }
-
     @ParameterizedTest
     @MethodSource("data")
     fun testInterface(testRoot: File) {
         val xmlStr = File(testRoot, "test.xml").readText()
-        val xml = xml.decodeFromString<XmlRootNode>(xmlStr)
+        val xml = introspectionXml.decodeFromString<XmlRootNode>(xmlStr)
         val gen = InterfaceGenerator().transformXmlToFile(xml).sortedBy { it.name }
         assertFiles(testRoot, "interface", gen)
     }
@@ -63,7 +43,7 @@ class GeneratorTest {
     @MethodSource("data")
     fun testAdaptor(testRoot: File) {
         val xmlStr = File(testRoot, "test.xml").readText()
-        val xml = xml.decodeFromString<XmlRootNode>(xmlStr)
+        val xml = introspectionXml.decodeFromString<XmlRootNode>(xmlStr)
         val gen = AdaptorGenerator().transformXmlToFile(xml).sortedBy { it.name }
         assertFiles(testRoot, "adaptor", gen)
     }
@@ -72,7 +52,7 @@ class GeneratorTest {
     @MethodSource("data")
     fun testProxy(testRoot: File) {
         val xmlStr = File(testRoot, "test.xml").readText()
-        val xml = xml.decodeFromString<XmlRootNode>(xmlStr)
+        val xml = introspectionXml.decodeFromString<XmlRootNode>(xmlStr)
         val gen = ProxyGenerator().transformXmlToFile(xml).sortedBy { it.name }
         assertFiles(testRoot, "proxy", gen)
     }

--- a/codegen/src/test/kotlin/TestXmlSupport.kt
+++ b/codegen/src/test/kotlin/TestXmlSupport.kt
@@ -1,27 +1,7 @@
 package com.monkopedia.sdbus
 
 import kotlinx.serialization.decodeFromString
-import nl.adaptivity.xmlutil.QName
-import nl.adaptivity.xmlutil.XmlReader
-import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
-import nl.adaptivity.xmlutil.serialization.InputKind
-import nl.adaptivity.xmlutil.serialization.XML
-import nl.adaptivity.xmlutil.serialization.XML.ParsedData
-import nl.adaptivity.xmlutil.serialization.structure.XmlDescriptor
 
 internal object TestXmlSupport {
-    private val xml = XML {
-        isUnchecked = true
-        policy = object : DefaultXmlSerializationPolicy(policy) {
-            override fun handleUnknownContentRecovering(
-                input: XmlReader,
-                inputKind: InputKind,
-                descriptor: XmlDescriptor,
-                name: QName?,
-                candidates: Collection<Any>
-            ): List<ParsedData<*>> = emptyList()
-        }
-    }
-
-    fun parse(text: String): XmlRootNode = xml.decodeFromString(text.trimIndent())
+    fun parse(text: String): XmlRootNode = introspectionXml.decodeFromString(text.trimIndent())
 }


### PR DESCRIPTION
Fixes #166

## What

The xmlutil parser configuration existed in three identical copies:

| Location | Used by |
| --- | --- |
| `codegen/src/main/kotlin/Xml2Kotlin.kt:114` | the shipped `Xml2Kotlin` CLI |
| `codegen/src/test/kotlin/TestXmlSupport.kt:13` | `CodegenParsingEdgeCaseTest`, `CodegenNamingAndTypeTest`, `CompilationIntegrationTest` |
| `codegen/src/test/kotlin/GeneratorTest.kt:40` | the golden-fixture tests |

So `GeneratorTest` — the contract test that asserts generated Kotlin matches the 66 checked-in BlueZ fixtures byte-for-byte — fed those fixtures through a parser it configured itself. It looked like end-to-end coverage of the generator and was actually coverage of a parallel configuration; a regression in the CLI's parsing path could not have failed it.

Extracted once as `internal val introspectionXml` in `:codegen`'s **main** source set (`XmlFormat.kt`, next to the model it parses into), and pointed all three call sites at it. `internal` keeps it off the public surface — `apiCheck` passes with `codegen/api/codegen.api` unchanged.

Net: **-28 lines** (65 deleted, 37 added). All three call sites collapse from a 12-line `XML { … }` block to a single identifier; `TestXmlSupport.kt` goes from 27 lines to 7.

## The xmlutil 1.0.1 deprecation (from #167's "related, small")

Handled at the now-single site, but **not** by switching builder form — that turns out not to be possible without changing behaviour. What I found in xmlutil 1.0.1:

- `XML { … }` resolves to `constructor(SerializersModule, XmlConfig.CompatBuilder.() -> Unit)`, deprecated with *"Update to the named factory functions"*.
- The named factory `XML.compat { … }` is **also** deprecated: *"Consider using the 1.0 object, but note it has changed defaults"*. So are `XML.Compat` and `XML.V1`.
- The only non-deprecated factories are `XML.recommended_1_0` / `XML.fast_1_0`, which build from `XmlConfig.DefaultBuilder` instead of `CompatBuilder` — different parsing defaults, and our policy is derived from the builder's default policy (`DefaultXmlSerializationPolicy(policy)`), so the change would propagate into decoding.
- Constructing the compat config directly is not open to callers either: `XmlConfig.CompatBuilder`'s constructor is `internal`, and `Compat.invoke` routes through `recommendedBuilder()` rather than a plain `CompatBuilder()`.

Verified against the bytecode that the deprecated `XML { … }` constructor and `XML.compat { … }` are instruction-for-instruction identical, so the site now calls `XML.compat` with a documented `@Suppress("DEPRECATION")` explaining why the pre-1.0 defaults stay pinned. **The build is warning-free for `:codegen` again** (only a pre-existing, unrelated `No cast needed.` warning in `CodegenNamingAndTypeTest.kt` remains).

Migrating to the 1.0 parsing defaults is a real behaviour change — 20 fixture inputs are not sufficient evidence for a parser defaults switch, which is precisely the class of silent drift this issue is about. Worth its own issue if wanted.

## Verification

- `./gradlew :codegen:test` — **77 tests, 0 failures**, including the 60 golden-fixture cases (20 fixture dirs x interface/adaptor/proxy).
- **`git diff` shows zero changes under `codegen/src/test/resources/`** — all 66 fixture `.kt` files are byte-identical, which is the proof the extracted config is behaviourally the same as all three copies it replaces.
- **`WRITE_FILES` is still `false`** in `GeneratorTest.kt` (the golden-file rewrite switch), so the assertions are real rather than vacuous.
- `./gradlew ktlintCheck apiCheck` — pass, no API dump change.
- `./gradlew :codegen:build --rerun-tasks` — pass.

Scope: `codegen/src/` only. No build script was touched.

## Deferred (explicitly out of scope)

The issue's optional second half — an end-to-end test that builds the distribution, runs the real CLI into a temp dir and compares to the fixtures by content — was deferred at triage as a materially larger piece of work with its own design questions. Not built here; it remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
