### PR TITLE
test(cross): run the reverse cross-runtime interop cases and skip unselected ones honestly

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -71,7 +71,10 @@ jobs:
             export DBUS_STARTER_BUS_TYPE=session
             export DBUS_STARTER_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
             export DBUS_SYSTEM_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
-            timeout 1800 ./gradlew --no-daemon allTests test crossRuntimeInteropTests --stacktrace
+            # -Dkdbus.crossRuntimeInterop.reverse.enabled selects the native-client -> JVM-peer
+            # half of CrossRuntimeInteropSmokeTest; without it those 7 cases never execute.
+            timeout 1800 ./gradlew --no-daemon allTests test crossRuntimeInteropTests \
+              -Dkdbus.crossRuntimeInterop.reverse.enabled=true --stacktrace
           '
 
       - name: Upload Failure Reports

--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -50,6 +50,14 @@ val reverseInteropEnabled = providers
     .systemProperty("kdbus.crossRuntimeInterop.reverse.enabled")
     .orElse(providers.gradleProperty("kdbus.crossRuntimeInterop.reverse.enabled"))
 
+// CrossRuntimeInteropSmokeTest only does anything under `jvmInteropTest` below, which is the task
+// that selects it and hands it a linked native test binary. Keep it out of the plain `jvmTest`
+// task (which `allTests` runs on every CI job) so it is reported exactly once, by the task that
+// actually configures it — mirroring the gcSoak gate in the root build.
+tasks.named<Test>("jvmTest") {
+    filter.excludeTestsMatching("com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest")
+}
+
 tasks.register<Test>("jvmInteropTest") {
     group = "verification"
     description = "Runs JVM<->native direct-bus interop smoke tests in cross_test."

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
@@ -31,11 +31,35 @@ import org.freedesktop.dbus.connections.transports.TransportBuilder
 import org.freedesktop.dbus.exceptions.DBusExecutionException
 import org.freedesktop.dbus.interfaces.DBusInterface
 import org.freedesktop.dbus.messages.DBusSignal
+import org.junit.Assume.assumeTrue
 
 class CrossRuntimeInteropSmokeTest {
+    /**
+     * These cases drive a real cross-runtime peer, so they only run under
+     * `:cross_test:jvmInteropTest`, which is the task that sets [CROSS_RUNTIME_ENABLED_PROP] and
+     * points [nativeTestBinaryPath] at a linked `test.kexe`. Failing an assumption (rather than
+     * returning early) makes an unselected case report SKIPPED instead of claiming a pass it never
+     * earned.
+     */
+    private fun assumeCrossRuntimeInteropSelected() = assumeTrue(
+        "$CROSS_RUNTIME_ENABLED_PROP is not \"true\": cross-runtime interop cases run only in " +
+            "the :cross_test:jvmInteropTest task.",
+        System.getProperty(CROSS_RUNTIME_ENABLED_PROP) == "true"
+    )
+
+    /**
+     * As [assumeCrossRuntimeInteropSelected], for the native-client -> JVM-peer direction, which is
+     * selected separately by [CROSS_RUNTIME_REVERSE_ENABLED_PROP].
+     */
+    private fun assumeReverseDirectionSelected() = assumeTrue(
+        "$CROSS_RUNTIME_REVERSE_ENABLED_PROP is not \"true\": the reverse (native client -> JVM " +
+            "peer) direction is selected separately.",
+        System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) == "true"
+    )
+
     @Test
     fun jvmClientInvokesNativePeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -112,7 +136,7 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun jvmClientObservesNativeSignalOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -194,7 +218,7 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun jvmClientObservesNativePropertiesChangedOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -279,7 +303,7 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun jvmClientRoundTripsUnixFdWithNativePeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -392,7 +416,7 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun jvmClientRoundTripsLargeMapWithNativePeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -468,7 +492,7 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun jvmClientRoundTripsNestedVariantWithNativePeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -547,7 +571,7 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun jvmClientRoundTripsMixedPayloadWithNativePeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -623,8 +647,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientInvokesJvmPeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -723,8 +747,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientObservesJvmSignalOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -815,8 +839,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientObservesJvmPropertiesChangedOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -903,8 +927,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientRoundTripsUnixFdWithJvmPeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -991,8 +1015,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientRoundTripsLargeMapWithJvmPeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -1087,8 +1111,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientRoundTripsNestedVariantWithJvmPeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")
@@ -1183,8 +1207,8 @@ class CrossRuntimeInteropSmokeTest {
 
     @Test
     fun nativeClientRoundTripsMixedPayloadWithJvmPeerOverDirectBus() {
-        if (System.getProperty(CROSS_RUNTIME_ENABLED_PROP) != "true") return
-        if (System.getProperty(CROSS_RUNTIME_REVERSE_ENABLED_PROP) != "true") return
+        assumeCrossRuntimeInteropSelected()
+        assumeReverseDirectionSelected()
 
         val kexe = nativeTestBinaryPath()
         assertTrue(Files.isExecutable(kexe), "Native test binary not found: $kexe")


### PR DESCRIPTION
Fixes #176

Authority for the scope, including the boundary this PR deliberately does not cross: the owner-decision comment on #176 — https://github.com/Monkopedia/sdbus-kotlin/issues/176#issuecomment-5171520219 — *"enable the reverse cases, with failures filed separately rather than fixed in the same PR"*, all three parts in scope, and *"if a newly-live case fails, that is a successful outcome for this issue, not a blocker for it."*

> **Staleness refresh, 2026-08-05.** This PR was approved against `a7bbf45`, then sat blocked on a credential issue (the bot PAT lacks `workflow` scope, so the merge — not the push — is refused) while four commits landed on `main`, one of which (#182) edits the very workflow file this PR edits. `main` has been **merged in** (`d793d59`), and **every number below was re-measured on the composed tree against `main` @ `c36abb5`** — the old numbers, taken against `a7bbf45`, are gone. The substance of the fix is unchanged; only the merge commit and these measurements are new.

## What changed

1. **`full-tests-x64` passes `-Dkdbus.crossRuntimeInterop.reverse.enabled=true`.** It was the only job running `crossRuntimeInteropTests` and it never set the property, so the reverse half of the suite had never executed in CI.
2. **The `if (…) return` guards become `org.junit.Assume` assumptions** (`assumeCrossRuntimeInteropSelected()` / `assumeReverseDirectionSelected()`), so an unselected case is reported SKIPPED rather than PASSED. 21 guards across 14 cases collapse into two named helpers that say *why* in the skip message.
3. **`CrossRuntimeInteropSmokeTest` is excluded from the plain `:cross_test:jvmTest` task** via `filter.excludeTestsMatching(...)`, mirroring the gcSoak gate in the root build. `allTests` runs `jvmTest` on every CI job, so the class was being reported green twice per run, once by a task that cannot configure it.

## Workflow-file composition with #182 (the reason for the refresh)

#182 added an `env:` block carrying `DBUSMOCK_REQUIRED: "1"` to the `Run Full Test Suite on x64` step; this PR edits that same step's `run:` script. The hunks are adjacent, so `git merge` composed them without conflict — **both survive**, and the composed step now reads:

```yaml
      - name: Run Full Test Suite on x64
        # The JVM target now has a single backend — the owned wire connection (epic #93 retired
        # dbus-java) — so there is no separate wire-parity matrix; this runs that one backend. A
        # hard `timeout` guard ensures a hung call/signal fails fast instead of stalling (a prior
        # run hung for 21 hours).
        env:
          # This job installs python3-dbusmock above, so the harness must fail — not skip — when
          # it cannot start a dbusmock peer.
          DBUSMOCK_REQUIRED: "1"
        run: |
          set -euo pipefail
          …
          dbus-run-session -- bash -lc '
            set -euo pipefail
            export DBUS_STARTER_BUS_TYPE=session
            export DBUS_STARTER_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
            export DBUS_SYSTEM_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
            # -Dkdbus.crossRuntimeInterop.reverse.enabled selects the native-client -> JVM-peer
            # half of CrossRuntimeInteropSmokeTest; without it those 7 cases never execute.
            timeout 1800 ./gradlew --no-daemon allTests test crossRuntimeInteropTests \
              -Dkdbus.crossRuntimeInterop.reverse.enabled=true --stacktrace
          '
```

Textual composition is not behavioural composition, so **#182's contract was re-measured on this tree**, both directions (`python-dbusmock` 0.38.1 in a venv via `DBUSMOCK_PYTHON`):

| condition | result |
| --- | --- |
| `DBUSMOCK_REQUIRED=1`, dbusmock **present** | `:cross_test:jvmTest` → `tests=50 skipped=0 failures=0`; all 44 dbusmock cases genuinely execute (no fake-pass) |
| `DBUSMOCK_REQUIRED=1`, dbusmock **absent** | build **FAILS** — `IllegalStateException: DBUSMOCK_REQUIRED is set but no dbusmock peer could be started: 'python3 -m dbusmock' exited immediately with status 1…` |
| `DBUSMOCK_REQUIRED` unset, dbusmock absent | skips honestly — `DbusmockSmokeTest tests=1 skipped=1 failures=0` |

The two changes do not interact: `DBUSMOCK_REQUIRED` is an environment variable read by the dbusmock harness, `kdbus.crossRuntimeInterop.reverse.enabled` is a Gradle system property forwarded only to `:cross_test:jvmInteropTest`, whose filter admits `CrossRuntimeInteropSmokeTest` alone. The native peers this PR turns on inherit `DBUSMOCK_REQUIRED` but are launched with `--ktest_gradle_filter=*NativeInteropPeerTest.…*`, so no dbusmock case runs inside them.

## Evidence — JUnit XML counts, read from the files (re-measured on `d793d59`, i.e. `main` @ `c36abb5`)

`cross_test/build/test-results/…/TEST-com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest.xml`:

| run | counts |
| --- | --- |
| **BEFORE** — `:cross_test:jvmTest` (i.e. every CI job) | `tests="14" skipped="0" failures="0" time="0.003"` |
| **AFTER** — `:cross_test:jvmTest` | class not present at all (excluded); the task reports 50 cases (was 64) |
| **AFTER** — `jvmInteropTest`, no reverse flag | `tests="14" **skipped="7"** failures="0" errors="0" time="1.499"` — 7 genuine `<skipped/>` elements, on exactly the 7 `nativeClient…` cases |
| **AFTER** — `jvmInteropTest -Dkdbus.crossRuntimeInterop.reverse.enabled=true` | `tests="14" skipped="0" failures="0" errors="0" time="17.271"` |

## The 7 newly-live reverse cases: all 7 still PASS on the composed tree

| reverse case | result | time |
| --- | --- | --- |
| `nativeClientInvokesJvmPeerOverDirectBus` | **pass** | 0.044s |
| `nativeClientObservesJvmSignalOverDirectBus` | **pass** | 0.138s |
| `nativeClientObservesJvmPropertiesChangedOverDirectBus` | **pass** | 0.144s |
| `nativeClientRoundTripsUnixFdWithJvmPeerOverDirectBus` | **pass** | 15.207s |
| `nativeClientRoundTripsLargeMapWithJvmPeerOverDirectBus` | **pass** | 0.069s |
| `nativeClientRoundTripsNestedVariantWithJvmPeerOverDirectBus` | **pass** | 0.052s |
| `nativeClientRoundTripsMixedPayloadWithJvmPeerOverDirectBus` | **pass** | 0.061s |

No marshalling or wire defect surfaced, and nothing moved versus the pre-merge measurement. **But that green is only partly real** — see below.

## Full composed CI step, run end to end locally

The exact command line from the composed workflow step (`allTests test crossRuntimeInteropTests -D… --stacktrace`, under `dbus-run-session -- bash -lc`, with `DBUSMOCK_REQUIRED=1` in the environment) — **BUILD SUCCESSFUL in 3m 4s**:

| module / task | counts |
| --- | --- |
| `(root) jvmTest` | `tests=327 skipped=0 failures=0 errors=0` |
| `(root) linuxX64Test` | `tests=297 skipped=0 failures=0 errors=0` |
| `codegen test` | `tests=83 skipped=0 failures=0 errors=0` |
| `plugin test` | `tests=6 skipped=0 failures=0 errors=0` |
| `cross_test jvmTest` | `tests=50 skipped=0 failures=0 errors=0` |
| `cross_test linuxX64Test` | `tests=62 skipped=0 failures=0 errors=0` |
| `cross_test jvmInteropTest` | `tests=14 skipped=0 failures=0 errors=0` |

`CrossRuntimeInteropSmokeTest` appears in **exactly one** result file across the whole run (`jvmInteropTest`), which is the double-reporting fix doing its job.

This also closes the one gap the earlier revision of this body flagged as CI-only: a separate `--no-daemon :cross_test:jvmInteropTest -Dkdbus.crossRuntimeInterop.reverse.enabled=true` run reports `tests=14 skipped=0 failures=0 errors=0 time=17.315`, so the `-D` flag demonstrably reaches the task through the `--no-daemon` invocation shape the workflow uses.

## ⚠️ What enabling them exposed instead — filed as #183, not fixed here

Every case in this suite spawns the native peer with `--ktest_no_exit_code` and then asserts `assertEquals(0, process.exitValue(), "Native peer failed…")`. That flag makes the Kotlin/Native launcher **exit 0 even when its own tests fail**, measured directly against the linked `test.kexe`:

```
… --ktest_no_exit_code   → ##teamcity[testFailed name='nativeClientCanRoundTripUnixFdWith…' …]   exit 0
… (flag removed)         → same failure                                                          exit 1
```

So the exit-code assertion is a tautology. For the forward direction that is merely redundant — the JVM side does real asserting on the round-tripped payload. For the reverse direction it matters: three of the seven cases this PR turns on (`…ObservesJvmSignal…`, `…ObservesJvmPropertiesChanged…`, `…RoundTripsUnixFd…`) have **no assertion other than the exit code**, so they would report PASSED even if the native client never saw the signal or the fd. Details, the measurement, and a proposed fix are in **#183**.

Not fixed here, per the scope boundary in the owner-decision comment: this PR is test-infrastructure, and adding JVM-side observations to three cases plus a `testFailed`-scanning helper is separate, reviewable work. Read the pass table above with #183 in mind: 4 of the 7 are meaningfully green, 3 are green-but-not-yet-measuring.

## Verification run (all on `d793d59`; `JAVA_HOME=java-17-openjdk`)

- `dbus-run-session -- ./gradlew :cross_test:jvmInteropTest -Dkdbus.crossRuntimeInterop.reverse.enabled=true` — green, `tests=14 skipped=0`
- `dbus-run-session -- ./gradlew :cross_test:jvmInteropTest` (no flag) — green, `tests=14 skipped=7`
- `dbus-run-session -- ./gradlew :cross_test:jvmTest` — green, 50 cases, `CrossRuntimeInteropSmokeTest` absent from the results
- composed CI step verbatim (`allTests test crossRuntimeInteropTests`, `DBUSMOCK_REQUIRED=1`) — green, table above
- #182's `DBUSMOCK_REQUIRED` contract, both directions — table above
- `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64 ktlintCheck apiCheck` — green; **`apiCheck` did not move** (clean tree afterwards, no `api/*.api` diff)

And on CI, [run 30972628090](https://github.com/Monkopedia/sdbus-kotlin/actions/runs/30972628090) on `d793d59` — **all 15 checks pass**. Its `full-tests-x64` log renders the step env as `DBUSMOCK_REQUIRED: 1` wrapping the `timeout 1800 ./gradlew --no-daemon allTests test crossRuntimeInteropTests -Dkdbus.crossRuntimeInterop.reverse.enabled=true --stacktrace` script, with `> Task :cross_test:jvmInteropTest` executing downstream. The runner apt-installs `python3-dbusmock 0.31.1`, so a green job under `DBUSMOCK_REQUIRED=1` is itself proof the dbusmock suites really ran rather than skipping. This is the first CI run of #182's and this PR's changes together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
