### PR TITLE
build: Gradle 10 readiness — migrate deprecated Kotlin DSL delegate syntax and drop eager tasks.all

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ kotlin {
     }
     applyDefaultHierarchyTemplate()
     sourceSets {
-        val commonMain by getting {
+        getByName("commonMain") {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 // kotlinx-serialization types (KSerializer, the serializer companions) are part
@@ -100,7 +100,7 @@ kotlin {
                 implementation(libs.kotlinx.atomicfu)
             }
         }
-        val jvmMain by getting {
+        getByName("jvmMain") {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
@@ -111,21 +111,21 @@ kotlin {
                 implementation(kotlin("stdlib"))
             }
         }
-        val jvmTest by getting {
+        getByName("jvmTest") {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.mockk)
             }
         }
-        val nativeMain by getting {
+        getByName("nativeMain") {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
                 implementation(kotlin("stdlib"))
             }
         }
-        val nativeTest by getting {
+        getByName("nativeTest") {
             dependencies {
                 implementation(libs.kotlinx.coroutines.test)
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,43 +167,47 @@ fun arm64RuntimeLibDirs(): List<String> = listOf(
     .filter { it.exists() }
     .map { it.absolutePath }
 
-afterEvaluate {
-    tasks.all {
-        val localSystemdLibDir = systemdLibDirForTask(name)
-        (this as? KotlinNativeLink)?.toolOptions {
-            freeCompilerArgs.addAll(overrides)
-            if (localSystemdLibDir != null) {
+// Configured lazily via withType/configureEach rather than an eager `tasks.all`: realizing every
+// task at configuration time also realizes the Kotlin plugin's `build` task, whose creation calls
+// the deprecated Configuration.getTaskDependencyFromProjectDependency (removed in Gradle 10).
+tasks.withType<KotlinNativeLink>().configureEach {
+    val localSystemdLibDir = systemdLibDirForTask(name)
+    toolOptions {
+        freeCompilerArgs.addAll(overrides)
+        if (localSystemdLibDir != null) {
+            freeCompilerArgs.addAll(
+                listOf(
+                    "-linker-option",
+                    "-L$localSystemdLibDir",
+                    "-linker-option",
+                    "-Wl,-rpath,$localSystemdLibDir"
+                )
+            )
+        }
+        if (name.contains("LinuxArm64", ignoreCase = true)) {
+            freeCompilerArgs.addAll(
+                listOf(
+                    "-linker-option",
+                    "-Wl,--allow-shlib-undefined"
+                )
+            )
+            arm64RuntimeLibDirs().forEach { armLibDir ->
                 freeCompilerArgs.addAll(
                     listOf(
                         "-linker-option",
-                        "-L$localSystemdLibDir",
+                        "-L$armLibDir",
                         "-linker-option",
-                        "-Wl,-rpath,$localSystemdLibDir"
+                        "-Wl,-rpath-link,$armLibDir"
                     )
                 )
             }
-            if (name.contains("LinuxArm64", ignoreCase = true)) {
-                freeCompilerArgs.addAll(
-                    listOf(
-                        "-linker-option",
-                        "-Wl,--allow-shlib-undefined"
-                    )
-                )
-                arm64RuntimeLibDirs().forEach { armLibDir ->
-                    freeCompilerArgs.addAll(
-                        listOf(
-                            "-linker-option",
-                            "-L$armLibDir",
-                            "-linker-option",
-                            "-Wl,-rpath-link,$armLibDir"
-                        )
-                    )
-                }
-            }
         }
-        (this as? KotlinNativeCompile)?.compilerOptions {
-            freeCompilerArgs.addAll(overrides)
-        }
+    }
+}
+
+tasks.withType<KotlinNativeCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.addAll(overrides)
     }
 }
 
@@ -321,23 +325,23 @@ license {
     ext["email"] = "monkopedia@gmail.com"
 }
 
-afterEvaluate {
-    tasks.findByName("licenseCheckForKotlin")?.let {
-        tasks.all {
-            if ((this.name.startsWith("ktlint") && this.name.endsWith("Check")) ||
-                (this.name.startsWith("transform") && this.name.endsWith("Metadata")) ||
-                (this.name.startsWith("compile") && this.name.contains("Kotlin")) ||
-                this.name.startsWith("link") ||
-                this.name == "copyLib" ||
-                this.name.endsWith("Test") ||
-                this.name.endsWith("Tests") ||
-                this.name == "processTestResources" ||
-                this.name == "test"
-            ) {
-                it.dependsOn(this)
-            }
+// `tasks.matching { }` is a live, lazily-realized view, so — unlike the eager `tasks.all { }` this
+// replaces — the task container is only walked when licenseCheckForKotlin is actually in the graph
+// instead of on every single invocation.
+tasks.named("licenseCheckForKotlin") {
+    dependsOn(
+        tasks.matching { task ->
+            (task.name.startsWith("ktlint") && task.name.endsWith("Check")) ||
+                (task.name.startsWith("transform") && task.name.endsWith("Metadata")) ||
+                (task.name.startsWith("compile") && task.name.contains("Kotlin")) ||
+                task.name.startsWith("link") ||
+                task.name == "copyLib" ||
+                task.name.endsWith("Test") ||
+                task.name.endsWith("Tests") ||
+                task.name == "processTestResources" ||
+                task.name == "test"
         }
-    }
+    )
 }
 allprojects {
     if (name == "compile_test") return@allprojects

--- a/compile_test/build.gradle.kts
+++ b/compile_test/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
     }
     applyDefaultHierarchyTemplate()
     sourceSets {
-        val nativeMain by getting {
+        getByName("nativeMain") {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)
@@ -34,7 +34,7 @@ kotlin {
                 implementation(project(":"))
             }
         }
-        val nativeTest by getting {
+        getByName("nativeTest") {
             dependencies {
                 implementation(libs.kotlinx.coroutines.test)
             }

--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -17,18 +17,18 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     sourceSets {
-        val commonMain by getting {
+        getByName("commonMain") {
             dependencies {
                 implementation(project(":"))
             }
         }
-        val commonTest by getting {
+        getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
-        val jvmTest by getting {
+        getByName("jvmTest") {
             dependencies {
                 // dbus-java here is an INDEPENDENT third-party D-Bus peer used by
                 // CrossRuntimeInteropSmokeTest to prove sdbus-kotlin interoperates with another

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -46,7 +46,7 @@ gradlePlugin {
     website = "https://github.com/monkopedia/sdbus-kotlin"
     vcsUrl = "https://github.com/monkopedia/sdbus-kotlin"
 
-    val sdbusPlugin by plugins.creating {
+    plugins.create("sdbusPlugin") {
         id = "com.monkopedia.sdbus.plugin"
         implementationClass = "com.monkopedia.sdbus.plugin.SdbusPlugin"
         displayName = "Sdbus-Kotlin Gradle Plugin"

--- a/stress_test/build.gradle.kts
+++ b/stress_test/build.gradle.kts
@@ -14,18 +14,18 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     sourceSets {
-        val commonMain by getting {
+        getByName("commonMain") {
             dependencies {
                 implementation(project(":"))
             }
         }
-        val commonTest by getting {
+        getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
-        val jvmTest by getting {
+        getByName("jvmTest") {
             dependencies {
                 // dbus-java is an INDEPENDENT third-party D-Bus peer for the cross-runtime interop
                 // stress test — NOT sdbus-kotlin's backend (retired in epic #93 phase 6) and not a


### PR DESCRIPTION
Fixes #164

Two commits, as the issue suggested: the mechanical delegate-syntax migration, then the `Configuration` API one.

## Before / after

`JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew ktlintCheck --warning-mode all`

**Before** (`main` @ `ba62857`) — **15** deprecation warnings:

| File | Lines | Deprecation |
| --- | --- | --- |
| `build.gradle.kts` | 94, 103, 114, 121, 128 | `val name by getting { }` |
| `build.gradle.kts` | 171 | `Configuration.getTaskDependencyFromProjectDependency` |
| `compile_test/build.gradle.kts` | 28, 37 | `val name by getting { }` |
| `cross_test/build.gradle.kts` | 20, 25, 31 | `val name by getting { }` |
| `stress_test/build.gradle.kts` | 17, 22, 28 | `val name by getting { }` |
| `plugin/build.gradle.kts` | 49 | `val name by creating { }` |

**After** — **0**. Not just for `ktlintCheck`; deprecation count is 0 for every invocation I could think of that walks the task graph:

```
### gradlew help                             0 deprecations
### gradlew build --dry-run                  0 deprecations
### gradlew license --dry-run                0 deprecations
### gradlew licenseCheckForKotlin --dry-run  0 deprecations
### gradlew tasks --all                      0 deprecations
### gradlew publishToMavenLocal --dry-run    0 deprecations
```

Nothing was left out of scope — there are no other Gradle-10 deprecations in this build. `codegen` had no affected call sites, and no file under `codegen/` is touched (concurrent work on #163/#166/#167).

Note the issue's table listed only the root + `compile_test` sites (7). The identical warning is emitted from `cross_test`, `stress_test` and `plugin` too, so those are migrated here as well — otherwise the stated goal (a build clean under `--warning-mode all`) isn't met and the next real deprecation still gets lost in noise.

## Commit 1 — delegate syntax

`val name by getting { }` → `getByName("name") { }`, and `val sdbusPlugin by plugins.creating { }` → `plugins.create("sdbusPlugin") { }`.

The Gradle guide's suggested form is `val element = getByName(name) { }`, but none of the delegated `val`s were referenced anywhere, so they're dropped rather than kept as unused locals.

## Commit 2 — `Configuration.getTaskDependencyFromProjectDependency`

**This one is not our call.** `--stacktrace` puts it inside the Kotlin Gradle Plugin, not the build script:

```
DefaultConfiguration.getTaskDependencyFromProjectDependency(DefaultConfiguration.java:852)
ConfigureBuildSideEffectKt$addDependsOnTaskInOtherProjects$1.execute(ConfigureBuildSideEffect.kt:35)
  ... DefaultNamedDomainObjectCollection$AbstractDomainObjectCreatingProvider.tryCreate
  ... DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:169)
Build_gradle$4.execute(build.gradle.kts:171)
```

KGP registers that side effect to run on task creation. `build.gradle.kts:171` is `tasks.all { }`, which eagerly realizes *every* task during configuration — including the one whose creation triggers KGP's deprecated call. So there is no API to swap on our side; what the build script contributes is forcing KGP's call to happen on every single invocation.

Confirmed by removing the eager enumerations: the warning disappears entirely, including from `build` and `tasks --all`. So this fix does genuinely remove it rather than defer it. (If a future KGP still calls the deprecated method from a path we do reach, that's a JetBrains-side fix and out of our hands — but today nothing in this build reaches it.)

Two eager `tasks.all { }` blocks are replaced:

1. **Native compiler/linker args** → `tasks.withType<KotlinNativeLink>().configureEach { }` + `tasks.withType<KotlinNativeCompile>().configureEach { }`. This also drops the `(this as? KotlinNativeLink)?` / `(this as? KotlinNativeCompile)?` casts and the surrounding `afterEvaluate`, which `configureEach` makes redundant. (Fixing only this one made the warning move to the second `tasks.all` — hence both.)
2. **`licenseCheckForKotlin` wiring** → `tasks.named("licenseCheckForKotlin") { dependsOn(tasks.matching { … }) }`. Same predicate, same direction; `matching` is a live view, so the container is walked only when that task is actually in the graph.

### Evidence the wiring is preserved

- `./gradlew licenseCheckForKotlin --dry-run` produces a **byte-identical 125-task graph** before and after (`diff` clean).
- Full `./gradlew :dependencies :compile_test:dependencies :cross_test:dependencies :stress_test:dependencies` report: **zero added lines**, and every removed line belongs to a `dokka*` configuration block. Excluding those blocks, the two reports differ only in 11 blank separator lines — every source-set / publication configuration is unchanged.
  The `dokka*` configurations are absent from the *report* only because they're now created when their tasks are realized rather than by our force-realizing everything; the publish graph still contains `dokkaGeneratePublicationHtml`, `jvmDokkaJavadocJar`, `kotlinMultiplatformDokkaJavadocJar`, `linuxX64DokkaJavadocJar`, `linuxArm64DokkaJavadocJar`, and `dokkaGeneratePublicationHtml` runs green.
- The `KotlinNativeLink` block is the arm64 cross-link wiring (`-Xoverride-konan-properties`, `-L`/`-rpath`, `--allow-shlib-undefined`), which only fails loudly if it stops being applied — `linkDebugSharedLinuxArm64` and the CI binaries `:linkDebugTestLinuxX64 :linkDebugTestLinuxArm64` all build green.

## Verification

- `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64` — green
- `./gradlew ktlintCheck apiCheck` — green, and **`apiCheck` produced no diff**: `git status` shows no change under `api/` (only build scripts are modified in this PR)
- `./gradlew :linkDebugTestLinuxX64 :linkDebugTestLinuxArm64 :compile_test:build :cross_test:compileKotlinJvm :cross_test:compileTestKotlinLinuxX64 :stress_test:compileTestKotlinJvm :plugin:build` — green
- `./gradlew dokkaGeneratePublicationHtml` — green
- `./gradlew publishToMavenLocal --dry-run` — green

Not run locally (needs a session bus / hardware, left to CI): `jvmTest`, `linuxX64Test`, the dbusmock cross suites, and the BlueZ sample suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
