### PR TITLE
feat(codegen): map D-Bus annotations onto runtime vtable flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Changed — codegen
+
+- **Standard D-Bus annotations are now mapped onto the runtime vtable/proxy flags.** The generated
+  adaptor carries `org.freedesktop.DBus.Deprecated` (on the interface, methods, signals and
+  properties) and `org.freedesktop.DBus.Property.EmitsChangedSignal` into its `addVTable` block, and
+  both generators honor `org.freedesktop.DBus.Method.NoReply` — the adaptor registers the method with
+  `hasNoReply = true` and the proxy calls it with `dontExpectReply = true`. Previously all three
+  annotations were parsed and then dropped, so the introspection a running adaptor served could
+  disagree with the XML it was generated from. (#159)
+- `Deprecated` is advisory: it changes only the introspection metadata the adaptor publishes.
+  `EmitsChangedSignal` is declarative property-update behavior — values other than the D-Bus default
+  (`invalidates`, `const`, `false`) now register the matching `Flags.PropertyUpdateBehaviorFlags`
+  entry. It previously reached the generator only to decide whether a *writable* property got a
+  `notifying` delegate, so read-only properties dropped it entirely. Neither annotation changes how
+  a method is called. (#159)
+- **`Method.NoReply` is a behavior change for consumers who regenerate from unchanged XML.** If your
+  XML already declares it on a method, regenerating switches that method to fire-and-forget on both
+  sides: the adaptor sends no reply and the proxy awaits none, so failures no longer propagate back
+  to the caller. Before this change the annotation was silently ignored and both sides used ordinary
+  request/reply semantics. Drop the annotation from the XML if you were relying on that. (#159)
+
 ### Changed — dependencies
 
 - **xmlutil** is now `implementation`-scoped rather than `api`-scoped in `sdbus-kotlin-codegen`. It is

--- a/codegen/src/main/kotlin/AdaptorGenerator.kt
+++ b/codegen/src/main/kotlin/AdaptorGenerator.kt
@@ -24,6 +24,9 @@ package com.monkopedia.sdbus
 
 import com.monkopedia.sdbus.Access.READWRITE
 import com.monkopedia.sdbus.Access.WRITE
+import com.monkopedia.sdbus.Annotations.DEPRECATED
+import com.monkopedia.sdbus.Annotations.EMITS_CHANGED_SIGNAL
+import com.monkopedia.sdbus.Annotations.METHOD_NO_REPLY
 import com.monkopedia.sdbus.Direction.OUT
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -130,12 +133,27 @@ class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageO
         )
     }
 
+    /**
+     * Emits the `addVTable` block, carrying the standard D-Bus annotations through to the vtable
+     * flags so the introspection the running adaptor serves matches the XML it was generated from:
+     * `org.freedesktop.DBus.Deprecated` on the interface/method/signal/property, and
+     * `org.freedesktop.DBus.Method.NoReply` on the method. Only non-default flags are emitted --
+     * `EmitsChangedSignal` resolves to a [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags]
+     * entry only when it is not the D-Bus default of `true`, which the runtime already applies.
+     */
     override fun FunSpec.Builder.buildRegistration(intf: Interface) {
         addModifiers(PUBLIC)
         addModifiers(OVERRIDE)
         val codeBlock = CodeBlock.builder().apply {
             add("obj.%T(%T) {\n", ClassName("com.monkopedia.sdbus", "addVTable"), intfName(intf))
             withIndent {
+                if (intf.annotations.isSet(DEPRECATED)) {
+                    add("%T {\n", ClassName("com.monkopedia.sdbus", "interfaceFlags"))
+                    withIndent {
+                        add("isDeprecated = true\n")
+                    }
+                    add("}\n")
+                }
                 intf.methods.forEach {
                     add(
                         "%T(%T(%S)) {\n",
@@ -160,6 +178,12 @@ class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageO
                                 *outs.map { it.name }.toTypedArray()
                             )
                         }
+                        if (it.annotations.isSet(DEPRECATED)) {
+                            add("isDeprecated = true\n")
+                        }
+                        if (it.annotations.isSet(METHOD_NO_REPLY)) {
+                            add("hasNoReply = true\n")
+                        }
                         add(
                             "asyncCall(this@%N::%N)\n",
                             intf.name.simpleName + "Adaptor",
@@ -183,6 +207,9 @@ class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageO
                                 arg.name ?: "arg$index"
                             )
                         }
+                        if (it.annotations.isSet(DEPRECATED)) {
+                            add("isDeprecated = true\n")
+                        }
                     }
                     add("}\n")
                 }
@@ -199,6 +226,10 @@ class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageO
                             intf.name.simpleName + "Adaptor",
                             it.name.decapitalCamelCase
                         )
+                        if (it.annotations.isSet(DEPRECATED)) {
+                            add("isDeprecated = true\n")
+                        }
+                        it.updateBehavior(intf)?.let { flag -> add("+%M\n", flag) }
                     }
                     add("}\n")
                 }
@@ -209,21 +240,42 @@ class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageO
     }
 
     private companion object {
-        private const val EMITS_CHANGED_SIGNAL =
-            "org.freedesktop.DBus.Property.EmitsChangedSignal"
+        private val propertyUpdateBehaviorFlags =
+            ClassName("com.monkopedia.sdbus", "Flags", "PropertyUpdateBehaviorFlags")
 
         /**
          * Resolves the effective `EmitsChangedSignal` value for [this] property: a property-level
          * annotation wins, otherwise the enclosing interface's annotation provides the default,
-         * otherwise the D-Bus default is `true`. Returns `true` unless the value is `false`/`const`
-         * (the two values for which the spec says no `PropertiesChanged` is emitted).
+         * otherwise the D-Bus default is `true`.
          */
-        private fun Property.emitsChangedSignal(intf: Interface): Boolean {
-            val value = annotations.firstOrNull { it.name == EMITS_CHANGED_SIGNAL }?.value
+        private fun Property.emitsChangedSignalValue(intf: Interface): String =
+            annotations.firstOrNull { it.name == EMITS_CHANGED_SIGNAL }?.value
                 ?: intf.annotations.firstOrNull { it.name == EMITS_CHANGED_SIGNAL }?.value
                 ?: "true"
-            return value != "false" && value != "const"
-        }
+
+        /**
+         * Whether `PropertiesChanged` is emitted for [this] property, i.e. the resolved
+         * `EmitsChangedSignal` value is neither `false` nor `const` (the two values for which the
+         * spec says no signal is emitted).
+         */
+        private fun Property.emitsChangedSignal(intf: Interface): Boolean =
+            emitsChangedSignalValue(intf).let { it != "false" && it != "const" }
+
+        /**
+         * The [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags] entry matching [this]
+         * property's resolved `EmitsChangedSignal` value, or `null` for the D-Bus default (`true`)
+         * which the runtime already applies.
+         */
+        private fun Property.updateBehavior(intf: Interface): MemberName? =
+            when (emitsChangedSignalValue(intf)) {
+                "invalidates" -> MemberName(
+                    propertyUpdateBehaviorFlags,
+                    "EMITS_INVALIDATION_SIGNAL"
+                )
+                "const" -> MemberName(propertyUpdateBehaviorFlags, "CONST_PROPERTY_VALUE")
+                "false" -> MemberName(propertyUpdateBehaviorFlags, "EMITS_NO_SIGNAL")
+                else -> null
+            }
 
         /**
          * A representable initial value for the [notifying] delegate backing a writable property, or

--- a/codegen/src/main/kotlin/ProxyGenerator.kt
+++ b/codegen/src/main/kotlin/ProxyGenerator.kt
@@ -24,6 +24,7 @@ package com.monkopedia.sdbus
 
 import com.monkopedia.sdbus.Access.READWRITE
 import com.monkopedia.sdbus.Access.WRITE
+import com.monkopedia.sdbus.Annotations.METHOD_NO_REPLY
 import com.monkopedia.sdbus.Direction.OUT
 import com.monkopedia.sdbus.NamingManager.SimpleType
 import com.squareup.kotlinpoet.ClassName
@@ -63,6 +64,11 @@ class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOve
             addParameter("proxy", proxy)
         }
 
+    /**
+     * `org.freedesktop.DBus.Method.NoReply` is the one annotation that changes call semantics, so
+     * it has to be honored on both sides: the adaptor registers the method with `hasNoReply`, and
+     * the proxy must therefore not wait for a reply that will never be sent.
+     */
     override fun methodBuilder(intf: Interface, method: Method): FunSpec.Builder =
         FunSpec.builder(method.name.decapitalCamelCase).apply {
             addModifiers(OVERRIDE)
@@ -86,6 +92,9 @@ class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOve
                         method.name
                     )
                     withIndent {
+                        if (method.annotations.isSet(METHOD_NO_REPLY)) {
+                            add("dontExpectReply = true\n")
+                        }
                         if (outputs.size > 1) {
                             add("isGroupedReturn = true\n")
                         }

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -174,6 +174,20 @@ data class Property(
 @XmlSerialName("annotation")
 data class Annotation(val name: String, val value: String, val doc: Doc? = null)
 
+/** Names of the standard D-Bus annotations the generators act on. See the table below. */
+internal object Annotations {
+    const val DEPRECATED = "org.freedesktop.DBus.Deprecated"
+    const val METHOD_NO_REPLY = "org.freedesktop.DBus.Method.NoReply"
+    const val EMITS_CHANGED_SIGNAL = "org.freedesktop.DBus.Property.EmitsChangedSignal"
+}
+
+/**
+ * Whether the boolean annotation [name] is present on [this] and set. Both `Deprecated` and
+ * `Method.NoReply` default to `false` when absent, so anything other than `true` means unset.
+ */
+internal fun List<Annotation>.isSet(name: String): Boolean =
+    firstOrNull { it.name == name }?.value == "true"
+
 /**
  * Name	Values (separated by ,)	Description
  * org.freedesktop.DBus.Deprecated	true,false	Whether or not the entity is deprecated; defaults to false

--- a/codegen/src/test/resources/MediaPlayer2/adaptor.1.kt
+++ b/codegen/src/test/resources/MediaPlayer2/adaptor.1.kt
@@ -1,5 +1,6 @@
 package org.mpris.mediaplayer2
 
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
 import com.monkopedia.sdbus.MethodName
 import com.monkopedia.sdbus.Object
 import com.monkopedia.sdbus.PropertyName
@@ -86,6 +87,7 @@ public abstract class PlayerAdaptor(
       }
       prop(PropertyName("Position")) {
         with(this@PlayerAdaptor::position)
+        +EMITS_NO_SIGNAL
       }
       prop(PropertyName("MinimumRate")) {
         with(this@PlayerAdaptor::minimumRate)
@@ -110,6 +112,7 @@ public abstract class PlayerAdaptor(
       }
       prop(PropertyName("CanControl")) {
         with(this@PlayerAdaptor::canControl)
+        +EMITS_NO_SIGNAL
       }
     }
   }

--- a/codegen/src/test/resources/VTableFlagsTest/adaptor.0.kt
+++ b/codegen/src/test/resources/VTableFlagsTest/adaptor.0.kt
@@ -1,0 +1,84 @@
+package org.example.flags
+
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.CONST_PROPERTY_VALUE
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.interfaceFlags
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.notifying
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import kotlin.String
+import kotlin.UInt
+import kotlin.Unit
+
+public abstract class LegacyAdaptor(
+  public val obj: Object,
+) : Legacy {
+  override var counter: UInt by
+      obj.notifying(Legacy.Companion.INTERFACE_NAME, PropertyName("Counter"), 0u)
+
+  public override fun register() {
+    obj.addVTable(Legacy.Companion.INTERFACE_NAME) {
+      interfaceFlags {
+        isDeprecated = true
+      }
+      method(MethodName("Ping")) {
+        inputParamNames = listOf("message")
+        outputParamNames = listOf("reply")
+        asyncCall(this@LegacyAdaptor::ping)
+      }
+      method(MethodName("OldPing")) {
+        inputParamNames = listOf("message")
+        outputParamNames = listOf("reply")
+        isDeprecated = true
+        asyncCall(this@LegacyAdaptor::oldPing)
+      }
+      method(MethodName("FireAndForget")) {
+        inputParamNames = listOf("value")
+        hasNoReply = true
+        asyncCall(this@LegacyAdaptor::fireAndForget)
+      }
+      signal(SignalName("Changed")) {
+        with<String>("reason")
+      }
+      signal(SignalName("OldChanged")) {
+        with<String>("reason")
+        isDeprecated = true
+      }
+      prop(PropertyName("Name")) {
+        with(this@LegacyAdaptor::name)
+      }
+      prop(PropertyName("OldName")) {
+        with(this@LegacyAdaptor::oldName)
+        isDeprecated = true
+      }
+      prop(PropertyName("MachineId")) {
+        with(this@LegacyAdaptor::machineId)
+        +CONST_PROPERTY_VALUE
+      }
+      prop(PropertyName("Counter")) {
+        with(this@LegacyAdaptor::counter)
+        +EMITS_INVALIDATION_SIGNAL
+      }
+      prop(PropertyName("Silent")) {
+        with(this@LegacyAdaptor::silent)
+        +EMITS_NO_SIGNAL
+      }
+    }
+  }
+
+  public suspend fun onChanged(reason: String): Unit = obj.emitSignal(Legacy.Companion.INTERFACE_NAME, SignalName("Changed")) {
+    call(reason)
+  }
+
+  public suspend fun onOldChanged(reason: String): Unit = obj.emitSignal(Legacy.Companion.INTERFACE_NAME, SignalName("OldChanged")) {
+    call(reason)
+  }
+}

--- a/codegen/src/test/resources/VTableFlagsTest/adaptor.1.kt
+++ b/codegen/src/test/resources/VTableFlagsTest/adaptor.1.kt
@@ -1,0 +1,23 @@
+package org.example.flags
+
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.prop
+
+public abstract class QuietAdaptor(
+  public val obj: Object,
+) : Quiet {
+  public override fun register() {
+    obj.addVTable(Quiet.Companion.INTERFACE_NAME) {
+      prop(PropertyName("Inherited")) {
+        with(this@QuietAdaptor::inherited)
+        +EMITS_NO_SIGNAL
+      }
+      prop(PropertyName("Overridden")) {
+        with(this@QuietAdaptor::overridden)
+      }
+    }
+  }
+}

--- a/codegen/src/test/resources/VTableFlagsTest/interface.0.kt
+++ b/codegen/src/test/resources/VTableFlagsTest/interface.0.kt
@@ -1,0 +1,31 @@
+package org.example.flags
+
+import com.monkopedia.sdbus.InterfaceName
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.UInt
+
+public interface Legacy {
+  public val name: String
+
+  public val oldName: String
+
+  public val machineId: String
+
+  public var counter: UInt
+
+  public var silent: Boolean
+
+  public fun register()
+
+  public suspend fun ping(message: String): String
+
+  public suspend fun oldPing(message: String): String
+
+  public suspend fun fireAndForget(`value`: Int)
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.example.flags.Legacy")
+  }
+}

--- a/codegen/src/test/resources/VTableFlagsTest/interface.1.kt
+++ b/codegen/src/test/resources/VTableFlagsTest/interface.1.kt
@@ -1,0 +1,16 @@
+package org.example.flags
+
+import com.monkopedia.sdbus.InterfaceName
+import kotlin.String
+
+public interface Quiet {
+  public val inherited: String
+
+  public val overridden: String
+
+  public fun register()
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.example.flags.Quiet")
+  }
+}

--- a/codegen/src/test/resources/VTableFlagsTest/proxy.0.kt
+++ b/codegen/src/test/resources/VTableFlagsTest/proxy.0.kt
@@ -1,0 +1,73 @@
+package org.example.flags
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.MutablePropertyDelegate
+import com.monkopedia.sdbus.PropertyDelegate
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.callMethodAsync
+import com.monkopedia.sdbus.mutableDelegate
+import com.monkopedia.sdbus.propDelegate
+import com.monkopedia.sdbus.signalFlow
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.UInt
+import kotlin.Unit
+import kotlinx.coroutines.flow.Flow
+
+public class LegacyProxy(
+  public val proxy: Proxy,
+) : Legacy {
+  public val nameProperty: PropertyDelegate<LegacyProxy, String> =
+      proxy.propDelegate(Legacy.Companion.INTERFACE_NAME, PropertyName("Name")) 
+
+  public val oldNameProperty: PropertyDelegate<LegacyProxy, String> =
+      proxy.propDelegate(Legacy.Companion.INTERFACE_NAME, PropertyName("OldName")) 
+
+  public val machineIdProperty: PropertyDelegate<LegacyProxy, String> =
+      proxy.propDelegate(Legacy.Companion.INTERFACE_NAME, PropertyName("MachineId")) 
+
+  public var counterProperty: MutablePropertyDelegate<LegacyProxy, UInt> =
+      proxy.mutableDelegate(Legacy.Companion.INTERFACE_NAME, PropertyName("Counter")) 
+
+  public var silentProperty: MutablePropertyDelegate<LegacyProxy, Boolean> =
+      proxy.mutableDelegate(Legacy.Companion.INTERFACE_NAME, PropertyName("Silent")) 
+
+  override val name: String by nameProperty
+
+  override val oldName: String by oldNameProperty
+
+  override val machineId: String by machineIdProperty
+
+  override var counter: UInt by counterProperty
+
+  override var silent: Boolean by silentProperty
+
+  public val changed: Flow<String> =
+      proxy.signalFlow(Legacy.Companion.INTERFACE_NAME, SignalName("Changed")) {
+        call { a: String -> a }
+      }
+
+  public val oldChanged: Flow<String> =
+      proxy.signalFlow(Legacy.Companion.INTERFACE_NAME, SignalName("OldChanged")) {
+        call { a: String -> a }
+      }
+
+  public override fun register() {
+  }
+
+  override suspend fun ping(message: String): String = proxy.callMethodAsync(Legacy.Companion.INTERFACE_NAME, MethodName("Ping")) {
+    call(message)
+  }
+
+  override suspend fun oldPing(message: String): String = proxy.callMethodAsync(Legacy.Companion.INTERFACE_NAME, MethodName("OldPing")) {
+    call(message)
+  }
+
+  override suspend fun fireAndForget(`value`: Int): Unit = proxy.callMethodAsync(Legacy.Companion.INTERFACE_NAME, MethodName("FireAndForget")) {
+    dontExpectReply = true
+    call(`value`)
+  }
+}

--- a/codegen/src/test/resources/VTableFlagsTest/proxy.1.kt
+++ b/codegen/src/test/resources/VTableFlagsTest/proxy.1.kt
@@ -1,0 +1,24 @@
+package org.example.flags
+
+import com.monkopedia.sdbus.PropertyDelegate
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.propDelegate
+import kotlin.String
+
+public class QuietProxy(
+  public val proxy: Proxy,
+) : Quiet {
+  public val inheritedProperty: PropertyDelegate<QuietProxy, String> =
+      proxy.propDelegate(Quiet.Companion.INTERFACE_NAME, PropertyName("Inherited")) 
+
+  public val overriddenProperty: PropertyDelegate<QuietProxy, String> =
+      proxy.propDelegate(Quiet.Companion.INTERFACE_NAME, PropertyName("Overridden")) 
+
+  override val inherited: String by inheritedProperty
+
+  override val overridden: String by overriddenProperty
+
+  public override fun register() {
+  }
+}

--- a/codegen/src/test/resources/VTableFlagsTest/test.xml
+++ b/codegen/src/test/resources/VTableFlagsTest/test.xml
@@ -1,0 +1,63 @@
+<!-- Exercises the standard D-Bus annotations that map onto runtime vtable flags. No other
+     checked-in fixture declares Deprecated or Method.NoReply, so this is the only golden file
+     covering them. -->
+<node>
+  <interface name="org.example.flags.Legacy">
+    <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+
+    <method name="Ping">
+      <arg type="s" name="message" direction="in"/>
+      <arg type="s" name="reply" direction="out"/>
+    </method>
+
+    <method name="OldPing">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+      <arg type="s" name="message" direction="in"/>
+      <arg type="s" name="reply" direction="out"/>
+    </method>
+
+    <method name="FireAndForget">
+      <annotation name="org.freedesktop.DBus.Method.NoReply" value="true"/>
+      <arg type="i" name="value" direction="in"/>
+    </method>
+
+    <signal name="Changed">
+      <arg type="s" name="reason"/>
+    </signal>
+
+    <signal name="OldChanged">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+      <arg type="s" name="reason"/>
+    </signal>
+
+    <property name="Name" type="s" access="read"/>
+
+    <property name="OldName" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </property>
+
+    <property name="MachineId" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+    </property>
+
+    <property name="Counter" type="u" access="readwrite">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates"/>
+    </property>
+
+    <property name="Silent" type="b" access="readwrite">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+  </interface>
+
+  <!-- The interface-level EmitsChangedSignal supplies the default for properties that do not
+       declare their own, per the D-Bus spec. -->
+  <interface name="org.example.flags.Quiet">
+    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+
+    <property name="Inherited" type="s" access="read"/>
+
+    <property name="Overridden" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+    </property>
+  </interface>
+</node>


### PR DESCRIPTION
Fixes #159

## Authority

Per the [owner-decision comment on #159](https://github.com/Monkopedia/sdbus-kotlin/issues/159#issuecomment-5171721340): Jason chose *implement* over declining or investigating first — `AdaptorGenerator` maps the standard D-Bus annotations onto the runtime vtable builders that already exist, so a generated service's served introspection matches the XML it was generated from. That comment is the authoritative scope statement for this PR.

## What changed

| Annotation | Applies to | Emitted as | Weight |
| --- | --- | --- | --- |
| `org.freedesktop.DBus.Deprecated` | interface, method, signal, property | `interfaceFlags { isDeprecated = true }` / `isDeprecated = true` | **advisory** — metadata only; it changes the introspection a client reads and nothing else |
| `org.freedesktop.DBus.Method.NoReply` | method | `hasNoReply = true` on the adaptor, `dontExpectReply = true` on the proxy | **semantic** — genuinely changes call behavior on both sides |
| `org.freedesktop.DBus.Property.EmitsChangedSignal` | property (interface supplies the default) | `+EMITS_INVALIDATION_SIGNAL` / `+CONST_PROPERTY_VALUE` / `+EMITS_NO_SIGNAL` | **semantic** for the served contract; the generator already read it for the `notifying` delegate, now it reaches the vtable too |

The generated code uses exactly the idiom of the hand-written `src/nativeTest/.../IntegrationTestsAdaptor.kt`, which compiles in CI.

### Advisory vs. semantic, spelled out

The owner decision asked for this to be stated explicitly:

- **`Deprecated` is advisory.** Getting it wrong costs a client a wrong hint in `busctl introspect`; nothing at runtime behaves differently. Both backends carry it: native passes it through sd-bus, and the JVM backend already reads `isDeprecated` off each vtable item when it builds the introspection XML it serves (`WireServe.buildMeta`).
- **`Method.NoReply` is semantic, and it is the one this PR had to get right.** Setting `hasNoReply` on the adaptor means the JVM dispatcher returns without sending a reply (`WireDbusObject.addVTable`, the `if (method.hasNoReply) return@register Unit` path) and sd-bus marks the vtable entry likewise. **Emitting it only on the adaptor would have shipped a generated pair that deadlocks**: the adaptor never replies, and the generated proxy would sit in `callMethodAsync` waiting for a reply that is never sent. So the proxy side sets `dontExpectReply = true` for the same annotation. This is the only change outside `AdaptorGenerator`, and it exists solely so the two halves of one generated binding agree.
- **`EmitsChangedSignal`** is resolved with the spec's precedence — property annotation wins, else the enclosing interface's annotation, else `true` — reusing (and now sharing) the logic `AdaptorGenerator` already had for deciding which writable properties get `notifying` delegates.

### Deliberately not emitted

- **`isPrivileged`**: no standard D-Bus annotation maps to it. It is an sd-bus vtable concept with no XML spelling, so nothing in the introspection can drive it.
- **Interface-level `Method.NoReply`**: the spec's annotation table defines `Method.NoReply` for methods, and only `EmitsChangedSignal` has a documented interface-level default-inheritance rule. Emitting an interface-wide `hasNoReply` would also desynchronize from the proxy, which resolves no-reply per method. Interface-level `Deprecated` *is* emitted, via `interfaceFlags`.
- **Default values**: `EmitsChangedSignal="true"` produces no output, because that is the D-Bus default and `Flags` already starts with `EMITS_CHANGE_SIGNAL` set. This keeps the fixture diff to genuine semantic changes rather than 14 no-op lines.

## Fixture evidence

**No checked-in XML declared `Deprecated` or `Method.NoReply`** — verified by grepping every `test.xml` (the full annotation inventory across the 20 fixtures is 16x `EmitsChangedSignal`, 9x `GDBus.DocString`, 4x `Method.Async`, 1x `QtTypeName`, 1x `DocString.Short`). So this PR adds a fixture, `codegen/src/test/resources/VTableFlagsTest/`, which is the only golden coverage of those two annotations. Its XML exercises interface-level `Deprecated`, per-method `Deprecated` and `NoReply`, per-signal and per-property `Deprecated`, all three non-default `EmitsChangedSignal` values, and interface-level `EmitsChangedSignal` inheritance (including a property that overrides it).

The **only existing fixture that changed** is `MediaPlayer2/adaptor.1.kt`, and the entire diff is:

```
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
...
       prop(PropertyName("Position")) {
         with(this@PlayerAdaptor::position)
+        +EMITS_NO_SIGNAL
       }
...
       prop(PropertyName("CanControl")) {
         with(this@PlayerAdaptor::canControl)
+        +EMITS_NO_SIGNAL
       }
```

Those are exactly the two properties in `MediaPlayer2/test.xml` carrying `EmitsChangedSignal="false"` (lines 103 and 135). Every other one of the 66 fixture files is byte-identical.

## Verification

- `./gradlew :codegen:test` — green (golden-fixture suite, now including `VTableFlagsTest`)
- `./gradlew :codegen:build ktlintCheck apiCheck` — green
- **`apiCheck` did not move**: `codegen/api/codegen.api` is unchanged. The new shared annotation-name constants and the `List<Annotation>.isSet` helper are `internal`.
- **`WRITE_FILES` is `false`** in `GeneratorTest.kt:88`. It was flipped to `true` to regenerate, then flipped back, and the suite was re-run afterwards so the assertions are real rather than vacuous.

## Sequencing

This is the first of three `:codegen` PRs regenerating the same golden fixtures (#159, then #160, then #158). The other two branch off `main` independently, so whichever lands second will need a rebase over this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
