### PR TITLE
fix(jvm): enumerate standard interfaces in no-arg InterfacesAdded/Removed

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -183,7 +183,15 @@ unsubscribe/re-subscribe lifecycle, and sender filtering behave identically.
 the deeply nested `a{oa{sa{sv}}}` shape, `InterfacesAdded`/`InterfacesRemoved` emission and
 consumption, and the `ObjectManagerProxy` reactive state flows behave identically.
 
+The **no-argument** `emitInterfacesAddedSignal()`/`emitInterfacesRemovedSignal()` map onto
+`sd_bus_emit_object_added`/`_removed`, so on both backends they enumerate the object's *standard*
+interfaces alongside its vtables — `org.freedesktop.DBus.Peer`, `.Introspectable` and `.Properties`
+always (with empty property maps), plus `.ObjectManager` when one is installed at that path
+(#141). The explicit-list overloads map onto `sd_bus_emit_interfaces_added_strv` and emit exactly
+what the caller named.
+
 - Proven by: `CommonApiIntegrationTest.interfacesAddedAndRemovedSignals_roundTripForExplicitList`,
+  `SignalPayloadParityTest` (payload property values + standard-interface enumeration),
   `cross_test/.../DbusmockObjectManagerTest.kt` (foreign-emitted lifecycle + `GetManagedObjects`
   round-trip + proxy flow convergence), and `cross_test/.../DbusmockBluezTest.kt`
   (ObjectManager discovery over the dbusmock `bluez5` template).

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/SignalPayloadParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/SignalPayloadParityTest.kt
@@ -88,6 +88,182 @@ class SignalPayloadParityTest {
     }
 
     @Test
+    fun noArgInterfacesAddedEnumeratesStandardInterfaces() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.iastd$id")
+        val managerPath = ObjectPath("/com/monkopedia/sdbus/iastd$id")
+        val childPath = ObjectPath("/com/monkopedia/sdbus/iastd$id/child")
+        val iface = InterfaceName("com.monkopedia.sdbus.iastd$id.Iface")
+        val levelProp = PropertyName("Level")
+        val holder = Holder(42)
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val managerObj = createObject(server, managerPath)
+        val manager = managerObj.addObjectManager()
+        val obj = createObject(server, childPath)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+            prop(levelProp) { with(holder::value) }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, managerPath)
+
+        val seen = CompletableDeferred<Map<InterfaceName, Map<PropertyName, Variant>>>()
+        val sigReg = proxy.onSignal(
+            ObjectManagerProxy.INTERFACE_NAME,
+            SignalName("InterfacesAdded")
+        ) {
+            call { _: ObjectPath, ifaces: Map<InterfaceName, Map<PropertyName, Variant>> ->
+                if (!seen.isCompleted) seen.complete(ifaces)
+            }
+        }
+
+        try {
+            // The no-argument form maps onto sd_bus_emit_object_added, which advertises the
+            // object's standard interfaces alongside its vtables. The object is not itself an
+            // ObjectManager, so that one must NOT appear.
+            obj.emitInterfacesAddedSignal()
+            val ifaces = withTimeout(2_000) { seen.await() }
+            assertEquals(
+                setOf(
+                    InterfaceName("org.freedesktop.DBus.Peer"),
+                    InterfaceName("org.freedesktop.DBus.Introspectable"),
+                    InterfaceName("org.freedesktop.DBus.Properties"),
+                    iface
+                ),
+                ifaces.keys
+            )
+            // The standard interfaces carry no properties; the vtable interface still carries its
+            // current values (#143).
+            assertEquals(emptyMap(), ifaces[InterfaceName("org.freedesktop.DBus.Peer")])
+            assertEquals(42, ifaces[iface]?.get(levelProp)?.get<Int>())
+        } finally {
+            sigReg.release()
+            reg.release()
+            manager.release()
+            managerObj.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+
+    @Test
+    fun noArgInterfacesAddedEnumeratesObjectManagerWhenPresent() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.iaom$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/iaom$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.iaom$id.Iface")
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+        }
+        val manager = obj.addObjectManager()
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, path)
+
+        val seen = CompletableDeferred<Set<InterfaceName>>()
+        val sigReg = proxy.onSignal(
+            ObjectManagerProxy.INTERFACE_NAME,
+            SignalName("InterfacesAdded")
+        ) {
+            call { _: ObjectPath, ifaces: Map<InterfaceName, Map<PropertyName, Variant>> ->
+                if (!seen.isCompleted) seen.complete(ifaces.keys)
+            }
+        }
+
+        try {
+            obj.emitInterfacesAddedSignal()
+            assertEquals(
+                setOf(
+                    InterfaceName("org.freedesktop.DBus.Peer"),
+                    InterfaceName("org.freedesktop.DBus.Introspectable"),
+                    InterfaceName("org.freedesktop.DBus.Properties"),
+                    ObjectManagerProxy.INTERFACE_NAME,
+                    iface
+                ),
+                withTimeout(2_000) { seen.await() }
+            )
+        } finally {
+            sigReg.release()
+            manager.release()
+            reg.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+
+    @Test
+    fun noArgInterfacesRemovedEnumeratesStandardInterfaces() = runBlocking {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.irstd$id")
+        val managerPath = ObjectPath("/com/monkopedia/sdbus/irstd$id")
+        val childPath = ObjectPath("/com/monkopedia/sdbus/irstd$id/child")
+        val iface = InterfaceName("com.monkopedia.sdbus.irstd$id.Iface")
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val managerObj = createObject(server, managerPath)
+        val manager = managerObj.addObjectManager()
+        val obj = createObject(server, childPath)
+        val reg = obj.addVTable(iface) {
+            method(MethodName("Ping")) { call<Unit> { } }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, managerPath)
+
+        val seen = CompletableDeferred<List<InterfaceName>>()
+        val sigReg = proxy.onSignal(
+            ObjectManagerProxy.INTERFACE_NAME,
+            SignalName("InterfacesRemoved")
+        ) {
+            call { _: ObjectPath, ifaces: List<InterfaceName> ->
+                if (!seen.isCompleted) seen.complete(ifaces)
+            }
+        }
+
+        try {
+            // sd_bus_emit_object_removed withdraws exactly what sd_bus_emit_object_added
+            // advertised, so the removal must name the standard interfaces too.
+            obj.emitInterfacesRemovedSignal()
+            assertEquals(
+                setOf(
+                    InterfaceName("org.freedesktop.DBus.Peer"),
+                    InterfaceName("org.freedesktop.DBus.Introspectable"),
+                    InterfaceName("org.freedesktop.DBus.Properties"),
+                    iface
+                ),
+                withTimeout(2_000) { seen.await() }.toSet()
+            )
+        } finally {
+            sigReg.release()
+            reg.release()
+            manager.release()
+            managerObj.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+
+    @Test
     fun noArgPropertiesChangedCarriesAllInterfaceProperties() = runBlocking {
         val id = Random.nextInt(100_000, 999_999)
         val service = ServiceName("com.monkopedia.sdbus.pcall$id")

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
@@ -276,8 +276,24 @@ internal class WireDbusObject(
         emitPropertiesChangedSignal(interfaceName, allProps)
     }
 
+    // The no-argument overloads map onto sd_bus_emit_object_added/_removed, which advertise the
+    // object's STANDARD interfaces alongside its vtables: Peer, Introspectable and Properties
+    // always, plus ObjectManager when one is installed at this very path. (The explicit-list
+    // overloads map onto sd_bus_emit_interfaces_added_strv and stay exactly what the caller named.)
+    // The standard ones carry no properties, which snapshotInterfaceProperties already reports as
+    // an empty map. #141.
+    private fun allInterfaceNames(): List<InterfaceName> = buildList {
+        add(InterfaceName(WireServe.PEER_INTERFACE))
+        add(InterfaceName(WireServe.INTROSPECTABLE_INTERFACE))
+        add(InterfaceName(propertiesInterfaceName))
+        if (LocalObjectManagerRegistry.resolveFor(objectPath.value) == objectPath.value) {
+            add(InterfaceName(objectManagerInterfaceName))
+        }
+        addAll(registeredInterfaces.keys.map(::InterfaceName))
+    }
+
     override fun emitInterfacesAddedSignal() {
-        emitInterfacesAddedSignal(registeredInterfaces.keys.map(::InterfaceName))
+        emitInterfacesAddedSignal(allInterfaceNames())
     }
 
     override fun emitInterfacesAddedSignal(interfaces: List<InterfaceName>) {
@@ -300,7 +316,7 @@ internal class WireDbusObject(
     }
 
     override fun emitInterfacesRemovedSignal() {
-        emitInterfacesRemovedSignal(registeredInterfaces.keys.map(::InterfaceName))
+        emitInterfacesRemovedSignal(allInterfaceNames())
     }
 
     override fun emitInterfacesRemovedSignal(interfaces: List<InterfaceName>) {


### PR DESCRIPTION
Refs #141 — item 3 of the three remaining in-scope items from the 2026-07-31 triage re-scope. This is the interface-*enumeration* half of the gap #143 opened; #143 fixed the property *values* in the same payload.

## The divergence

The two `emitInterfacesAddedSignal` overloads map onto **different** sd-bus calls (`ConnectionImpl.kt`):

| Overload | sd-bus call | Enumerates |
| --- | --- | --- |
| `emitInterfacesAddedSignal()` | `sd_bus_emit_object_added` | the object's standard interfaces **plus** its vtables |
| `emitInterfacesAddedSignal(interfaces)` | `sd_bus_emit_interfaces_added_strv` | exactly what the caller named |

The JVM backend implemented the no-argument form as `registeredInterfaces.keys` — the user vtables only — for both Added and Removed.

I measured what native actually emits rather than inferring it from the sd-bus source. Throwaway test, `linuxX64`, printing the received `InterfacesAdded` payload:

```
MEASURE child no-arg InterfacesAdded:
MEASURE   path=/com/monkopedia/sdbus/mia144259/child
MEASURE   org.freedesktop.DBus.Peer props=[]
MEASURE   org.freedesktop.DBus.Introspectable props=[]
MEASURE   org.freedesktop.DBus.Properties props=[]
MEASURE   com.monkopedia.sdbus.mia144259.Iface props=[Level]
```

and with an ObjectManager installed at the object's own path (both `InterfacesAdded` and `InterfacesRemoved`):

```
MEASURE child-with-own-OM no-arg InterfacesAdded:
MEASURE   org.freedesktop.DBus.Peer props=[]
MEASURE   org.freedesktop.DBus.Introspectable props=[]
MEASURE   org.freedesktop.DBus.Properties props=[]
MEASURE   org.freedesktop.DBus.ObjectManager props=[]
MEASURE   com.monkopedia.sdbus.mib431937.Iface props=[Level]

MEASURE child-with-own-OM no-arg InterfacesRemoved:
MEASURE   org.freedesktop.DBus.Peer
MEASURE   org.freedesktop.DBus.Introspectable
MEASURE   org.freedesktop.DBus.Properties
MEASURE   org.freedesktop.DBus.ObjectManager
MEASURE   com.monkopedia.sdbus.mib275648.Iface
```

So: Peer / Introspectable / Properties always with **empty** property maps, ObjectManager only when one is installed at that path, vtable interfaces with their current values — and `InterfacesRemoved` withdraws exactly the same set.

## Red-first evidence

Three cross-backend tests added to the existing `SignalPayloadParityTest` (`src/commonTest`, so they run on every target). Run BEFORE the production change:

```
> Task :jvmTest FAILED
SignalPayloadParityTest[jvm] > noArgInterfacesAddedEnumeratesObjectManagerWhenPresent[jvm] FAILED
SignalPayloadParityTest[jvm] > noArgInterfacesRemovedEnumeratesStandardInterfaces[jvm] FAILED
SignalPayloadParityTest[jvm] > noArgInterfacesAddedEnumeratesStandardInterfaces[jvm] FAILED
5 tests completed, 3 failed
```

```
java.lang.AssertionError: expected:<[org.freedesktop.DBus.Peer, org.freedesktop.DBus.Introspectable, org.freedesktop.DBus.Properties, com.monkopedia.sdbus.iastd892755.Iface]> but was:<[com.monkopedia.sdbus.iastd892755.Iface]>
java.lang.AssertionError: expected:<[org.freedesktop.DBus.Peer, org.freedesktop.DBus.Introspectable, org.freedesktop.DBus.Properties, org.freedesktop.DBus.ObjectManager, com.monkopedia.sdbus.iaom614941.Iface]> but was:<[com.monkopedia.sdbus.iaom614941.Iface]>
java.lang.AssertionError: expected:<[org.freedesktop.DBus.Peer, org.freedesktop.DBus.Introspectable, org.freedesktop.DBus.Properties, com.monkopedia.sdbus.irstd872584.Iface]> but was:<[com.monkopedia.sdbus.irstd872584.Iface]>
```

At that same commit, `./gradlew :linuxX64Test --tests "*SignalPayloadParityTest*"` was **BUILD SUCCESSFUL** — the tests pin a real one-sided divergence, not a tautology.

The assertions are exact set equality, so they also pin the negative: the object that is *not* an ObjectManager must not advertise `.ObjectManager`.

## The fix

One helper in `WireDbusObject`, used by both no-argument emitters:

```kotlin
private fun allInterfaceNames(): List<InterfaceName> = buildList {
    add(InterfaceName(WireServe.PEER_INTERFACE))
    add(InterfaceName(WireServe.INTROSPECTABLE_INTERFACE))
    add(InterfaceName(propertiesInterfaceName))
    if (LocalObjectManagerRegistry.resolveFor(objectPath.value) == objectPath.value) {
        add(InterfaceName(objectManagerInterfaceName))
    }
    addAll(registeredInterfaces.keys.map(::InterfaceName))
}
```

Notes on the two judgement calls in it:

- **No new state for the ObjectManager check.** `LocalObjectManagerRegistry.resolveFor` returns the longest registered manager path that covers this object; equal to our own path means one is installed *here*. That is the same lookup `emitInterfacesAddedSignal` already uses to choose the signal path, and it counts managers added through **either** route (`Connection.addObjectManager(path)` and `Object.addObjectManager()`), which a `WireDbusObject`-local counter would not.
- **Empty property maps come for free**: the payload builder already runs each name through `snapshotInterfaceProperties`, which returns `emptyMap()` for an interface with no registered properties — exactly what native emits for the standard ones.

**`InterfacesRemoved` is included deliberately**, though the triage line named only `InterfacesAdded`. The measurement above shows native's `sd_bus_emit_object_removed` withdraws precisely what `_added` advertised; fixing only the Added side would leave an ObjectManager consumer holding standard interfaces that are never withdrawn — a worse state than the symmetric bug it replaces. Same one-line change, same helper.

The explicit-list overloads are untouched.

## Verification

- `dbus-run-session -- ./gradlew jvmTest linuxX64Test` — BUILD SUCCESSFUL (full root suites, both backends).
- `./gradlew ktlintCheck apiCheck compileKotlinLinuxArm64` — BUILD SUCCESSFUL.
- **`apiCheck` did NOT move.** `WireDbusObject` is `internal`; no public surface change, so neither `api/sdbus-kotlin.api` nor `api/sdbus-kotlin.klib.api` needed a regen and there is no consumer-visible ABI change for `blue-falcon-sdbus`.

`docs/BACKENDS.md`'s ObjectManager section now states the no-arg vs explicit-list distinction.
