### PR TITLE
build(codegen): scope xmlutil as implementation rather than api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to sdbus-kotlin are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed — dependencies
+
+- **xmlutil** is now `implementation`-scoped rather than `api`-scoped in `sdbus-kotlin-codegen`. It is
+  used only inside the introspection-XML parser and appears in zero public signatures, so it no longer
+  takes part in consumers' compile-classpath resolution — it stays on the runtime classpath, where the
+  tool actually needs it. The binary-compatibility surface is unchanged. This is a small source-breaking
+  change for anyone who relied on xmlutil being transitively available at compile time through
+  `sdbus-kotlin-codegen` or the `com.monkopedia.sdbus.plugin` Gradle plugin; declare it directly instead.
+  (#167)
+
 ## [1.0.1] - 2026-07-15
 
 A maintenance release: refreshed external dependencies to their latest stable versions. There are

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    api(libs.xmlutil)
+    implementation(libs.xmlutil)
     api(libs.clikt)
     api(libs.kotlinpoet)
     testImplementation(project(":"))


### PR DESCRIPTION
Fixes #167

`codegen/build.gradle.kts:20` declared `api(libs.xmlutil)`, but xmlutil appears in **zero** public signatures of `:codegen` — it is used only inside `Xml2Kotlin`/`XmlFormat` to parse introspection XML. `api` scope is for dependencies whose types leak into your own API, so this made xmlutil a transitive part of the compile classpath of anyone consuming `sdbus-kotlin-codegen` (or, via `api(project(":codegen"))`, the Gradle plugin), where it could force a resolution bump on a project pinning its own older xmlutil.

One line changed: `api(libs.xmlutil)` -> `implementation(libs.xmlutil)`.

## Classpath evidence (before / after)

`./gradlew :plugin:dependencies --configuration compileClasspath` — `:plugin` is a real downstream consumer of `:codegen`, so this shows exactly what the scoping change does to a consumer.

**Before** — xmlutil arrives transitively on the *compile* classpath:

```
compileClasspath - Compile classpath for 'main'.
+--- project ':codegen'
|    +--- io.github.pdvrieze.xmlutil:serialization:1.0.1
|    |    \--- io.github.pdvrieze.xmlutil:serialization-jvm:1.0.1
|    |         +--- io.github.pdvrieze.xmlutil:core:1.0.1
|    |         |    \--- io.github.pdvrieze.xmlutil:core-jvm:1.0.1
...
```

**After** — xmlutil is gone from the compile classpath entirely (`grep -c xmlutil`: 4 -> 0):

```
compileClasspath - Compile classpath for 'main'.
+--- project ':codegen'
|    +--- com.github.ajalt.clikt:clikt:5.1.0
...
```

And it is still present on `runtimeClasspath`, where the tool actually needs it (`grep -c xmlutil`: 4 -> 4, unchanged):

```
runtimeClasspath - Runtime classpath of 'main'.
+--- project ':codegen'
|    ...
|    \--- io.github.pdvrieze.xmlutil:serialization:1.0.1
|         \--- io.github.pdvrieze.xmlutil:serialization-jvm:1.0.1
```

That is precisely the claimed effect: off the consumer compile classpath, still on runtime.

## The two things the issue asked to confirm

1. **Nothing was quietly relying on the transitive xmlutil types.** `grep -rn "nl.adaptivity"` across the repo returns hits in `codegen/src/main` (`Xml2Kotlin.kt`, `XmlFormat.kt`) and `codegen/src/test` only — no other module references xmlutil. `:codegen:clean :plugin:clean` followed by `:codegen:build :plugin:build` is green from a clean, which covers both `:plugin`'s compile and codegen's own tests (`testImplementation` extends `implementation`, so the test sources that do use xmlutil still see it).
2. **`apiCheck` is green with no `api/*.api` diff.** `./gradlew ktlintCheck apiCheck` passes and `git status` showed only `codegen/build.gradle.kts` modified — no dump regenerated itself.

Also run: `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64` — green.

## Ruling on `:plugin`'s `api(project(":codegen"))` — left as `api`, deliberately

The issue's reasoning does apply *formally*: `plugin/api/plugin.api` contains zero `:codegen` types. Its whole public surface is `SdbusPlugin`, `SdbusExtension` and `SdbusGenerationTask`, and every signature in it is a Gradle or JDK type; `Xml2Kotlin` is referenced only inside `SdbusGenerationTask.execute()`'s body. So by the letter of "api is for types that leak", it could be `implementation`.

I am **not** changing it, for two reasons:

- **There is no resolution benefit to gain.** Gradle resolves a plugin's classpath (the `plugins {}` / buildscript path, which is how essentially every consumer gets this) as a **runtime** classpath. `api` vs `implementation` on `:plugin`'s dependencies makes no difference to what is resolved there. The xmlutil flip matters because `sdbus-kotlin-codegen` is *also* published as an ordinary JVM library that people compile against; the plugin is not consumed that way.
- **It has a small, real cost.** `:codegen` is a tool the plugin deliberately ships, and a build script or precompiled script plugin invoking `Xml2Kotlin` directly for a one-off generation step is a plausible (if undocumented) use. `api` keeps that available; `implementation` would break it for no gain.

The asymmetry is the point: xmlutil is a **third-party** artifact subject to conflict resolution against a consumer's own pin — the exact hazard #167 describes — whereas `:codegen` is our own artifact reached only through a runtime-resolved plugin classpath.

## CHANGELOG

Added — the issue asked for a line rather than a silent flip, and I agree: consumers who *were* leaning on the transitive compile-time availability will see a source break, even though the binary surface does not move. `CHANGELOG.md` had **no `[Unreleased]` section** (verified — `## [1.0.1] - 2026-07-15` sat directly under the preamble), so this PR adds one, with a `### Changed — dependencies` subsection matching the 1.0.1 style. No link ref is added for `[Unreleased]`; per `CLAUDE.md`'s release checklist the ref is added when the heading is renamed to a version at release time.

## Overlap with the concurrent sibling PRs — verified

- **#168** also edits `codegen/build.gradle.kts`, but only the `mavenPublishing`/`signing` blocks at **lines 104-113**; mine is the dependency declaration at **line 20**. I pulled #168's diff and confirmed the hunks do not overlap textually, so whichever merges second should apply cleanly — but it is the same file, so a rebase check is worth a glance.
- **#170** edits `plugin/build.gradle.kts` and several other build scripts; it does not touch `codegen/build.gradle.kts`.
- **#169** edits `codegen/src/` only.
- None of the three touches `CHANGELOG.md`, so the new `[Unreleased]` section is uncontested.

The xmlutil `XML` builder deprecation warning noted at the end of #167 is **out of scope here** — it is #169's, and `codegen/src/` is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
