### PR TITLE
fix(jvm): give each brokerless direct connection its own unique name

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -274,6 +274,11 @@ There are 11 `create*Connection` entry points — 10 declared in the common API
   JVM backend rejects the fd-based bus types (`JvmBusType.DIRECT_FD`/`SERVER_FD`, in
   `WireDbusBackend.createConnection`).
   On native they adopt the descriptor as documented in their KDoc.
+- A **brokerless direct connection** has no daemon to run `Hello` against, so neither backend gets
+  a bus-assigned unique name for it. The JVM backend synthesizes one **per connection**
+  (`":jvm-wire-<n>"`) — the in-process registries are keyed by it, so two direct connections in one
+  JVM keep separate identities and objects they export at the same path no longer clobber each
+  other (#141, pinned by `src/jvmTest/.../JvmDirectConnectionIdentityTest.kt`).
 - `createRemoteSystemBusConnection(host)` is **native-only and not declared in the common
   or JVM API** (it lives in `src/nativeMain/.../Connection.native.kt`). It opens the system
   bus of a remote host over ssh via sd-bus (`sd_bus_open_system_remote`, which spawns
@@ -363,8 +368,6 @@ cross-backend regression tests).
 A few **same-process / direct-connection** edges remain JVM-specific and are documented rather than
 matched (they don't affect cross-process usage):
 
-- Two brokerless **direct** connections in one JVM share a synthetic `uniqueName` (`":jvm-wire"`),
-  and objects they export at the same path can clobber each other in the local dispatch table.
 - `startEventLoop()` is a no-op on JVM (the reader thread auto-starts at connect), where native
   requires it to receive — a JVM proxy can receive signals without it; native cannot.
 - `Properties.GetAll` on an interface the object doesn't implement returns an empty `a{sv}` on JVM,

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -28,6 +28,7 @@ import com.monkopedia.sdbus.signalFromMetadata
 import java.io.IOException
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.thread
 import kotlin.time.Duration
 
@@ -158,8 +159,17 @@ private fun emitWireSignal(
     }
 }
 
+// A brokerless DIRECT connection is not told a unique name — there is no daemon to run Hello
+// against — but the in-process registries (JvmStaticDispatch, WireServeRegistry,
+// LocalObjectManagerRegistry, ...) are all keyed by it. Every such connection used to answer with
+// the same constant ":jvm-wire", so two of them in one JVM shared one identity and objects they
+// exported at the same path clobbered each other in the dispatch table. Give each its own name
+// instead. #141.
+private val directConnectionCounter = AtomicLong()
+
 internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbusConnection {
-    private val localUniqueName: String = wire.uniqueName.orEmpty()
+    private val localUniqueName: String =
+        wire.uniqueName ?: ":jvm-wire-${directConnectionCounter.incrementAndGet()}"
     private val released = AtomicBoolean(false)
     private var timeout: Duration = Duration.ZERO
 
@@ -209,7 +219,7 @@ internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbu
 
     override fun uniqueName(): BusName {
         checkNotReleased()
-        return BusName(localUniqueName.ifEmpty { ":jvm-wire" })
+        return BusName(localUniqueName)
     }
 
     override fun requestName(name: ServiceName, flags: UInt): RequestNameReply {

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmDirectConnectionIdentityTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmDirectConnectionIdentityTest.kt
@@ -1,0 +1,143 @@
+package com.monkopedia.sdbus
+
+import java.io.Closeable
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * A brokerless DIRECT connection has no daemon to hand it a unique name, and the JVM backend used
+ * to substitute one shared constant (`":jvm-wire"`) for every such connection. Since the in-process
+ * dispatch table is keyed by that name, two direct connections in one JVM shared an identity and
+ * objects they exported at the same path clobbered each other. Parity item from #141.
+ */
+class JvmDirectConnectionIdentityTest {
+
+    @Test
+    fun twoDirectConnectionsHaveDistinctUniqueNames() {
+        DirectPeer().use { first ->
+            DirectPeer().use { second ->
+                val a = createDirectBusConnection(first.address)
+                val b = createDirectBusConnection(second.address)
+                try {
+                    assertNotEquals(b.uniqueName, a.uniqueName)
+                } finally {
+                    a.release()
+                    b.release()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun objectsOnTwoDirectConnectionsDoNotClobberEachOther() {
+        val path = ObjectPath("/com/monkopedia/sdbus/direct")
+        val iface = InterfaceName("com.monkopedia.sdbus.direct.Iface")
+        val whoAmI = MethodName("WhoAmI")
+
+        DirectPeer().use { first ->
+            DirectPeer().use { second ->
+                val a = createDirectBusConnection(first.address)
+                val b = createDirectBusConnection(second.address)
+                val objA = createObject(a, path)
+                val objB = createObject(b, path)
+                val regA = objA.addVTable(iface) {
+                    method(whoAmI) { call<String> { "a" } }
+                }
+                val regB = objB.addVTable(iface) {
+                    method(whoAmI) { call<String> { "b" } }
+                }
+                val proxyA = createProxy(a, ServiceName(a.uniqueName.value), path)
+                val proxyB = createProxy(b, ServiceName(b.uniqueName.value), path)
+
+                try {
+                    // Each connection must reach its OWN object; before the fix both registered
+                    // under ":jvm-wire", so the second export overwrote the first and both proxies
+                    // answered "b".
+                    assertEquals("a", proxyA.callMethod<String>(iface, whoAmI) { call() })
+                    assertEquals("b", proxyB.callMethod<String>(iface, whoAmI) { call() })
+                } finally {
+                    proxyA.release()
+                    proxyB.release()
+                    regA.release()
+                    regB.release()
+                    objA.release()
+                    objB.release()
+                    a.release()
+                    b.release()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A minimal brokerless D-Bus peer: an AF_UNIX listener that completes the SASL EXTERNAL handshake
+ * (`NUL` / `AUTH` / `NEGOTIATE_UNIX_FD` / `BEGIN`) and then stays silent. Enough for
+ * [createDirectBusConnection] to establish a direct connection, which — unlike a bus connection —
+ * never sends `Hello`.
+ */
+private class DirectPeer : Closeable {
+    private val directory: Path = Files.createTempDirectory("sdbus-direct")
+    private val socketPath: Path = directory.resolve("peer")
+    private val listener: ServerSocketChannel =
+        ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            .apply { bind(UnixDomainSocketAddress.of(socketPath)) }
+
+    val address: String = "unix:path=$socketPath"
+
+    private val acceptor = thread(start = true, isDaemon = true, name = "sdbus-test-direct-peer") {
+        while (true) {
+            val channel = try {
+                listener.accept()
+            } catch (_: IOException) {
+                return@thread
+            }
+            thread(start = true, isDaemon = true, name = "sdbus-test-direct-peer-sasl") {
+                runCatching { handshake(channel) }
+            }
+        }
+    }
+
+    private fun handshake(channel: SocketChannel) {
+        val input = Channels.newInputStream(channel)
+        val output = Channels.newOutputStream(channel)
+        fun readLine(): String = buildString {
+            while (!endsWith("\r\n")) {
+                val c = input.read()
+                if (c < 0) return@buildString
+                append(c.toChar())
+            }
+        }.removeSuffix("\r\n")
+        fun writeLine(line: String) {
+            output.write("$line\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.flush()
+        }
+
+        input.read() // the mandatory leading NUL
+        readLine() // AUTH EXTERNAL <uid>
+        writeLine("OK 0123456789abcdef0123456789abcdef")
+        readLine() // NEGOTIATE_UNIX_FD
+        writeLine("AGREE_UNIX_FD")
+        readLine() // BEGIN
+        // The client sends no further traffic on a direct connection it does not call over, and
+        // this peer never initiates any, so the socket just idles until the test closes it.
+    }
+
+    override fun close() {
+        runCatching { listener.close() }
+        acceptor.join(1_000)
+        runCatching { Files.deleteIfExists(socketPath) }
+        runCatching { Files.deleteIfExists(directory) }
+    }
+}


### PR DESCRIPTION
Refs #141 — item 4 of the three remaining in-scope items from the 2026-07-31 triage re-scope.

## The divergence

A brokerless **direct** (peer-to-peer) connection never runs `Hello` — there is no daemon to run it against — so `DBusWireConnection.uniqueName` is `null` for one. `WireDbusConnection` filled that hole with a **shared constant**:

```kotlin
private val localUniqueName: String = wire.uniqueName.orEmpty()
...
override fun uniqueName(): BusName = BusName(localUniqueName.ifEmpty { ":jvm-wire" })
```

That name is not cosmetic — it is the **key of every in-process registry**: `JvmStaticDispatch`, `WireServeRegistry`, `LocalObjectManagerRegistry`, `LocalJvmServiceRegistry`. So two direct connections in one JVM were one identity: exporting an object at the same path from both meant the second `JvmStaticDispatch.register` **overwrote** the first, and *both* connections' proxies then reached the survivor. Native has no such constant, so there is nothing on that side to diverge from — this is a JVM-internal identity bug, which is why triage scoped it as "a bug fix, not a contract change".

## Red-first evidence

New test `src/jvmTest/.../JvmDirectConnectionIdentityTest.kt`, run on the **unmodified** backend (the exact committed test source, with only `WireDbusBackend.kt` reverted):

```
> Task :jvmTest FAILED
JvmDirectConnectionIdentityTest[jvm] > twoDirectConnectionsHaveDistinctUniqueNames[jvm] FAILED
JvmDirectConnectionIdentityTest[jvm] > objectsOnTwoDirectConnectionsDoNotClobberEachOther[jvm] FAILED
2 tests completed, 2 failed
```

with, from `build/test-results/jvmTest/TEST-...JvmDirectConnectionIdentityTest.xml`:

```
message="java.lang.AssertionError: Values should be different. Actual: :jvm-wire"
message="org.junit.ComparisonFailure: expected:<[a]> but was:<[b]>"
```

The second one is the consequence, not just the symptom: connection **A**'s proxy, addressed to A's own unique name, was served by connection **B**'s object.

Both pass after the fix; the full `jvmTest` and `linuxX64Test` suites pass.

### Why this test is JVM-only rather than cross-backend

The epic's method is cross-backend-red-first, and I could not make this one cross-backend honestly: the divergent value (`":jvm-wire"`) is a JVM-internal invention with no native counterpart, and a shared fixture is impossible in either direction — the JVM backend has no fd-based direct factories (`createDirectBusConnection(fd)`/`createServerBusConnection(fd)` are `@Deprecated(ERROR)` there), while native's direct-connection fixture is fd-based. The test therefore lives in `jvmTest` and proves the JVM behaviour before and after directly.

The test brings its own peer: `DirectPeer` is a ~40-line AF_UNIX listener (pure JDK `ServerSocketChannel`/`UnixDomainSocketAddress`, no new dependency) that completes the SASL EXTERNAL handshake and then idles — exactly enough for `createDirectBusConnection` to establish a direct connection, which sends nothing else on its own.

## The fix

```kotlin
private val directConnectionCounter = AtomicLong()
...
private val localUniqueName: String =
    wire.uniqueName ?: ":jvm-wire-${directConnectionCounter.incrementAndGet()}"
```

and `uniqueName()` returns it verbatim (the `ifEmpty` fallback is gone — `localUniqueName` can no longer be empty).

Bus connections are untouched: they have a daemon-assigned name, so `wire.uniqueName` is non-null and nothing about them changes.

One side effect worth naming, because it is a second latent bug the same constant was hiding: on a direct connection, objects were **registered** under `dispatchDestination` (`":jvm-wire"`, read back through `connection.uniqueName`) but **served** under `localUniqueName` (`""`), so `WireServe`'s registration and serve keys did not match. With a single non-empty name for both, they now do.

## Verification

- `dbus-run-session -- ./gradlew jvmTest linuxX64Test` — BUILD SUCCESSFUL (full root suites, both backends).
- `./gradlew ktlintCheck apiCheck compileKotlinLinuxArm64` — BUILD SUCCESSFUL.
- **`apiCheck` did NOT move.** `WireDbusConnection` is `internal`; no public surface change, so neither `api/sdbus-kotlin.api` nor `api/sdbus-kotlin.klib.api` needed a regen and there is no consumer-visible ABI change for `blue-falcon-sdbus`.

`docs/BACKENDS.md` is updated in step: the "two direct connections share `":jvm-wire"`" entry is removed from the JVM-limitations list and the per-connection synthetic name is documented with the connection factories.
