### PR TITLE
test(cross): make the dbusmock harness fail when required and skip honestly when absent

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -50,8 +50,9 @@ jobs:
       - name: Install Test Dependencies
         run: |
           sudo apt-get update
-          # python3-dbusmock powers the independent-peer harness (DbusmockSmokeTest); if it is
-          # ever unavailable the smoke test skips cleanly rather than failing the build.
+          # python3-dbusmock powers the independent-peer harness (the Dbusmock* suites). Because
+          # this job installs it deliberately, the test step sets DBUSMOCK_REQUIRED so a missing
+          # package fails loudly instead of turning the whole foreign-peer layer into no-ops.
           sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus python3-dbusmock
 
       - name: Run Full Test Suite on x64
@@ -59,6 +60,10 @@ jobs:
         # dbus-java) — so there is no separate wire-parity matrix; this runs that one backend. A
         # hard `timeout` guard ensures a hung call/signal fails fast instead of stalling (a prior
         # run hung for 21 hours).
+        env:
+          # This job installs python3-dbusmock above, so the harness must fail — not skip — when
+          # it cannot start a dbusmock peer.
+          DBUSMOCK_REQUIRED: "1"
         run: |
           set -euo pipefail
           X64_SYSTEMD_LIB="$(find "${GITHUB_WORKSPACE}/libs/x86_64" -maxdepth 2 -type d -name lib | head -n 1 || true)"

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockBluezTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockBluezTest.kt
@@ -534,8 +534,8 @@ private typealias IfacesAndProps = Map<InterfaceName, Map<PropertyName, Variant>
 /**
  * Launches the dbusmock `bluez5` template (claiming the well-known `org.bluez` name on the
  * session bus — see the class KDoc for the `--session` override), waits until the template's
- * `/org/bluez` manager object is up, runs [block], and tears everything down. Skips cleanly
- * (runs no assertions) when python-dbusmock is unavailable.
+ * `/org/bluez` manager object is up, runs [block], and tears everything down. Skips (see
+ * [skipTest]) when python-dbusmock is unavailable, unless [DBUSMOCK_REQUIRED_ENV] is set.
  */
 private fun withBluezMock(block: suspend BluezMock.() -> Unit) = runBlocking {
     val handle = launchDbusmock(
@@ -545,11 +545,7 @@ private fun withBluezMock(block: suspend BluezMock.() -> Unit) = runBlocking {
         template = "bluez5"
     )
     if (handle == null) {
-        println(
-            "[withBluezMock] SKIP: python-dbusmock unavailable. " +
-                "Install via 'apt install python3-dbusmock' / 'pip install python-dbusmock' " +
-                "(see DbusmockHarness KDoc)."
-        )
+        skipTest(DBUSMOCK_UNAVAILABLE_SKIP)
         return@runBlocking
     }
 

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
@@ -46,13 +46,56 @@ package com.monkopedia.sdbus.integration
  * If a custom interpreter is needed (e.g. a venv), point the `DBUSMOCK_PYTHON` environment
  * variable at it; otherwise `python3` on `PATH` is used.
  *
- * ## Graceful skip
+ * ## Graceful skip, and `DBUSMOCK_REQUIRED`
  *
  * If python3 / python3-dbusmock is not present, or no D-Bus session bus is reachable,
- * [launchDbusmock] returns `null` and the smoke test SKIPs cleanly (asserts nothing) rather
- * than failing — so CI without dbusmock still passes.
+ * [launchDbusmock] returns `null` and the caller SKIPs (see [skipTest]) rather than failing —
+ * so a contributor laptop without dbusmock still passes.
+ *
+ * That default is wrong for a CI job that installs python3-dbusmock deliberately: there, a
+ * vanished package would silently turn the whole foreign-peer layer into no-ops while the build
+ * stayed green. Setting the [DBUSMOCK_REQUIRED_ENV] environment variable inverts it — every
+ * skip path fails instead, naming the underlying reason.
  */
 internal expect fun dbusmockGetenv(name: String): String?
+
+/**
+ * Environment variable that turns a "dbusmock could not be started" skip into a hard failure.
+ * Set by the CI job that installs python3-dbusmock on purpose.
+ */
+internal const val DBUSMOCK_REQUIRED_ENV = "DBUSMOCK_REQUIRED"
+
+/** Message reported by every suite that skips because no dbusmock peer could be started. */
+internal const val DBUSMOCK_UNAVAILABLE_SKIP =
+    "python-dbusmock unavailable. Install via 'apt install python3-dbusmock' / " +
+        "'pip install python-dbusmock' (see DbusmockHarness KDoc), or set " +
+        "$DBUSMOCK_REQUIRED_ENV=1 to fail instead of skipping."
+
+/**
+ * Handles a dbusmock peer that could not be started, [reason] saying why (no session bus, python
+ * missing, module missing, …).
+ *
+ * Returns `null` — the caller then skips — unless [DBUSMOCK_REQUIRED_ENV] is set, in which case
+ * it fails loudly with [reason] instead.
+ */
+internal fun dbusmockUnavailable(reason: String): DbusmockHandle? {
+    if (dbusmockGetenv(DBUSMOCK_REQUIRED_ENV) == null) return null
+    error("$DBUSMOCK_REQUIRED_ENV is set but no dbusmock peer could be started: $reason")
+}
+
+/**
+ * Reports the running test as skipped with [reason], so the test report says "skipped" instead of
+ * claiming a pass for a case that asserted nothing.
+ *
+ * On the JVM this raises a JUnit assumption failure, which Gradle records as `skipped`. Kotlin/
+ * Native's test runner has no runtime-skip primitive — an early return is indistinguishable from a
+ * pass, and a TeamCity `testIgnored` emitted from inside a running test is rejected by the Gradle
+ * parser — so the native actual can only write [reason] to the captured test output. CI does not
+ * depend on that: [DBUSMOCK_REQUIRED_ENV] makes the harness fail rather than skip.
+ *
+ * Callers must still `return` afterwards; only the JVM actual aborts the test by throwing.
+ */
+internal expect fun skipTest(reason: String)
 
 /**
  * A running python-dbusmock process. [stop] terminates it and reaps the child.
@@ -76,7 +119,8 @@ internal expect class DbusmockHandle {
  *   private system bus is needed. [busName]/[objectPath]/[interfaceName] are ignored in this
  *   mode (callers should pass the template's well-known values for readability).
  * @return a [DbusmockHandle] if the process started, or `null` if dbusmock / python is not
- *   available (the caller should then SKIP).
+ *   available (the caller should then SKIP). Throws instead of returning `null` when
+ *   [DBUSMOCK_REQUIRED_ENV] is set — see [dbusmockUnavailable].
  */
 internal expect fun launchDbusmock(
     busName: String,

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPeerFixture.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockPeerFixture.kt
@@ -138,7 +138,8 @@ internal suspend fun <T> pumpUntilSubscribed(received: ReceiveChannel<T>, poke: 
 /**
  * Launches a fresh dbusmock peer (unique bus name / path / interface), waits for it to claim
  * its name, runs [block] against it, and tears everything down. If python-dbusmock is not
- * available the test SKIPs cleanly (runs no assertions).
+ * available the test SKIPs (see [skipTest]) — unless [DBUSMOCK_REQUIRED_ENV] is set, in which
+ * case it fails.
  *
  * @param suffix Distinguishes the peer's bus name / object path between tests.
  * @param objectManager When `true`, the peer also implements
@@ -163,11 +164,7 @@ internal fun withDbusmockPeer(
 
     val handle = launchDbusmock(busName, objectPath, interfaceName, objectManager)
     if (handle == null) {
-        println(
-            "[withDbusmockPeer] SKIP: python-dbusmock unavailable. " +
-                "Install via 'apt install python3-dbusmock' / 'pip install python-dbusmock' " +
-                "(see DbusmockHarness KDoc)."
-        )
+        skipTest(DBUSMOCK_UNAVAILABLE_SKIP)
         return@runBlocking
     }
 

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSmokeTest.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockSmokeTest.kt
@@ -46,8 +46,8 @@ import kotlinx.coroutines.runBlocking
  * Deeper coverage (signals, property writes, richer payloads, real templates such as BlueZ /
  * Secret Service) lands in the follow-up tickets that this harness unblocks.
  *
- * Skips cleanly when python3 / python3-dbusmock is not installed. See [DbusmockHarness] for
- * installation instructions.
+ * Skips when python3 / python3-dbusmock is not installed, unless [DBUSMOCK_REQUIRED_ENV] is set.
+ * See [DbusmockHarness] for installation instructions.
  */
 class DbusmockSmokeTest {
     @Test
@@ -59,12 +59,8 @@ class DbusmockSmokeTest {
 
         val handle = launchDbusmock(busName, objectPath, interfaceName)
         if (handle == null) {
-            // python3 / python3-dbusmock not available, or no session bus — skip cleanly.
-            println(
-                "[DbusmockSmokeTest] SKIP: python-dbusmock unavailable. " +
-                    "Install via 'apt install python3-dbusmock' / 'pip install python-dbusmock' " +
-                    "(see DbusmockHarness KDoc)."
-            )
+            // python3 / python3-dbusmock not available, or no session bus — skip.
+            skipTest(DBUSMOCK_UNAVAILABLE_SKIP)
             return@runBlocking
         }
 

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.jvm.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.jvm.kt
@@ -21,8 +21,13 @@
 package com.monkopedia.sdbus.integration
 
 import java.util.concurrent.TimeUnit
+import org.junit.Assume.assumeTrue
 
 internal actual fun dbusmockGetenv(name: String): String? = System.getenv(name)
+
+// A failed JUnit assumption aborts the test and Gradle records it as skipped (JUnit 4 is what
+// kotlin("test") resolves to for this module; org.junit.Assume is its Assumptions equivalent).
+internal actual fun skipTest(reason: String) = assumeTrue(reason, false)
 
 internal actual class DbusmockHandle(private val process: Process) {
     actual fun stop() {
@@ -41,7 +46,9 @@ internal actual fun launchDbusmock(
     template: String?
 ): DbusmockHandle? {
     // No session bus -> nothing to launch dbusmock on; skip.
-    if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) return null
+    if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) {
+        return dbusmockUnavailable("no D-Bus session bus (DBUS_SESSION_BUS_ADDRESS is unset)")
+    }
 
     val python = dbusmockGetenv("DBUSMOCK_PYTHON") ?: "python3"
     val command = buildList {
@@ -60,21 +67,23 @@ internal actual fun launchDbusmock(
             add(interfaceName)
         }
     }
-    return try {
-        val process = ProcessBuilder(command).redirectErrorStream(true)
+    val process = try {
+        ProcessBuilder(command).redirectErrorStream(true)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .start()
-
-        // python3 exists but dbusmock module is missing -> process exits ~immediately non-zero.
-        if (process.waitFor(500, TimeUnit.MILLISECONDS)) {
-            // Exited already: dbusmock not installed / failed to start. Skip.
-            return null
-        }
-        DbusmockHandle(process)
-    } catch (_: Exception) {
-        // python3 not on PATH, etc. Skip.
-        null
+    } catch (e: Exception) {
+        // python3 not on PATH, etc.
+        return dbusmockUnavailable("could not start '$python' ($e)")
     }
+
+    // python3 exists but dbusmock module is missing -> process exits ~immediately non-zero.
+    if (process.waitFor(500, TimeUnit.MILLISECONDS)) {
+        return dbusmockUnavailable(
+            "'$python -m dbusmock' exited immediately with status ${process.exitValue()}; " +
+                "the dbusmock module is probably not installed"
+        )
+    }
+    return DbusmockHandle(process)
 }
 
 internal actual fun busyWait(millis: Long) {

--- a/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
@@ -30,6 +30,7 @@ import kotlinx.cinterop.cstr
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toKString
+import kotlinx.cinterop.value
 import platform.posix.SIGTERM
 import platform.posix.WNOHANG
 import platform.posix._exit
@@ -41,6 +42,10 @@ import platform.posix.usleep
 import platform.posix.waitpid
 
 internal actual fun dbusmockGetenv(name: String): String? = getenv(name)?.toKString()
+
+// Kotlin/Native's test runner cannot record a skip at runtime (see the expect declaration), so the
+// reason only reaches the captured test output.
+internal actual fun skipTest(reason: String) = println("SKIP: $reason")
 
 internal actual class DbusmockHandle(private val pid: Int) {
     actual fun stop() {
@@ -64,7 +69,9 @@ internal actual fun launchDbusmock(
     template: String?
 ): DbusmockHandle? {
     // No session bus -> nothing to launch dbusmock on; skip.
-    if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) return null
+    if (dbusmockGetenv("DBUS_SESSION_BUS_ADDRESS") == null) {
+        return dbusmockUnavailable("no D-Bus session bus (DBUS_SESSION_BUS_ADDRESS is unset)")
+    }
 
     val python = dbusmockGetenv("DBUSMOCK_PYTHON") ?: "python3"
     val args = buildList {
@@ -85,7 +92,7 @@ internal actual fun launchDbusmock(
     }
 
     val pid = fork()
-    if (pid < 0) return null
+    if (pid < 0) return dbusmockUnavailable("fork() failed while starting '$python -m dbusmock'")
     if (pid == 0) {
         // Child: exec python3 -m dbusmock. On any failure, exit non-zero.
         memScoped {
@@ -101,8 +108,17 @@ internal actual fun launchDbusmock(
         val status = alloc<IntVar>()
         repeat(50) {
             if (waitpid(pid, status.ptr, WNOHANG) == pid) {
-                // Child already exited: dbusmock not installed / failed to start. Skip.
-                return null
+                // Child already exited: dbusmock not installed / failed to start.
+                // 127 is the exit code the child uses when execvp itself failed.
+                val exitStatus = (status.value shr 8) and 0xFF
+                return dbusmockUnavailable(
+                    if (exitStatus == 127) {
+                        "'$python' could not be executed (not on PATH?)"
+                    } else {
+                        "'$python -m dbusmock' exited immediately with status $exitStatus; " +
+                            "the dbusmock module is probably not installed"
+                    }
+                )
             }
             usleep(10_000u)
         }


### PR DESCRIPTION
Fixes #177

Authority for the scope: the owner-decision comment on #177 (https://github.com/Monkopedia/sdbus-kotlin/issues/177#issuecomment-5171519966) — "**full fix — all three parts**", with part 3 (real skip, not a pass) explicitly kept: *"'44 passed' when nothing ran is a false statement in the one artifact anyone reads to find out what ran."*

## What changed

**1. `DBUSMOCK_REQUIRED` honoured in both `launchDbusmock` actuals.**
A shared `dbusmockUnavailable(reason)` helper in `commonTest/DbusmockHarness.kt` returns `null` (caller skips) when the env var is unset, and fails with `reason` when it is set. The reasons are distinct, as asked:

| situation | reason reported |
| --- | --- |
| no session bus | `no D-Bus session bus (DBUS_SESSION_BUS_ADDRESS is unset)` |
| python not executable | JVM: `could not start 'python3' (<IOException>)`; native: `'python3' could not be executed (not on PATH?)` (child exit 127) |
| dbusmock module missing | `'python3 -m dbusmock' exited immediately with status 1; the dbusmock module is probably not installed` |
| `fork()` failed (native) | `fork() failed while starting 'python3 -m dbusmock'` |

The JVM actual also had a latent bug that this fixes: the "exited immediately" `return` sat *inside* a `try { … } catch (_: Exception)`, so a throw from there would have been swallowed. The `try` now wraps only `ProcessBuilder.start()`.

**2. `DBUSMOCK_REQUIRED: "1"` on the `full-tests-x64` job** — the job that apt-installs `python3-dbusmock` deliberately. The stale comment at the apt step ("if it is ever unavailable the smoke test skips cleanly rather than failing the build") is updated, since that is no longer what happens there.

**3. The skip path is a real skip.** The three duplicated `println("… SKIP …")` blocks (`withDbusmockPeer`, `withBluezMock`, `DbusmockSmokeTest`) collapse into one `skipTest(DBUSMOCK_UNAVAILABLE_SKIP)` call against a new `expect fun skipTest`.

## Evidence — JUnit XML counts, read from the files, not inferred

`cross_test/build/test-results/*/TEST-*.xml`, this checkout, no `python3-dbusmock` installed:

| run | jvmTest | linuxX64Test |
| --- | --- | --- |
| **BEFORE** | `tests=64 skipped=0 failures=0` | `tests=62 skipped=0 failures=0` |
| **AFTER** (ungated) | `tests=64 **skipped=44** failures=0` | `tests=62 skipped=0 failures=0` |

The 44 skips are exactly the nine dbusmock suites (3+7+5+2+5+6+3+1+12).

**With `DBUSMOCK_REQUIRED=1` and no dbusmock** (both backends), the run now fails with:

```
java.lang.IllegalStateException: DBUSMOCK_REQUIRED is set but no dbusmock peer could be started:
  'python3 -m dbusmock' exited immediately with status 1; the dbusmock module is probably not installed
```

**Happy path verified locally too.** The host had no `python3-dbusmock`, but `python3 -m venv --system-site-packages` + `pip install python-dbusmock` (0.38.1) worked, so with `DBUSMOCK_PYTHON` pointed at that venv and `DBUSMOCK_REQUIRED=1`:

| | jvmTest (Dbusmock\* only) | linuxX64Test (Dbusmock\* only) |
| --- | --- | --- |
| real dbusmock peer | `tests=44 skipped=0 failures=0` | `tests=44 skipped=0 failures=0` |

i.e. the same 88 cases that were previously vacuous now do real work and pass against a foreign peer. That is the configuration CI will be in (CI has 0.31.1 from apt; I exercised 0.38.1 from pip).

## What I could NOT do: `skipped` on Kotlin/Native

`linuxX64Test` still reports `skipped=0`. **Kotlin/Native's test runner has no runtime-skip primitive**, and this is measured, not assumed:

- `TestCase.ignored` in `kotlin.native.internal.test` is a static `val` populated from `@Ignore`; the runner only calls `TestListener.ignore` for those, and nothing lets a running test change its own outcome to ignored.
- Emitting the TeamCity message the runner itself uses (`##teamcity[testIgnored name='…']`) from inside a test body is rejected by the Gradle-side parser — I tried it:

  ```
  Error while processing test process output message "##teamcity[testIgnored name='callsMethodAndReadsPropertyOnDbusmockPeer' …]"
  java.lang.IllegalStateException: previous test `linuxX64Test/…/callsMethodAndReadsPropertyOnDbusmockPeer` not finished
      at …TCServiceMessagesClient.requireLeafGroup(TCServiceMessagesClient.kt:557)
      at …TCServiceMessagesClient.beginTest(TCServiceMessagesClient.kt:124)
  ```
  `beginTest` requires the leaf node to be a *group*, so `testIgnored` is only accepted between tests — a place no test code can reach. The result XML was not written at all.

So the native actual of `skipTest` only prints the reason into the captured test output, and this is documented on the `expect` declaration. I deliberately did **not** work around it by excluding the suites from `linuxX64Test` at the Gradle level: that would trade away auto-detection for contributors who do have dbusmock, and it would not help the `arm-runtime-tests` job at all, which runs the `.kexe` directly with no Gradle in the loop.

Worth noting what this does *not* leave exposed: after parts 1+2, native can no longer silently no-op **in CI** — `full-tests-x64` sets `DBUSMOCK_REQUIRED`, so a missing harness there is a hard failure on both backends. The residual `skipped=0` lie is confined to native runs on machines without dbusmock. I'll file a follow-up so the gap is tracked rather than forgotten.

## Note on "JUnit 5 `Assumptions`"

The issue proposed JUnit 5's `Assumptions.assumeTrue`. `cross_test`'s `kotlin("test")` resolves to `kotlin-test-junit` → `junit:junit:4.13.2` (verified via `:cross_test:dependencies --configuration jvmTestCompileClasspath`); there is no JUnit 5 on that classpath. `org.junit.Assume.assumeTrue` is the JUnit 4 equivalent and Gradle records its `AssumptionViolatedException` as `skipped` — which is what the numbers above show.

## Verification run

- `dbus-run-session -- ./gradlew :cross_test:jvmTest :cross_test:linuxX64Test` — green (44 skipped on JVM)
- same, with `DBUSMOCK_REQUIRED=1` — fails with the reason above (intended)
- same, with `DBUSMOCK_REQUIRED=1 DBUSMOCK_PYTHON=<venv>/bin/python3` — green, 88 real cases
- `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64 ktlintCheck apiCheck` — green; `apiCheck` did not move (test- and workflow-only changes, no `api/*.api` diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
