### PR TITLE
docs: correct the served-introspection claim for #159 (measured on both backends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,23 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   properties) and `org.freedesktop.DBus.Property.EmitsChangedSignal` into its `addVTable` block, and
   both generators honor `org.freedesktop.DBus.Method.NoReply` — the adaptor registers the method with
   `hasNoReply = true` and the proxy calls it with `dontExpectReply = true`. Previously all three
-  annotations were parsed and then dropped, so the introspection a running adaptor served could
-  disagree with the XML it was generated from. (#159)
-- `Deprecated` is advisory: it changes only the introspection metadata the adaptor publishes.
-  `EmitsChangedSignal` is declarative property-update behavior — values other than the D-Bus default
-  (`invalidates`, `const`, `false`) now register the matching `Flags.PropertyUpdateBehaviorFlags`
-  entry. It previously reached the generator only to decide whether a *writable* property got a
-  `notifying` delegate, so read-only properties dropped it entirely. Neither annotation changes how
-  a method is called. (#159)
+  annotations were parsed and then dropped, so nothing in the generated code carried them at all.
+  (#159)
+- **How much of that reaches the introspection a running adaptor *serves* depends on the backend, and
+  it is not yet a full round-trip of the source XML.** Measured against a live adaptor on both
+  backends via `org.freedesktop.DBus.Introspectable.Introspect`:
+  `Deprecated` on a **method, signal or property** is served on **both** backends; `Deprecated` on the
+  **interface** and `EmitsChangedSignal` (`const` / `invalidates` / `false`) are served on **native
+  only** — the JVM backend reads no vtable flags beyond the per-member deprecated bit; and
+  `org.freedesktop.DBus.Method.NoReply` is served by **neither** backend. This affects only what an
+  adaptor advertises to external introspectors (`busctl`, d-feet, other language bindings), not how it
+  behaves. Tracked in #193. (#159)
+- `Deprecated` is advisory: where it is served, it changes only the introspection metadata the
+  adaptor publishes. `EmitsChangedSignal` is declarative property-update behavior — values other
+  than the D-Bus default (`invalidates`, `const`, `false`) now register the matching
+  `Flags.PropertyUpdateBehaviorFlags` entry. It previously reached the generator only to decide
+  whether a *writable* property got a `notifying` delegate, so read-only properties dropped it
+  entirely. Neither annotation changes how a method is called. (#159)
 - **`Method.NoReply` is a behavior change for consumers who regenerate from unchanged XML.** If your
   XML already declares it on a method, regenerating switches that method to fire-and-forget on both
   sides: the adaptor sends no reply and the proxy awaits none, so failures no longer propagate back

--- a/codegen/src/main/kotlin/AdaptorGenerator.kt
+++ b/codegen/src/main/kotlin/AdaptorGenerator.kt
@@ -135,11 +135,16 @@ class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageO
 
     /**
      * Emits the `addVTable` block, carrying the standard D-Bus annotations through to the vtable
-     * flags so the introspection the running adaptor serves matches the XML it was generated from:
-     * `org.freedesktop.DBus.Deprecated` on the interface/method/signal/property, and
+     * flags: `org.freedesktop.DBus.Deprecated` on the interface/method/signal/property, and
      * `org.freedesktop.DBus.Method.NoReply` on the method. Only non-default flags are emitted --
      * `EmitsChangedSignal` resolves to a [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags]
      * entry only when it is not the D-Bus default of `true`, which the runtime already applies.
+     *
+     * Setting a vtable flag is not the same as advertising it. What the running adaptor then serves
+     * from `org.freedesktop.DBus.Introspectable.Introspect` is a subset of the source XML:
+     * member-level `Deprecated` is served on both backends, interface-level `Deprecated` and
+     * `EmitsChangedSignal` on the native backend only, and `Method.NoReply` on neither. Tracked in
+     * https://github.com/Monkopedia/sdbus-kotlin/issues/193.
      */
     override fun FunSpec.Builder.buildRegistration(intf: Interface) {
         addModifiers(PUBLIC)

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -42,6 +42,7 @@ Every row below is pinned by tests on current `main`, not by intention:
 | Behavior when the bus is unreachable | ✅ throws `Error` | ✅ throws `Error` | JVM fixed in #81; the in-process stub backend is an explicit internal test opt-in only |
 | Event loop (`startEventLoop`/`stopEventLoop`) | no-op (always running) | required for dispatch; `createObject`/`createProxy` auto-start it | Same calling pattern works on both; `startEventLoop` is idempotent (#114), and each native connection gets its own loop thread (#128) |
 | Strict deserialization (signature mismatch rejected) | ✅ | ✅ | Same `System.Error.ENXIO` error |
+| Vtable-flag annotations in **served** `Introspect` XML | ⚠️ partial | ⚠️ partial | Member-level `Deprecated` served on both; interface-level `Deprecated` and `EmitsChangedSignal` (`const`/`invalidates`/`false`) **native only**; `org.freedesktop.DBus.Method.NoReply` served by **neither**. Affects what an adaptor *advertises*, not how it behaves — see #193 |
 
 ✅ = identical observable behavior, asserted on both backends.
 


### PR DESCRIPTION
Refs #193 — the correction half of the split. **Documentation only.** No generator behavior changes, no runtime changes, no API changes.

## The problem

`CHANGELOG.md`'s `[Unreleased]` #159 entry (landed two days ago via #187) told consumers that mapping D-Bus annotations onto vtable flags makes a running adaptor's served introspection agree with the XML it was generated from. `AdaptorGenerator.kt`'s KDoc carried the same sentence. A release is pending and that entry is consumer-facing release-note material, so it should not ship as written.

## I verified this empirically, on both backends

The audit on #193 established the JVM half by code reading and *inferred* the native half from sd-bus's vtable contract. Rather than replace one unverified claim with another, I ran the round-trip: a temporary probe test exported an object with `interfaceFlags { isDeprecated = true }`, a `hasNoReply` method, a deprecated method, and three properties carrying `CONST_PROPERTY_VALUE` / `EMITS_INVALIDATION_SIGNAL` / `EMITS_NO_SIGNAL`, then called `org.freedesktop.DBus.Introspectable.Introspect` on it under `dbus-run-session` — once as `linuxX64Test`, once as `jvmTest`. The probe was deleted before committing; the diff here is documentation only.

Measured result:

| Annotation | native (sd-bus) | JVM (wire) |
| --- | --- | --- |
| `Deprecated` on method / signal / property | served | served |
| `Deprecated` on the **interface** | served | **not served** |
| `EmitsChangedSignal` → `const` / `invalidates` / `false` | served | **not served** |
| `org.freedesktop.DBus.Method.NoReply` | **not served** | **not served** |

Native XML, verbatim (`Fire` is the `hasNoReply` method):

```xml
<interface name="com.monkopedia.sdbus.probe534028.Iface">
 <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
 <method name="Fire">
 </method>
 <method name="OldMethod">
  <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
 </method>
 <property name="ConstProp" type="s" access="read">
  <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
 </property>
 <property name="InvalidatingProp" type="s" access="read">
  <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates"/>
 </property>
 <property name="SilentProp" type="s" access="read">
  <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
</interface>
```

JVM XML, same vtable:

```xml
<interface name="com.monkopedia.sdbus.probe616531.Iface">
  <method name="Fire">
  </method>
  <method name="OldMethod">
    <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
  </method>
  <property name="ConstProp" type="s" access="read"/>
  <property name="InvalidatingProp" type="s" access="read"/>
  <property name="SilentProp" type="s" access="read"/>
</interface>
```

**The measurement contradicts #193 on one point, in the issue's own favour on the rest.** #193 lists `Method.NoReply` as a native-serves / JVM-does-not divergence. It is not — **neither** backend advertises it. `Flags.native.kt:61-63` reads

```kotlin
if (has(METHOD_NO_REPLY)) {
    sdbusFlags = sdbusFlags or 0u // SD_BUS_VTABLE_METHOD_NO_REPLY
}
```

i.e. the sd-bus constant was never wired up, so the flag never reaches sd-bus's introspection writer. The two genuine JVM-only gaps (interface-level `Deprecated`, `EmitsChangedSignal`) are confirmed exactly as #193 described, as is the JVM positive control — `grep -rn "PropertyUpdateBehaviorFlags\|GeneralFlags" --include='*.kt' src/jvmMain/` returns nothing, `src/nativeMain/` returns 8 hits. I have left a comment on #193 recording the `NoReply` correction.

## The change

- **`CHANGELOG.md`** — the #159 entries. The false round-trip sentence is replaced by a factual per-backend statement of what is served, labelled as measured. Structure and `(#159)` refs are unchanged, and the `Method.NoReply` behavior-change disclosure is kept verbatim: it is accurate (that half *is* honoured on both backends) and load-bearing for anyone regenerating from unchanged XML. No `[Unreleased]` link ref added — per `CLAUDE.md` that is minted at release.
- **`codegen/src/main/kotlin/AdaptorGenerator.kt`** — `buildRegistration` KDoc. Drops the round-trip clause and adds a paragraph making the distinction explicit: setting a vtable flag is not the same as advertising it.
- **`docs/BACKENDS.md`** — one summary-matrix row. The matrix's silence on vtable flags reads as parity, which is what left a reader unwarned; the row states the partial support and points at #193.

## What this deliberately does NOT do

It does not implement JVM support for the missing flags and does not touch the generator. Whether the JVM backend should serve these annotations so it matches native is the **open owner decision on #193**, which is why this is `Refs`, not `Fixes` — the issue stays open for that ruling. If the answer is "implement it", these docs change again; in the meantime nothing ships claiming a round-trip that does not happen.

## Verification

- `./gradlew :codegen:test ktlintCheck apiCheck` — BUILD SUCCESSFUL. No `api/*.api` file moved and no golden fixture changed (`git status` clean after the run).
- `git diff --stat main...HEAD` → `CHANGELOG.md`, `AdaptorGenerator.kt` (KDoc only), `docs/BACKENDS.md`. 25 insertions, 10 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
