### PR TITLE
fix(jvm): guard currentlyProcessedMessage against use after release

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -305,6 +305,29 @@ class FailurePathParityTest {
         assertFailsWith<IllegalArgumentException> {
             connection.methodCallTimeout = 100.milliseconds
         }
+        // currentlyProcessedMessage is the accessor #144 missed: native guards it like every
+        // other op, the JVM backend handed back a fresh empty message instead. #141.
+        assertFailsWith<IllegalArgumentException> { connection.currentlyProcessedMessage }
+        Unit
+    }
+
+    // The Object/Proxy currentlyProcessedMessage accessors both read through to the owning
+    // connection on native (ObjectImpl/ProxyImpl delegate to ConnectionImpl), so releasing the
+    // connection makes all three throw. On the JVM backend they answered from a thread-local
+    // dispatch context and fell back to a fresh empty message, so a released connection kept
+    // handing out messages. #141.
+    @Test
+    fun currentlyProcessedMessageAfterReleaseThrowsOnBothBackends() = runBlocking {
+        val ids = uniqueFixtureIds("currentMsg")
+        val connection = createBusConnection(ids.service)
+        val obj = createObject(connection, ids.path)
+        val proxy = createProxy(connection, ids.service, ids.path, runEventLoopThread = false)
+
+        connection.release()
+
+        assertFailsWith<IllegalArgumentException> { connection.currentlyProcessedMessage }
+        assertFailsWith<IllegalArgumentException> { obj.currentlyProcessedMessage }
+        assertFailsWith<IllegalArgumentException> { proxy.currentlyProcessedMessage }
         Unit
     }
 

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -106,13 +106,15 @@ internal class WireDbusBackend : JvmDbusBackend {
         // D-Bus SIGNAL the bus routes to all subscribers (external processes AND same-JVM
         // connections, each via its own AddMatch) -- uniform with the native backend, and the only
         // way a receiver can resolve our sender credentials off the bus.
-        val wire = ((connection as? JvmConnection)?.backend as? WireDbusConnection)?.wireConnection
+        val wireConnection = (connection as? JvmConnection)?.backend as? WireDbusConnection
             ?: throw createError(-1, "createObject failed: connection has no wire transport")
+        val wire = wireConnection.wireConnection
         val emitter =
             WireSignalEmitter { path, interfaceName, member, signature, payload, destination ->
                 emitWireSignal(wire, path, interfaceName, member, signature, payload, destination)
             }
         return WireDbusObject(
+            wireConnection,
             objectPath,
             runCatching { connection.uniqueName.value }.getOrNull(),
             emitter
@@ -185,8 +187,10 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
 
     override suspend fun stopEventLoop() = checkNotReleased()
 
-    override fun currentlyProcessedMessage(): Message =
-        JvmCurrentMessageContext.current() ?: createPlainMessage()
+    override fun currentlyProcessedMessage(): Message {
+        checkNotReleased()
+        return JvmCurrentMessageContext.current() ?: createPlainMessage()
+    }
 
     override fun setMethodCallTimeout(timeout: Duration): Unit = run {
         checkNotReleased()
@@ -255,8 +259,12 @@ internal class WireDbusProxy(
     // Signal handlers registered through this proxy, released together on release() (native parity).
     private val signalRegistrations = CopyOnWriteArrayList<Resource>()
 
-    override fun currentlyProcessedMessage(): Message =
-        JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
+    override fun currentlyProcessedMessage(): Message {
+        // Native's ProxyImpl reads through to the connection, which rejects use after release()
+        // (ConnectionImpl.checkNotReleased). Parity #141.
+        require(connection?.isReleased() != true) { "Connection has already been released" }
+        return JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
+    }
 
     override fun createMethodCall(
         interfaceName: InterfaceName,

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
@@ -51,6 +51,7 @@ internal fun interface WireSignalEmitter {
  * via [wireSignalEmitter], uniform with the native backend.
  */
 internal class WireDbusObject(
+    private val connection: WireDbusConnection,
     private val objectPath: ObjectPath,
     private val senderName: String?,
     private val wireSignalEmitter: WireSignalEmitter
@@ -332,8 +333,12 @@ internal class WireDbusObject(
         }
     }
 
-    override fun currentlyProcessedMessage(): Message =
-        JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
+    override fun currentlyProcessedMessage(): Message {
+        // Native's ObjectImpl reads through to the connection, which rejects use after release()
+        // (ConnectionImpl.checkNotReleased). Parity #141.
+        require(!connection.isReleased()) { "Connection has already been released" }
+        return JvmCurrentMessageContext.current() ?: signalFromMetadata(Message.Metadata())
+    }
 
     override fun addVTable(interfaceName: InterfaceName, vtable: List<VTableItem>): Resource {
         registeredInterfaces[interfaceName.value] =


### PR DESCRIPTION
Refs #141 — first of the four in-scope items from the 2026-07-31 triage re-scope.

## The divergence

Native guards every connection op with `ConnectionImpl.checkNotReleased()`, and that includes `currentlyProcessedMessage`. `ObjectImpl.currentlyProcessedMessage` and `ProxyImpl.currentlyProcessedMessage` both just read through to the connection, so on native all three accessors throw `IllegalArgumentException("Connection has already been released")` once the connection is released.

The JVM wire backend was missed by the #144 hardening sweep. All three answered from the thread-local dispatch context (`JvmCurrentMessageContext.current()`) and fell back to a fresh empty message, so a released connection kept handing out `Message` objects indefinitely.

## Red-first evidence

Test added to the existing cross-backend `FailurePathParityTest`, run BEFORE the production change:

`./gradlew :jvmTest --tests "*FailurePathParityTest.currentlyProcessedMessageAfterReleaseThrowsOnBothBackends"`

```
FailurePathParityTest[jvm] > currentlyProcessedMessageAfterReleaseThrowsOnBothBackends[jvm] FAILED
java.lang.AssertionError: Expected an exception of class java.lang.IllegalArgumentException
to be thrown, but was completed successfully with the result: <com.monkopedia.sdbus.PlainMessage@71c27ee8>.
```

The same assertion appended to `connectionOperationsAfterReleaseThrowOnBothBackends` also failed before the fix, with the identical message.

`./gradlew :linuxX64Test --tests "*FailurePathParityTest.currentlyProcessedMessageAfterReleaseThrowsOnBothBackends"` was **green on native at that same commit** — i.e. the test pins a real one-sided divergence, not a tautology.

## The fix

The same `require(!released) { "Connection has already been released" }` guard already used elsewhere in the wire backend, applied to the three accessors:

- `WireDbusConnection.currentlyProcessedMessage()` — `checkNotReleased()` (the existing private helper).
- `WireDbusProxy.currentlyProcessedMessage()` — the proxy already held its `WireDbusConnection` for the `callMethod` guard added in #144; this reuses it.
- `WireDbusObject.currentlyProcessedMessage()` — `WireDbusObject` previously kept only the owning connection's unique-name string, so it now takes the `WireDbusConnection` itself. Single construction site (`WireDbusBackend.createObject`), which already resolved that object.

## Verification

- `dbus-run-session -- ./gradlew :jvmTest :linuxX64Test` — BUILD SUCCESSFUL (full root suites, both backends).
- `FailurePathParityTest` specifically: 11/11 green on jvm, green on linuxX64.
- `./gradlew ktlintCheck apiCheck compileKotlinLinuxArm64` — BUILD SUCCESSFUL.

**`apiCheck` did NOT move.** Everything touched is `internal`; no public surface change, so neither `api/sdbus-kotlin.api` nor `api/sdbus-kotlin.klib.api` needed a regen. No consumer-visible ABI change for `blue-falcon-sdbus`.

## Scope note

The triage comment scoped this item as "the one accessor that was missed". It is three accessors on the JVM side because native reaches the same guard through one — `Object`/`Proxy` delegate to the connection there, so fixing only `Connection` on JVM would have left two-thirds of the same divergence in place. Same one-line guard, same test.
