### PR TITLE
docs: state the startEventLoop backend asymmetry on the public API

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -316,6 +316,13 @@ Consequence: explicit `startEventLoop()` is no longer a footgun — `createObjec
 auto-start it on native and it is a free no-op on JVM, while a redundant call is idempotent on
 both (`EventLoopStartIdempotencyTest.createObjectAutoStartsLoop_andRepeatedStartEventLoopIsIdempotent`).
 You can still call it explicitly after registering handlers on a bare connection.
+
+The asymmetry only bites in the *omitted* direction, and it is **documented rather than tested**
+(#141): a client that registers a signal handler on a bare connection and never starts the loop
+receives the signal on JVM and receives nothing on native. That makes the "loop required" contract
+untestable as a single cross-backend assertion — the same test is green on JVM and times out on
+native — so it is stated on `Connection.startEventLoop`'s KDoc instead, where a consumer reading
+the API docs will see it.
 `currentlyProcessedMessage` is valid inside handlers on both backends
 (`CommonApiIntegrationTest.signalHandler_exposesCurrentlyProcessedMessageOnProxy`,
 `propertySetter_exposesCurrentlyProcessedMessageOnObject`).
@@ -366,7 +373,9 @@ matched (they don't affect cross-process usage):
 - Two brokerless **direct** connections in one JVM share a synthetic `uniqueName` (`":jvm-wire"`),
   and objects they export at the same path can clobber each other in the local dispatch table.
 - `startEventLoop()` is a no-op on JVM (the reader thread auto-starts at connect), where native
-  requires it to receive — a JVM proxy can receive signals without it; native cannot.
+  requires it to receive — a JVM proxy can receive signals without it; native cannot. Stated on
+  `Connection.startEventLoop`/`stopEventLoop` so it reaches the API docs; see "Event loop
+  semantics" above for why it is not pinned by a test.
 - `Properties.GetAll` on an interface the object doesn't implement returns an empty `a{sv}` on JVM,
   where native returns an error.
 - A same-process `UnixFd` argument is passed by reference (not dup'd) on the local short-circuit,

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
@@ -41,7 +41,17 @@ interface Connection : Resource {
      *
      * The loop runs in a separate, internally managed thread, processing incoming
      * and outgoing D-Bus messages, so this call does not block. The loop runs until
-     * [stopEventLoop] is called or the connection is released.
+     * [stopEventLoop] is called or the connection is released. Repeated calls are idempotent —
+     * a connection never runs more than one loop.
+     *
+     * **Call it, even though only one backend needs it.** On the native (sd-bus) backend the loop
+     * *is* the dispatcher: a proxy on a connection whose loop was never started receives no
+     * signals and no async replies. On the JVM backend the owned wire connection reads and
+     * dispatches on its own threads from the moment it connects, so this call is a no-op and
+     * messages arrive whether or not it was made. Code that omits it therefore works on JVM and
+     * silently receives nothing on native — so start the loop (or leave `runEventLoopThread` at
+     * its `true` default on [createObject]/[createProxy], which starts it for you) in code meant
+     * to be portable. See `docs/BACKENDS.md` ("Event loop semantics").
      */
     fun startEventLoop()
 
@@ -50,6 +60,10 @@ interface Connection : Resource {
      *
      * This causes the loop started by [startEventLoop] to exit, and frees the
      * thread serving the loop
+     *
+     * The mirror image of the asymmetry described on [startEventLoop]: stopping the loop stops
+     * dispatch on native, while on JVM this is a no-op and dispatch continues until the
+     * connection is released.
      *
      * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */


### PR DESCRIPTION
Refs #141 — item 1 of the three remaining in-scope items from the 2026-07-31 triage re-scope.

## The choice the issue offers, and why I picked "document"

The issue offers *"add a cross-backend test that pins the 'loop required' contract, **or** document the asymmetry."* I measured the asymmetry first, and the measurement is itself the argument for documenting: **the cross-backend test cannot exist.** The same test is a pass on one backend and a timeout on the other, so any single assertion would be asserting a fiction on whichever backend it did not describe.

## Measured evidence (throwaway test, not committed)

A client that registers a signal handler on a bare connection and **never calls `startEventLoop()`** (`createProxy(..., runEventLoopThread = false)`), server emits, client waits 3s:

```
> Task :jvmTest
BUILD SUCCESSFUL in 7s
```
(stdout: `MEASURE: signal DELIVERED without startEventLoop -> 7`)

```
com.monkopedia.sdbus.integration.ZzMeasureEventLoopTest.signalWithoutStartEventLoop[linuxX64] FAILED
    kotlinx.coroutines.TimeoutCancellationException at null:-1

> Task :linuxX64Test FAILED
1 test completed, 1 failed
```

Same source file, same fixture, same commit: green on `jvmTest`, timeout on `linuxX64Test`. So:

- A test asserting *"no signal without the loop"* (native's contract) fails on JVM.
- A test asserting *"signal arrives without the loop"* passes on JVM but fails on native — **and it would freeze the divergence as a contract**, which is the wrong thing to do to a gap we may later want to close.

The only remaining shape is a per-backend expectation flag, i.e. a test that asserts the divergence rather than a contract. That is the "green for the wrong reason" problem restated, not a fix for it, so I did not commit one. The measurement file was deleted after the run.

## What changed

Doc only — **no behavior change, no test change, no production code change.**

`docs/BACKENDS.md` already recorded the asymmetry (it is in the "JVM limitations at a glance" list). What it did *not* reach is the **public API docs**: `Connection.startEventLoop`'s KDoc described only the native behaviour ("The loop runs in a separate, internally managed thread…"), so a consumer reading dokka had no way to learn that omitting the call is a native-only footgun.

- `src/commonMain/.../Connection.kt` — `startEventLoop` KDoc now states the contract and the asymmetry: on native the loop *is* the dispatcher, on JVM it is a no-op because the wire connection dispatches from connect time, therefore portable code must still call it (or leave `runEventLoopThread = true`). `stopEventLoop` gets the one-line mirror image.
- `docs/BACKENDS.md` — "Event loop semantics" now records *why* this is documented rather than tested, and the limitations bullet cross-references the KDoc.

## Verification

- `./gradlew ktlintCheck apiCheck compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64` — BUILD SUCCESSFUL.
- **`apiCheck` did NOT move.** KDoc is not part of the ABI; neither `api/sdbus-kotlin.api` nor `api/sdbus-kotlin.klib.api` needed a regen, so there is no consumer-visible change for `blue-falcon-sdbus`.
