### PR TITLE
fix(native): stop the event loop busy-spinning on a default-timeout method call

### DIFF
--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
@@ -91,7 +91,6 @@ import platform.posix.EEXIST
 import platform.posix.EINTR
 import platform.posix.EINVAL
 import platform.posix.POLLIN
-import platform.posix.UINT64_MAX
 import platform.posix.close
 import platform.posix.errno
 import platform.posix.poll
@@ -872,11 +871,7 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
 
             require(eventFd.fd >= 0)
 
-            val timeout = if (pollData.timeout_usec == UINT64_MAX) {
-                Duration.INFINITE
-            } else {
-                pollData.timeout_usec.toLong().microseconds
-            }
+            val timeout = absoluteTimeoutOf(pollData.timeout_usec)
 
             return PollData(pollData.fd, pollData.events, timeout, 0) // eventFd_.fd)
         }

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/PollData.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/PollData.kt
@@ -23,6 +23,18 @@
 package com.monkopedia.sdbus.internal
 
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.microseconds
+import platform.posix.UINT64_MAX
+
+/**
+ * Converts an absolute sd-bus timeout, expressed in microseconds of CLOCK_MONOTONIC, into the
+ * [Duration] carried by [PollData.timeout].
+ */
+internal fun absoluteTimeoutOf(timeoutUsec: ULong): Duration = if (timeoutUsec == UINT64_MAX) {
+    Duration.INFINITE
+} else {
+    timeoutUsec.toLong().microseconds
+}
 
 /**
  * Carries poll data needed for integration with external event loop implementations.

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/PollData.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/PollData.kt
@@ -24,17 +24,24 @@ package com.monkopedia.sdbus.internal
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.microseconds
-import platform.posix.UINT64_MAX
 
 /**
  * Converts an absolute sd-bus timeout, expressed in microseconds of CLOCK_MONOTONIC, into the
  * [Duration] carried by [PollData.timeout].
+ *
+ * Anything that does not fit in a signed 64-bit integer is indefinite. That covers sd-bus'
+ * `UINT64_MAX` "no timeout" sentinel, and also the deadline a call left at the default timeout
+ * produces: it asks sd-bus for `Long.MAX_VALUE` microseconds, which sd-bus stores as an absolute
+ * `now + Long.MAX_VALUE` with bit 63 set. A real deadline cannot set bit 63 — that is over 292,000
+ * years of uptime — so there is no value to lose, and comparing unsigned leaves no signed
+ * conversion that could overflow into a negative (and therefore already-expired) timeout.
  */
-internal fun absoluteTimeoutOf(timeoutUsec: ULong): Duration = if (timeoutUsec == UINT64_MAX) {
-    Duration.INFINITE
-} else {
-    timeoutUsec.toLong().microseconds
-}
+internal fun absoluteTimeoutOf(timeoutUsec: ULong): Duration =
+    if (timeoutUsec > Long.MAX_VALUE.toULong()) {
+        Duration.INFINITE
+    } else {
+        timeoutUsec.toLong().microseconds
+    }
 
 /**
  * Carries poll data needed for integration with external event loop implementations.

--- a/src/nativeTest/kotlin/unit/PollDataTest.kt
+++ b/src/nativeTest/kotlin/unit/PollDataTest.kt
@@ -25,6 +25,7 @@
 package com.monkopedia.sdbus.unit
 
 import com.monkopedia.sdbus.internal.PollData
+import com.monkopedia.sdbus.internal.absoluteTimeoutOf
 import com.monkopedia.sdbus.internal.now
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,6 +35,7 @@ import kotlin.time.Duration.Companion.microseconds
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.UINT64_MAX
 
 class PollDataTest {
 
@@ -111,5 +113,37 @@ class PollDataTest {
         val pollTimeout = pd.getPollTimeout()
 
         assertTrue(pollTimeout in 900..1100)
+    }
+
+    @Test
+    fun `PollData ConvertsUint64MaxSentinelToInfiniteTimeout`() {
+        assertEquals(Duration.INFINITE, absoluteTimeoutOf(UINT64_MAX))
+    }
+
+    @Test
+    fun `PollData ConvertsDefaultTimeoutDeadlineToInfiniteTimeout`() {
+        // A call left at the default timeout sends sd-bus Long.MAX_VALUE microseconds, so sd-bus
+        // stores an absolute deadline of now + Long.MAX_VALUE. That has bit 63 set but is not
+        // UINT64_MAX.
+        val deadline = now().inWholeMicroseconds.toULong() + Long.MAX_VALUE.toULong()
+
+        assertEquals(Duration.INFINITE, absoluteTimeoutOf(deadline))
+    }
+
+    @Test
+    fun `PollData ReturnsNegativePollTimeoutForDefaultTimeoutDeadline`() {
+        // The whole point: poll(2) must block rather than return immediately, or the event loop
+        // busy-spins for the entire duration of the call.
+        val deadline = now().inWholeMicroseconds.toULong() + Long.MAX_VALUE.toULong()
+        val pd = PollData(timeout = absoluteTimeoutOf(deadline))
+
+        assertEquals(-1, pd.getPollTimeout())
+    }
+
+    @Test
+    fun `PollData ConvertsRepresentableDeadlinesExactly`() {
+        assertEquals(1_500_000.microseconds, absoluteTimeoutOf(1_500_000uL))
+        // The largest deadline that still fits in a signed 64-bit integer stays finite.
+        assertEquals(Long.MAX_VALUE.microseconds, absoluteTimeoutOf(Long.MAX_VALUE.toULong()))
     }
 }


### PR DESCRIPTION
Fixes #178

Native only. Every D-Bus method call left at the default timeout busy-spun a CPU core for the call's whole duration — invisible on millisecond calls, indistinguishable from a hang on a long one. Reported downstream by the `blue-falcon-sdbus` agent in Monkopedia/blue-falcon-sdbus#16, where a BlueZ `Connect()` to an unreachable device runs ~48 s and pinned a core at **104% CPU**; the same call with an explicit `timeout = 120.seconds` measured 0%.

## Root cause

`EventLoopThread.getEventLoopPollData()` read sd-bus' absolute `uint64_t` poll deadline and treated only `UINT64_MAX` as "indefinite", converting everything else with `.toLong()`:

```kotlin
val timeout = if (pollData.timeout_usec == UINT64_MAX) {
    Duration.INFINITE
} else {
    pollData.timeout_usec.toLong().microseconds
}
```

A default-timeout call asks sd-bus for `Long.MAX_VALUE` microseconds (`Duration.INFINITE.inWholeMicroseconds` clamps there), so sd-bus stores an absolute `CLOCK_MONOTONIC` deadline of `now + 2^63-1` — **bit 63 set, but nowhere near `UINT64_MAX`**. The guard missed it and `.toLong()` overflowed negative. `PollData.getRelativeTimeout()` then `coerceAtLeast(Duration.ZERO)`'d that to `ZERO`, `getPollTimeout()` returned `0`, and `waitForNextEvent()` called `poll(fds, 3, 0)` — an unbounded busy re-poll.

The same overflow also caused a spurious event-loop wakeup in `callMethod()`, which compares the poll deadline before and after `send()` and saw the negative value as smaller than the previous one. That is fixed as a side effect.

## The fix

One line of logic: compare **unsigned** rather than testing a single sentinel.

```kotlin
internal fun absoluteTimeoutOf(timeoutUsec: ULong): Duration =
    if (timeoutUsec > Long.MAX_VALUE.toULong()) {
        Duration.INFINITE
    } else {
        timeoutUsec.toLong().microseconds
    }
```

Both forms suggested in the issue work. I chose the unsigned comparison over an explicit bit-63 test because it is **structurally** safe rather than correct-by-inspection: it subsumes the `UINT64_MAX` sentinel (so there is no longer a special case to keep in sync), and it leaves *no* signed conversion on any path — the `.toLong()` is unreachable for any value that could overflow it, by construction. A bit-63 mask would read as a heuristic and would still leave a `.toLong()` a future edit could widen.

Soundness of treating bit 63 as infinite: a genuine absolute `CLOCK_MONOTONIC` deadline cannot set bit 63 — that is over 292,000 years of uptime — so no reachable timeout changes meaning. Calls that already work are unaffected.

The conversion moved out of the private inner `EventLoopThread` into `PollData.kt` purely so it is reachable from a unit test; the call site in `ConnectionImpl.kt` gets shorter, and the `UINT64_MAX` import goes away. Nothing else changed.

## Red-first

Two commits, so the red is reproducible independently: `a504659` moves the conversion out **verbatim, bug included**, and adds the tests; `badce2e` fixes it.

At `a504659` (`./gradlew linuxX64Test --tests '*PollDataTest*'`):

```
com.monkopedia.sdbus.unit.PollDataTest.PollData ConvertsDefaultTimeoutDeadlineToInfiniteTimeout[linuxX64] FAILED
    kotlin.AssertionError at null:-1

com.monkopedia.sdbus.unit.PollDataTest.PollData ReturnsNegativePollTimeoutForDefaultTimeoutDeadline[linuxX64] FAILED
    kotlin.AssertionError at null:-1

> Task :linuxX64Test FAILED

12 tests completed, 2 failed
```

with the assertion messages from `build/test-results/linuxX64Test/*.xml`:

```
kotlin.AssertionError: Expected <Infinity>, actual <-(106751988d 19h 20m 57.067s)>.
kotlin.AssertionError: Expected <-1>, actual <0>.
```

`-(106751988d 19h 20m 57.067s)` is exactly `-Long.MAX_VALUE` microseconds — the overflowed value. The second failure is the defect itself at the end of the chain: `poll(2)` was being handed `0` (spin) where it must get `-1` (block).

Four tests added, all in `PollDataTest`. Two are the red above; the other two guard the fix's edges — that `UINT64_MAX` still maps to `INFINITE`, and that the largest deadline which *does* fit in a signed 64-bit integer stays finite (so the widened condition is not off by one and does not swallow real deadlines).

## No end-to-end test — deliberate

I did not add an integration assertion that a slow call must not spin. To observe the spin you have to sample the event-loop thread's CPU time across a multi-second in-flight call and assert on a usage threshold — seconds of added CI wall time for an assertion a loaded shared runner can trip either way. The unit tests instead pin the exact deterministic quantity that caused it (`getPollTimeout()` returns `-1`, not `0`), which is what `poll(2)` actually consumes. The one link they do not cover is "sd-bus really does return a bit-63 deadline here", and that is established by the downstream measurement in the issue (observed `0x8000_0044_...`, matching a `CLOCK_MONOTONIC` sample at the same instant to within one microsecond).

## Out of scope

**#179 is untouched.** What `Duration.INFINITE` *should* map to — the `MethodInvoker.timeout` default and its KDoc, and whether an infinite timeout should send sd-bus' `0` "use connection default" sentinel instead of `Long.MAX_VALUE` — is a separate owner decision about behaviour already shipped in 1.0.1. `MethodInvoker.kt` is not in this diff. This fix stands regardless of how #179 goes: the overflow is a defect on *any* path producing a large deadline.

## Verification

`JAVA_HOME=/usr/lib/jvm/java-21-openjdk`

- `dbus-run-session -- ./gradlew linuxX64Test jvmTest` — green. 296 native / 326 JVM tests, 0 failures, 0 skipped.
- `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64` — green.
- `./gradlew ktlintCheck apiCheck` — green. **`apiCheck` did not move**: `absoluteTimeoutOf` is `internal`, so neither `api/sdbus-kotlin.api` nor `api/sdbus-kotlin.klib.api` changed. No regeneration, and no klib-ABI shift for `blue-falcon-sdbus`, which consumes it.

No `*.gradle.kts` touched (open PRs #168/#171 are on build scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
