### PR TITLE
docs: correct MethodInvoker.timeout KDoc and pin the Duration.ZERO connection-default path (#179)

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -26,7 +26,7 @@ Every row below is pinned by tests on current `main`, not by intention:
 | Struct (`@Serializable`) marshalling to/from remote peers | ✅ | ✅ | JVM fixed in #71 |
 | Multi-out (grouped) replies (`isGroupedReturn`) | ✅ | ✅ | JVM fixed in #74 |
 | Per-call timeout (`timeout = …` in the invoker block) | ✅ | ✅ | Timeout *error name* may differ, see below |
-| Connection-level `Connection.methodCallTimeout` | ✅ | ✅ | Applied as the default for calls without an explicit timeout; JVM fixed in #80 |
+| Connection-level `Connection.methodCallTimeout` | ✅ | ✅ | Selected by a `Duration.ZERO` per-call timeout; JVM fixed in #80 |
 | Error propagation: named D-Bus errors round-trip name + message verbatim | ✅ | ✅ | Incl. foreign (non-sdbus) peers; JVM fixed in #72 |
 | errno → D-Bus error-name mapping for locally created errors | ✅ | ✅ | JVM pinned to native output |
 | Call-after-release fails with `IllegalArgumentException("Connection has already been released")` | ✅ | ✅ | |
@@ -89,17 +89,27 @@ timeout-shaped `com.monkopedia.sdbus.Error` — never a hang.
   (`methodCallTimeout_surfacesTimeoutError`) and the `callbackAsyncMethodCall_timeout*` tests
   in `CommonApiIntegrationTest.kt`.
 
-The **connection-level default** (`Connection.methodCallTimeout`) applies on both backends to
-calls made *without* an explicit per-call timeout: on native it maps to
+The **connection-level default** (`Connection.methodCallTimeout`) is selected by a per-call
+timeout of `Duration.ZERO` — the sentinel the raw-message overloads (`Proxy.callMethod(message)`,
+`Proxy.callMethodAsync(message)`) send. On native it maps to
 `sd_bus_set/get_method_call_timeout` (sd_bus resolves a 0 per-call timeout through the
 connection default inside `sd_bus_call`); the JVM call paths consult the stored value the same
-way (issue #80). An explicit per-call timeout always wins over the connection default; if
-neither is set, each backend's own default reply timeout applies (sd-bus's 25 s default / the
-JVM wire backend's own default reply timeout).
+way (issue #80). Any other explicit per-call timeout wins over the connection default; if the
+connection default is never set either, each backend's own default reply timeout applies
+(sd-bus's 25 s default / the JVM wire backend's own default reply timeout).
+
+Note that the high-level invoker block defaults `timeout` to `Duration.INFINITE` — *no* per-call
+timeout, **not** the connection default — so `callMethod { call(…) }` with no `timeout =` line
+waits for as long as the peer takes. Write `timeout = Duration.ZERO` to select the connection
+default from an invoker block (issue #179).
 
 - Proven by: `FailurePathParityTest.connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout`
   (both backends: connection default expires a slow call made with no per-call timeout, and an
-  explicit per-call timeout overrides the connection default).
+  explicit per-call timeout overrides the connection default) and
+  `FailurePathParityTest.explicitZeroPerCallTimeout_selectsConnectionDefault` (both backends, both
+  the blocking and the async path: a `Duration.ZERO` per-call timeout succeeds under a generous
+  connection default and expires under a short one, so it is neither an immediate timeout nor
+  "no timeout").
 
 One honest caveat, visible in the tests:
 

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/MethodInvoker.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/MethodInvoker.kt
@@ -179,7 +179,13 @@ class MethodInvoker @PublishedApi internal constructor(private val method: Metho
     /** Whether to send the call without waiting for a reply. */
     var dontExpectReply by method::dontExpectReply
 
-    /** The per-call timeout. Defaults to [Duration.INFINITE], meaning the connection default. */
+    /**
+     * The per-call timeout.
+     *
+     * Defaults to [Duration.INFINITE], meaning no per-call timeout is applied and the call waits
+     * for as long as the remote peer takes to answer. Set it to [Duration.ZERO] to use the
+     * connection default instead — see [Connection.methodCallTimeout].
+     */
     var timeout: Duration = INFINITE
 
     override fun createCall(inputType: InputType, values: List<Any>): TypedArguments =

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -94,16 +95,7 @@ class FailurePathParityTest {
                     }
                 }
             }
-            // The backends differ on whether the daemon reports Timeout or NoReply, and on the
-            // exact human-readable string, so assert membership rather than an exact value -- but
-            // require that it is recognizably a timeout, never a generic/unrelated error.
-            assertTrue(
-                thrown.name.contains("Timeout") ||
-                    thrown.name.contains("NoReply") ||
-                    thrown.errorMessage.contains("timed out", ignoreCase = true),
-                "expected a timeout-shaped error, got name='${thrown.name}' " +
-                    "message='${thrown.errorMessage}'"
-            )
+            assertIsTimeout(thrown)
             // Let the slow handler finish and flush its late reply while loops are still alive.
             delay(serverDelayMs + 400)
         } finally {
@@ -155,13 +147,7 @@ class FailurePathParityTest {
                 call.append(1)
                 proxy.callMethod(call)
             }
-            assertTrue(
-                thrown.name.contains("Timeout") ||
-                    thrown.name.contains("NoReply") ||
-                    thrown.errorMessage.contains("timed out", ignoreCase = true),
-                "expected a timeout-shaped error, got name='${thrown.name}' " +
-                    "message='${thrown.errorMessage}'"
-            )
+            assertIsTimeout(thrown)
 
             // An explicit per-call timeout always wins over the connection default: with a
             // generous per-call timeout the same slow method completes successfully.
@@ -186,6 +172,108 @@ class FailurePathParityTest {
             serverConnection.release()
         }
     }
+
+    // [Duration.ZERO] is the API's "use the connection default" sentinel for a per-call timeout.
+    // It is documented on Proxy.callMethod/callMethodAsync, MethodCall.send and -- since #179 --
+    // MethodInvoker.timeout, whose own default of Duration.INFINITE means the opposite (no
+    // per-call timeout at all). The sentinel is implemented explicitly only on the JVM backend
+    // (WireDbusBackend resolves a 0 per-call timeout through the connection's stored default);
+    // native gets it implicitly because 0 is sd-bus's own sentinel inside sd_bus_call. So it needs
+    // a cross-backend guard before the docs actively point people at it.
+    //
+    // Two phases pin the behavior from both sides: with a generous connection default a
+    // ZERO-timeout call to a slow method must SUCCEED (so ZERO is not an immediate/zero timeout),
+    // and with a short connection default the same call must EXPIRE (so ZERO is not "no timeout"
+    // either). Both the blocking and the async call path are checked -- they reach the timeout
+    // differently on the JVM backend.
+    @Test
+    fun explicitZeroPerCallTimeout_selectsConnectionDefault() = runBlocking {
+        val ids = uniqueFixtureIds("zeroTimeout")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        // Same slow-method fixture as the tests above: the handler sleeps past the short
+        // connection default, then completes while both loops are still up so its late reply
+        // doesn't hit a torn-down native connection.
+        val serverDelayMs = 600L
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("Slow")) {
+                asyncCall { value: Int ->
+                    delay(serverDelayMs)
+                    value
+                }
+            }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path)
+
+        try {
+            // Phase 1: connection default is generous, so a ZERO per-call timeout must let the
+            // slow method run to completion. A ZERO taken literally would fail here immediately.
+            proxyConnection.methodCallTimeout = 5_000.milliseconds
+            assertEquals(
+                1,
+                proxy.callMethod<Int>(ids.iface, MethodName("Slow")) {
+                    call(1)
+                    timeout = Duration.ZERO
+                }
+            )
+            assertEquals(
+                2,
+                proxy.callMethodAsync<Int>(ids.iface, MethodName("Slow")) {
+                    call(2)
+                    timeout = Duration.ZERO
+                }
+            )
+
+            // Phase 2: connection default is shorter than the handler's delay, so the same
+            // ZERO per-call timeout must now expire the call. A ZERO meaning "no timeout" (or
+            // INFINITE leaking through) would instead return 3 after ~600 ms.
+            proxyConnection.methodCallTimeout = 100.milliseconds
+            val blockingFailure = assertFailsWith<SdbusException> {
+                proxy.callMethod<Int>(ids.iface, MethodName("Slow")) {
+                    call(3)
+                    timeout = Duration.ZERO
+                }
+            }
+            assertIsTimeout(blockingFailure)
+
+            val asyncFailure = withTimeout(3_000) {
+                assertFailsWith<SdbusException> {
+                    proxy.callMethodAsync<Int>(ids.iface, MethodName("Slow")) {
+                        call(4)
+                        timeout = Duration.ZERO
+                    }
+                }
+            }
+            assertIsTimeout(asyncFailure)
+
+            // Let the timed-out handler invocations flush their late replies while the loops
+            // are still alive.
+            delay(serverDelayMs + 400)
+        } finally {
+            withTimeout(5_000) {
+                proxyConnection.stopEventLoop()
+                serverConnection.stopEventLoop()
+            }
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
+    // The backends differ on whether the daemon reports Timeout or NoReply, and on the exact
+    // human-readable string, so assert membership rather than an exact value -- but require that
+    // it is recognizably a timeout, never a generic/unrelated error.
+    private fun assertIsTimeout(thrown: SdbusException) = assertTrue(
+        thrown.name.contains("Timeout") ||
+            thrown.name.contains("NoReply") ||
+            thrown.errorMessage.contains("timed out", ignoreCase = true),
+        "expected a timeout-shaped error, got name='${thrown.name}' " +
+            "message='${thrown.errorMessage}'"
+    )
 
     // --- remote D-Bus error propagation ----------------------------------------------------
 


### PR DESCRIPTION
Fixes #179

## What was wrong

`MethodInvoker.timeout` defaults to `Duration.INFINITE`, but its KDoc read:

> The per-call timeout. Defaults to [Duration.INFINITE], meaning the connection default.

`Duration.INFINITE` does not mean the connection default. **`Duration.ZERO` does** — and it is already documented as the connection-default sentinel in three other places (`Proxy.kt:135`, `Proxy.kt:178`, `MethodCall.kt:40`), implemented explicitly on JVM (`WireDbusBackend.kt:301`, `Message.jvm.kt:419` branch on `timeout == 0uL`) and implicitly on native (`0` is sd-bus's own sentinel inside `sd_bus_call`). So this was never a missing capability: one line disagreed with the rest of the API, and that disagreement is what sent `Long.MAX_VALUE` microseconds to sd-bus and produced the bit-63 deadline behind #178.

## The decision this implements

Per the [owner decision comment on #179](https://github.com/Monkopedia/sdbus-kotlin/issues/179#issuecomment-5171411308): **keep the default at `INFINITE`, correct the documentation.** No behavior change, so nothing shipped in 1.0.0/1.0.1 moves and a long call such as BlueZ's ~48 s `Device1.Connect` keeps surfacing BlueZ's real error rather than being cut short at sd-bus's 25 s default. The rejected alternative — changing the default to `ZERO` — would have made the sentence true but started failing every default-timeout call after 25 s, a behavior change on a released artifact.

The diff contains **no behavior change**: docs plus tests only.

## The `Duration.ZERO` path is now verified on both backends

The decision required this before the docs actively point people at `Duration.ZERO`, on the grounds that documenting an unverified path is exactly how the #178 bug came about. New cross-backend test `FailurePathParityTest.explicitZeroPerCallTimeout_selectsConnectionDefault` (commonTest, so it runs on `jvmTest` and `linuxX64Test`) pins the sentinel from *both* sides against a deliberately slow (600 ms) method:

- **Phase 1** — connection default `5 s`: a `timeout = Duration.ZERO` call **succeeds**, so `ZERO` is not taken literally as an immediate/zero timeout.
- **Phase 2** — connection default `100 ms`: the same `timeout = Duration.ZERO` call **expires** with a timeout-shaped error, so `ZERO` is not "no timeout" either. It resolves to the connection default, and nothing else.

Both phases run through the blocking (`callMethod`) *and* the async (`callMethodAsync`) path, which reach the timeout via different branches on the JVM backend.

### Result per backend

| Backend | `Duration.ZERO` → connection default |
| --- | --- |
| **JVM** (`jvmTest`) | ✅ works end to end, both call paths |
| **native** (`linuxX64Test`) | ✅ works end to end, both call paths |

**Neither backend is broken** — the path already worked; the test is now the guard that keeps the newly-documented promise true.

### The test was checked for discriminating power (red-first, by mutation)

Because "it passes" is worth little for a test written after the fact, each phase was mutated and re-run on **both** backends:

- phase 1's `Duration.ZERO` → `1.milliseconds` (models "`ZERO` taken literally"): **fails on JVM and native**.
- phase 2's `Duration.ZERO` → `Duration.INFINITE` (models "`ZERO` leaks through as no-timeout", i.e. the current default): **fails on JVM and native**.

The second mutation is also a direct demonstration of the documentation defect: with `INFINITE` the call does **not** honour the 100 ms connection default, it waits out the slow handler.

## Changes

- `src/commonMain/.../MethodInvoker.kt` — KDoc corrected: `INFINITE` means no per-call timeout is applied; `Duration.ZERO` selects the connection default (`Connection.methodCallTimeout`).
- `docs/BACKENDS.md` — repeated the same wrong claim in a different form: it said the connection default applies to "calls made *without* an explicit per-call timeout", which is true of the raw-message overloads but **not** of the high-level invoker block (whose unset `timeout` is `INFINITE`). Corrected, plus the parity-table row and a `Proven by:` entry for the new test. No other doc in the tree repeats the claim.
- `src/commonTest/.../FailurePathParityTest.kt` — the new test, plus the timeout-shape assertion the suite already repeated twice extracted to a private `assertIsTimeout` helper and reused.

## Verification

- `dbus-run-session -- ./gradlew :jvmTest :linuxX64Test` — full suites green on both backends.
- `./gradlew ktlintCheck apiCheck compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64` — green.
- **`apiCheck` did not move** (KDoc is not ABI); no `api/*.api` file is touched by this PR, so the klib consumed by `blue-falcon-sdbus` is unchanged.
- `CHANGELOG.md` and every `*.gradle.kts` deliberately untouched (open PRs #168/#171 own those).

## Related

- #178 — the CPU-burn bug whose root cause is this documentation defect (a KDoc that had been wrong since it was written, unchecked because nobody had reason to look at the timeout path). Its code fix landed in #180; this PR removes the misleading text that produced it.
- #80 — the earlier work that wired `Connection.methodCallTimeout` through the JVM backend.
