### PR TITLE
fix(jvm): bound hostile wire input to the D-Bus spec limits and stop a dead reader reporting healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Fixed — JVM backend
+
+- **The JVM wire backend now bounds hostile peer input, and a dead connection says so.** Length
+  prefixes and container nesting arriving from a peer were trusted without limit, and a u32 length
+  at or above 2^31 narrowed to a *negative* `Int` that passed every `length > size` check. A single
+  frame could therefore raise `OutOfMemoryError` (a declared 2.1 GB body from 16 bytes of input),
+  `NegativeArraySizeException`, `StackOverflowError` (nested variants cost 3 bytes per level) or
+  `ClassCastException` (a header field carrying the wrong variant type) — and an array declaring
+  `0xFFFFFFF0` bytes decoded *successfully* to an empty list, silently losing the real contents.
+  Wire lengths are now validated while still unsigned against the D-Bus specification's own limits
+  (128 MiB per message, 64 MiB per array, container nesting depth 64), and header fields use checked
+  casts. Anything past those limits is now rejected as a malformed message where it previously
+  raised one of the errors above. (#190)
+- **A reader thread that dies no longer leaves the connection reporting itself healthy.** The reader
+  caught only `IOException` and `DBusMarshallingException`; anything else killed the thread while the
+  socket stayed open, so the connection accepted calls that could only ever time out. It now catches
+  broadly, records the cause, closes the socket, fails in-flight calls with the real error rather
+  than a generic "connection closed", and refuses further sends — so a call on a dead connection
+  fails immediately instead of waiting out its timeout. (#190)
+
 ### Added — codegen
 
 - **Generated code now carries KDoc taken from the introspection XML.** Documentation reaches the

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusMarshaller.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusMarshaller.kt
@@ -60,6 +60,28 @@ internal enum class Endian(val code: Byte) {
 internal class DBusMarshallingException(message: String) : RuntimeException(message)
 
 /**
+ * The D-Bus specification's hard protocol limits, which `dbus-daemon` enforces on every message it
+ * relays. Using the spec's own numbers keeps the checks below a CONFORMANCE test rather than an
+ * invented threshold: nothing a conforming peer may legally send is refused.
+ */
+internal object DBusLimits {
+    /** `DBUS_MAXIMUM_MESSAGE_LENGTH`: 2^27 bytes for header + alignment padding + body. */
+    const val MAX_MESSAGE_LENGTH = 134_217_728
+
+    /** `DBUS_MAXIMUM_ARRAY_LENGTH`: 2^26 bytes of array content (the header fields are an array). */
+    const val MAX_ARRAY_LENGTH = 67_108_864
+
+    /**
+     * Maximum container-nesting depth. The spec caps a signature at "32 array type codes and 32
+     * open parentheses", and says so with the consequence spelled out: "the maximum total depth of
+     * recursion is 64". Counting EVERY container level (array, struct, dict-entry, variant) against
+     * that 64 therefore accepts every signature the spec permits, while still refusing a
+     * nested-variant bomb — each level of which costs only 3 bytes on the wire.
+     */
+    const val MAX_TYPE_RECURSION_DEPTH = 64
+}
+
+/**
  * The parsed model of a single complete D-Bus type, carrying its natural [alignment] and the
  * signature fragment it [code]s back to.
  */
@@ -121,23 +143,31 @@ internal object DBusSignatureParser {
     }
 
     /** Parses exactly one complete type starting at [index]; returns it and the next index. */
-    fun parseOne(signature: String, index: Int): Pair<DBusType, Int> {
+    fun parseOne(signature: String, index: Int): Pair<DBusType, Int> = parseOne(signature, index, 0)
+
+    private fun parseOne(signature: String, index: Int, depth: Int): Pair<DBusType, Int> {
         if (index >= signature.length) {
             throw DBusMarshallingException("Unexpected end of signature '$signature'")
+        }
+        if (depth > DBusLimits.MAX_TYPE_RECURSION_DEPTH) {
+            throw DBusMarshallingException(
+                "Signature nests deeper than the D-Bus maximum of " +
+                    "${DBusLimits.MAX_TYPE_RECURSION_DEPTH}: '$signature'"
+            )
         }
         return when (val c = signature[index]) {
             'a' -> {
                 if (signature.getOrNull(index + 1) == '{') {
-                    val (entry, next) = parseDictEntry(signature, index + 1)
+                    val (entry, next) = parseDictEntry(signature, index + 1, depth + 1)
                     DBusType.ArrayType(entry) to next
                 } else {
-                    val (element, next) = parseOne(signature, index + 1)
+                    val (element, next) = parseOne(signature, index + 1, depth + 1)
                     DBusType.ArrayType(element) to next
                 }
             }
 
-            '(' -> parseStruct(signature, index)
-            '{' -> parseDictEntry(signature, index)
+            '(' -> parseStruct(signature, index, depth + 1)
+            '{' -> parseDictEntry(signature, index, depth + 1)
             'v' -> DBusType.VariantType to index + 1
             'y', 'b', 'n', 'q', 'i', 'u', 'x', 't', 'd', 's', 'o', 'g', 'h' ->
                 DBusType.Basic(c) to index + 1
@@ -148,14 +178,14 @@ internal object DBusSignatureParser {
         }
     }
 
-    private fun parseStruct(signature: String, openIndex: Int): Pair<DBusType, Int> {
+    private fun parseStruct(signature: String, openIndex: Int, depth: Int): Pair<DBusType, Int> {
         val fields = mutableListOf<DBusType>()
         var index = openIndex + 1
         while (signature.getOrNull(index) != ')') {
             if (index >= signature.length) {
                 throw DBusMarshallingException("Unterminated struct in '$signature'")
             }
-            val (field, next) = parseOne(signature, index)
+            val (field, next) = parseOne(signature, index, depth)
             fields.add(field)
             index = next
         }
@@ -165,9 +195,9 @@ internal object DBusSignatureParser {
         return DBusType.StructType(fields) to index + 1
     }
 
-    private fun parseDictEntry(signature: String, openIndex: Int): Pair<DBusType, Int> {
-        val (key, afterKey) = parseOne(signature, openIndex + 1)
-        val (value, afterValue) = parseOne(signature, afterKey)
+    private fun parseDictEntry(signature: String, openIndex: Int, depth: Int): Pair<DBusType, Int> {
+        val (key, afterKey) = parseOne(signature, openIndex + 1, depth)
+        val (value, afterValue) = parseOne(signature, afterKey, depth)
         if (signature.getOrNull(afterValue) != '}') {
             throw DBusMarshallingException("Unterminated dict-entry in '$signature'")
         }
@@ -361,6 +391,9 @@ internal class DBusReader(private val bytes: ByteArray, offset: Int, private val
     var offset: Int = offset
         private set
 
+    // How many container levels deep [unmarshalValue] currently is; see [nested].
+    private var depth = 0
+
     fun align(boundary: Int) {
         val rem = offset % boundary
         if (rem != 0) offset += boundary - rem
@@ -394,15 +427,54 @@ internal class DBusReader(private val bytes: ByteArray, offset: Int, private val
         return bytes[offset++].toInt() and 0xff
     }
 
+    /**
+     * Reads a 32-bit wire length prefix, rejecting anything above [limit] BEFORE it is narrowed to
+     * [Int]. [readRaw] zero-extends the four bytes into a [Long], so the comparison is exact and
+     * unsigned and the narrowing that follows is provably in `0..limit`.
+     *
+     * This is the ONLY place a wire-supplied length becomes an [Int], which is what makes the
+     * overflow structurally impossible rather than merely guarded: no `length > bytes.size` check
+     * downstream can be handed a negative length that silently passes it (issue #190).
+     */
+    private fun readLength(limit: Int, what: String): Int {
+        val length = readRaw(4)
+        if (length > limit) {
+            throw DBusMarshallingException(
+                "Declared $what length $length exceeds the D-Bus maximum of $limit bytes"
+            )
+        }
+        return length.toInt()
+    }
+
     /** Reads [types], one value per type, in order. */
     fun unmarshal(types: List<DBusType>): List<Any?> = types.map { unmarshalValue(it) }
 
     fun unmarshalValue(type: DBusType): Any? = when (type) {
         is DBusType.Basic -> unmarshalBasic(type.type)
-        is DBusType.ArrayType -> unmarshalArray(type)
-        is DBusType.StructType -> unmarshalStruct(type)
-        is DBusType.DictEntryType -> unmarshalDictEntry(type)
-        DBusType.VariantType -> unmarshalVariant()
+        is DBusType.ArrayType -> nested { unmarshalArray(type) }
+        is DBusType.StructType -> nested { unmarshalStruct(type) }
+        is DBusType.DictEntryType -> nested { unmarshalDictEntry(type) }
+        DBusType.VariantType -> nested { unmarshalVariant() }
+    }
+
+    /**
+     * Runs [block] one container level deeper, refusing to descend past
+     * [DBusLimits.MAX_TYPE_RECURSION_DEPTH]. Demarshalling is recursive, so without this a peer can
+     * spend 3 bytes per level to buy a stack frame and overflow the stack from a tiny body.
+     */
+    private fun <T> nested(block: () -> T): T {
+        if (depth >= DBusLimits.MAX_TYPE_RECURSION_DEPTH) {
+            throw DBusMarshallingException(
+                "Container nesting exceeds the D-Bus maximum depth of " +
+                    "${DBusLimits.MAX_TYPE_RECURSION_DEPTH}"
+            )
+        }
+        depth++
+        try {
+            return block()
+        } finally {
+            depth--
+        }
     }
 
     private fun unmarshalBasic(type: Char): Any = when (type) {
@@ -451,7 +523,7 @@ internal class DBusReader(private val bytes: ByteArray, offset: Int, private val
     private fun readString(lengthPrefixBytes: Int): String {
         val length = if (lengthPrefixBytes == 4) {
             align(4)
-            readRaw(4).toInt()
+            readLength(DBusLimits.MAX_MESSAGE_LENGTH, "string")
         } else {
             readByte()
         }
@@ -465,7 +537,7 @@ internal class DBusReader(private val bytes: ByteArray, offset: Int, private val
 
     private fun unmarshalArray(type: DBusType.ArrayType): Any {
         align(4)
-        val byteLength = readRaw(4).toInt()
+        val byteLength = readLength(DBusLimits.MAX_ARRAY_LENGTH, "array")
         align(type.element.alignment)
         val end = offset + byteLength
         if (end > bytes.size) {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -140,6 +140,13 @@ internal class DBusWireConnection private constructor(
     private var readerThread: Thread? = null
 
     /**
+     * The error that tore the reader thread down, or null while the connection is healthy (and
+     * after an ordinary [close]). Set exactly once, by the reader itself, before it exits.
+     */
+    @Volatile
+    private var readerFailure: Throwable? = null
+
+    /**
      * The unique name assigned by the bus during [hello] (e.g. `:1.42`), or null before Hello — and
      * always null on a brokerless [direct] connection, which has no daemon to assign one.
      */
@@ -199,16 +206,28 @@ internal class DBusWireConnection private constructor(
     private fun startReader() {
         running = true
         readerThread = thread(start = true, isDaemon = true, name = "sdbus-jvm-wire-reader") {
+            var fatal: Throwable? = null
             try {
                 while (running) {
                     dispatch(resolveReceivedFds(WireMessageCodec.read(input)))
                 }
-            } catch (_: IOException) {
-                // Expected on close() (socket closed) or peer disconnect.
-            } catch (_: DBusMarshallingException) {
-                // Malformed frame; treat as fatal for this connection.
+            } catch (t: Throwable) {
+                // Anything that escapes the loop is fatal to this connection: the stream is FRAMED,
+                // so once a frame fails to parse the byte offset is no longer known and nothing
+                // after it can be decoded. Catching Throwable rather than just IOException /
+                // DBusMarshallingException is what stops a hostile or buggy frame from killing the
+                // reader while `running` stayed true and the socket stayed open -- which left the
+                // connection reporting itself healthy while delivering nothing, so every later call
+                // could only ever time out (issue #190). `running == false` means close() did this.
+                if (running) fatal = IOException("D-Bus reader failed: $t", t)
             } finally {
-                failAllPending(IOException("D-Bus connection closed"))
+                // Make the death OBSERVABLE rather than silent: stop pretending to run, close the
+                // socket so subsequent sends fail immediately instead of vanishing into a peer we
+                // can no longer read, and hand in-flight callers the real cause.
+                running = false
+                readerFailure = fatal
+                runCatching { socket.close() }
+                failAllPending(fatal ?: IOException("D-Bus connection closed"))
             }
         }
     }
@@ -243,6 +262,16 @@ internal class DBusWireConnection private constructor(
     // --- sending --------------------------------------------------------------------------------
 
     private fun nextSerial(): Int = serialCounter.incrementAndGet()
+
+    /**
+     * Refuses to put anything on the wire once the reader has died: a connection with no reader can
+     * never deliver a reply, so the alternative is the caller waiting out its full timeout for a
+     * reply that provably is not coming. This is the one thing that made the old silent reader death
+     * indistinguishable from a healthy-but-slow bus (issue #190).
+     */
+    private fun checkAlive() {
+        readerFailure?.let { throw IOException("D-Bus connection is dead: ${it.message}", it) }
+    }
 
     private fun writeMessage(message: WireMessage) {
         // Collect any UnixFds in the body (depth-first, body order) and replace each with its
@@ -337,6 +366,7 @@ internal class DBusWireConnection private constructor(
      * pending entry if they give up waiting (timeout).
      */
     private fun dispatchCall(request: WireMessage): PendingCall {
+        checkAlive()
         val serial = nextSerial()
         val future = CompletableFuture<WireMessage>()
         pending[serial] = future
@@ -411,6 +441,7 @@ internal class DBusWireConnection private constructor(
 
     /** Fire-and-forget send (e.g. a method call with NO_REPLY_EXPECTED, a signal, or a reply). */
     fun send(message: WireMessage): Int {
+        checkAlive()
         val serial = nextSerial()
         writeMessage(message.copy(serial = serial))
         return serial

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireMessage.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireMessage.kt
@@ -108,6 +108,9 @@ internal data class WireMessage(
 internal object WireMessageCodec {
     private const val PROTOCOL_VERSION = 1
 
+    // Fixed header (12 bytes) + the header-fields array length prefix (4 bytes).
+    private const val PREFIX_BYTES = 16
+
     // The full header up to (but excluding) the trailing pad+body, expressed as one signature so
     // the marshaller produces correct absolute alignment counted from the message start.
     private const val HEADER_SIGNATURE = "yyyyuua(yv)"
@@ -178,17 +181,28 @@ internal object WireMessageCodec {
     fun read(input: InputStream): WireMessage {
         // The fixed header (12 bytes) plus the header-fields array length prefix (4 bytes) are
         // always present, so we can safely read 16 bytes to learn the remaining sizes.
-        val prefix = readFully(input, 16)
+        val prefix = readFully(input, PREFIX_BYTES)
         val endian = Endian.fromCode(prefix[0])
         val pre = DBusReader(prefix, 0, endian)
         // "yyyyuuu": endian, type, flags, version, bodyLength, serial, then the a(yv) length.
         val header = pre.unmarshal(DBusSignatureParser.parse("yyyyuuu"))
-        val bodyLength = (header[4] as UInt).toInt()
-        val fieldsLength = (header[6] as UInt).toInt()
+        // Both lengths are peer-supplied and go straight into a ByteArray allocation, so they are
+        // validated while still UNSIGNED: narrowing first would turn anything >= 2^31 into a
+        // negative Int, which every downstream size check happily accepts (issue #190).
+        val bodyLength = checkedLength(header[4] as UInt, DBusLimits.MAX_MESSAGE_LENGTH, "body")
+        val fieldsLength =
+            checkedLength(header[6] as UInt, DBusLimits.MAX_ARRAY_LENGTH, "header fields")
 
-        val headerEnd = 16 + fieldsLength
-        val paddedHeaderEnd = align8(headerEnd)
-        val remaining = readFully(input, (paddedHeaderEnd - 16) + bodyLength)
+        val paddedHeaderEnd = align8(PREFIX_BYTES + fieldsLength)
+        // The spec's maximum covers the WHOLE message, not each part, so check the total too.
+        val totalLength = paddedHeaderEnd.toLong() + bodyLength
+        if (totalLength > DBusLimits.MAX_MESSAGE_LENGTH) {
+            throw DBusMarshallingException(
+                "Message length $totalLength exceeds the D-Bus maximum of " +
+                    "${DBusLimits.MAX_MESSAGE_LENGTH} bytes"
+            )
+        }
+        val remaining = readFully(input, (paddedHeaderEnd - PREFIX_BYTES) + bodyLength)
 
         val full = ByteArray(prefix.size + remaining.size)
         System.arraycopy(prefix, 0, full, 0, prefix.size)
@@ -218,15 +232,15 @@ internal object WireMessageCodec {
             val code = (field.fields[0] as UByte).toInt()
             val variant = field.fields[1] as Message.JvmVariantPayload
             when (code) {
-                WireHeaderField.PATH -> path = variant.value as String
-                WireHeaderField.INTERFACE -> interfaceName = variant.value as String
-                WireHeaderField.MEMBER -> member = variant.value as String
-                WireHeaderField.ERROR_NAME -> errorName = variant.value as String
-                WireHeaderField.REPLY_SERIAL -> replySerial = (variant.value as UInt).toInt()
-                WireHeaderField.DESTINATION -> destination = variant.value as String
-                WireHeaderField.SENDER -> sender = variant.value as String
-                WireHeaderField.SIGNATURE -> signature = variant.value as String
-                WireHeaderField.UNIX_FDS -> unixFds = (variant.value as UInt).toInt()
+                WireHeaderField.PATH -> path = variant.asString("PATH")
+                WireHeaderField.INTERFACE -> interfaceName = variant.asString("INTERFACE")
+                WireHeaderField.MEMBER -> member = variant.asString("MEMBER")
+                WireHeaderField.ERROR_NAME -> errorName = variant.asString("ERROR_NAME")
+                WireHeaderField.REPLY_SERIAL -> replySerial = variant.asUInt("REPLY_SERIAL")
+                WireHeaderField.DESTINATION -> destination = variant.asString("DESTINATION")
+                WireHeaderField.SENDER -> sender = variant.asString("SENDER")
+                WireHeaderField.SIGNATURE -> signature = variant.asString("SIGNATURE")
+                WireHeaderField.UNIX_FDS -> unixFds = variant.asUInt("UNIX_FDS")
             }
         }
 
@@ -253,6 +267,33 @@ internal object WireMessageCodec {
             body = body
         )
     }
+
+    /**
+     * Validates a peer-supplied 32-bit length against [limit] while it is still UNSIGNED, so the
+     * [Int] it returns is provably in `0..limit` and no later size comparison can be fooled by a
+     * value that went negative on the way in.
+     */
+    private fun checkedLength(length: UInt, limit: Int, what: String): Int {
+        if (length > limit.toUInt()) {
+            throw DBusMarshallingException(
+                "Declared $what length $length exceeds the D-Bus maximum of $limit bytes"
+            )
+        }
+        return length.toInt()
+    }
+
+    // The spec fixes the type of every header field, so a variant carrying anything else is a
+    // malformed message -- report it as one instead of letting an unchecked cast raise a
+    // ClassCastException that no caller (nor the reader thread) is prepared for.
+    private fun Message.JvmVariantPayload.asString(field: String): String = value as? String
+        ?: throw DBusMarshallingException(
+            "Header field $field must be a string, got variant of type '$signature'"
+        )
+
+    private fun Message.JvmVariantPayload.asUInt(field: String): Int = (value as? UInt)?.toInt()
+        ?: throw DBusMarshallingException(
+            "Header field $field must be a uint32, got variant of type '$signature'"
+        )
 
     private fun align8(value: Int): Int {
         val rem = value % 8

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/HostileWireInputTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/HostileWireInputTest.kt
@@ -1,0 +1,307 @@
+package com.monkopedia.sdbus.internal.jvmdbus
+
+import com.monkopedia.sdbus.Message
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.newsclub.net.unix.AFUNIXServerSocket
+import org.newsclub.net.unix.AFUNIXSocketAddress
+
+/**
+ * Hostile-input coverage for the JVM wire backend (issue #190).
+ *
+ * Every case here is a frame (or a body fragment) that a peer can put on the wire but that no
+ * conforming sender would produce: lengths above the D-Bus specification's maxima, lengths that go
+ * NEGATIVE when narrowed to [Int], container nesting far past the spec's recursion limit, and
+ * header fields carrying the wrong variant type. All of them must surface as
+ * [DBusMarshallingException] — never as an [OutOfMemoryError], a [NegativeArraySizeException], a
+ * [StackOverflowError], a [ClassCastException], and above all never as a *successful* decode of the
+ * wrong value.
+ *
+ * The last test stands up a real fake AF_UNIX peer (SASL EXTERNAL, then one hostile frame, then it
+ * holds the socket open) and pins the umbrella failure: a connection whose reader thread has died
+ * must say so, rather than accepting calls that can only ever time out.
+ */
+class HostileWireInputTest {
+
+    // --- framing-level lengths ------------------------------------------------------------------
+
+    @Test
+    fun frameDeclaringA2GbBody_isRejectedWithoutAttemptingTheAllocation() {
+        val frame = framePrefix(bodyLength = 0x7F000000L, fieldsLength = 0L)
+
+        assertFailsWith<DBusMarshallingException> {
+            WireMessageCodec.read(ByteArrayInputStream(frame))
+        }
+    }
+
+    @Test
+    fun frameWithBodyLengthThatNarrowsNegative_isRejected() {
+        val frame = framePrefix(bodyLength = 0x80000000L, fieldsLength = 0L)
+
+        assertFailsWith<DBusMarshallingException> {
+            WireMessageCodec.read(ByteArrayInputStream(frame))
+        }
+    }
+
+    @Test
+    fun frameWithHeaderFieldsLengthThatNarrowsNegative_isRejected() {
+        val frame = framePrefix(bodyLength = 0L, fieldsLength = 0x80000000L)
+
+        assertFailsWith<DBusMarshallingException> {
+            WireMessageCodec.read(ByteArrayInputStream(frame))
+        }
+    }
+
+    // --- body-level lengths ---------------------------------------------------------------------
+
+    @Test
+    fun stringLengthThatNarrowsNegative_isRejectedInsteadOfIndexingOutOfBounds() {
+        for (declared in listOf(0x80000000L, 0xFFFFFFFFL)) {
+            val bytes = littleEndianU32(declared) + byteArrayOf('A'.code.toByte(), 0)
+
+            assertFailsWith<DBusMarshallingException>("string length $declared") {
+                DBusMarshaller.unmarshal("s", bytes, 0, Endian.LITTLE)
+            }
+        }
+    }
+
+    /**
+     * The worst of the set, because it never threw: an array whose declared byte-length narrows to
+     * a negative [Int] made `end < offset`, the fill loop never ran, and the caller got a
+     * successful decode of an EMPTY array indistinguishable from a genuinely empty one. Silent
+     * peer-driven data loss, reachable with no hostile intent at all.
+     */
+    @Test
+    fun arrayLengthThatNarrowsNegative_isRejectedRatherThanSilentlyDecodingToEmpty() {
+        for (declared in listOf(0xFFFFFFF0L, 0x80000000L)) {
+            val bytes = littleEndianU32(declared) + byteArrayOf(1, 2, 3, 4)
+
+            assertFailsWith<DBusMarshallingException>("array length $declared") {
+                DBusMarshaller.unmarshal("ay", bytes, 0, Endian.LITTLE)
+            }
+        }
+    }
+
+    // --- nesting ----------------------------------------------------------------------------------
+
+    /**
+     * A variant nesting level costs 3 bytes on the wire (`0x01 'v' 0x00`), so a ~30 KB body reaches
+     * 10,000 frames of recursion in the demarshaller.
+     */
+    @Test
+    fun nestedVariantsBeyondSpecDepth_areRejectedInsteadOfOverflowingTheStack() {
+        assertFailsWith<DBusMarshallingException> {
+            DBusMarshaller.unmarshal("v", nestedVariantBody(10_000), 0, Endian.LITTLE)
+        }
+    }
+
+    /** The depth cap is the spec's, so nesting the spec permits must still decode. */
+    @Test
+    fun nestedVariantsWithinSpecDepth_stillDecode() {
+        val result = DBusMarshaller.unmarshal("v", nestedVariantBody(30), 0, Endian.LITTLE)
+
+        var payload = result.values.single() as Message.JvmVariantPayload
+        repeat(30) { payload = payload.value as Message.JvmVariantPayload }
+        assertEquals(42u.toUByte(), payload.value)
+    }
+
+    // --- header-field types -----------------------------------------------------------------------
+
+    @Test
+    fun headerFieldCarryingTheWrongVariantType_isRejectedAsAMarshallingFailure() {
+        val pathAsUInt = frameWithHeaderFields(listOf(headerField(WireHeaderField.PATH, "u", 7u)))
+        val memberAsByteArray = frameWithHeaderFields(
+            listOf(headerField(WireHeaderField.MEMBER, "ay", listOf(1u.toUByte())))
+        )
+
+        assertFailsWith<DBusMarshallingException>("PATH as 'u'") {
+            WireMessageCodec.decode(pathAsUInt)
+        }
+        assertFailsWith<DBusMarshallingException>("MEMBER as 'ay'") {
+            WireMessageCodec.decode(memberAsByteArray)
+        }
+    }
+
+    // --- the umbrella failure ---------------------------------------------------------------------
+
+    /**
+     * A hostile peer sends exactly ONE frame the parser cannot handle. The frame itself is fatal
+     * either way — the stream is framed, so a failed parse leaves the byte offset unknown and
+     * nothing further can be decoded — but the connection must then REPORT that it is dead.
+     * Previously the reader thread just vanished (only [IOException] and [DBusMarshallingException]
+     * were caught) while `running` stayed true and the socket stayed open, so every later call sat
+     * out its full timeout against a black hole.
+     */
+    @Test
+    fun hostileFrameFromAPeer_failsTheConnectionVisiblyInsteadOfSilently() {
+        val frame = frameWithHeaderFields(listOf(headerField(WireHeaderField.PATH, "u", 7u)))
+        HostilePeer(frame).use { peer ->
+            val connection = DBusWireConnection.connectDirect(peer.address)
+            try {
+                assertTrue(connection.isReaderRunning, "reader should run right after connect")
+                assertTrue(peer.awaitFrameSent(), "the hostile peer should have sent its frame")
+                awaitReaderStopped(connection)
+
+                val start = System.nanoTime()
+                val failure = assertFailsWith<IOException> {
+                    connection.callBlocking(
+                        WireMessage(
+                            type = WireMessageType.METHOD_CALL,
+                            path = "/",
+                            interfaceName = "org.freedesktop.DBus.Peer",
+                            member = "Ping"
+                        ),
+                        timeoutMillis = 5_000
+                    )
+                }
+                val elapsedMillis = (System.nanoTime() - start) / 1_000_000
+                assertTrue(
+                    elapsedMillis < 2_000,
+                    "a call on a dead connection must fail fast, took ${elapsedMillis}ms: $failure"
+                )
+            } finally {
+                connection.close()
+            }
+        }
+    }
+
+    private fun awaitReaderStopped(connection: DBusWireConnection) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (connection.isReaderRunning && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10)
+        }
+        assertFalse(connection.isReaderRunning, "the reader thread should have stopped")
+    }
+
+    // --- frame construction -------------------------------------------------------------------------
+
+    private fun littleEndianU32(value: Long): ByteArray =
+        ByteArray(4) { ((value shr (8 * it)) and 0xff).toByte() }
+
+    /**
+     * The 16 bytes that open every frame: the fixed header plus the header-fields array length
+     * prefix. That is all [WireMessageCodec.read] needs to decide how much more to allocate, so a
+     * length defect is reachable from these bytes alone.
+     */
+    private fun framePrefix(bodyLength: Long, fieldsLength: Long): ByteArray = byteArrayOf(
+        Endian.LITTLE.code,
+        WireMessageType.METHOD_RETURN.code.toByte(),
+        0,
+        1
+    ) + littleEndianU32(bodyLength) + littleEndianU32(1L) + littleEndianU32(fieldsLength)
+
+    private fun headerField(code: Int, variantSignature: String, value: Any?) =
+        Message.JvmStructPayload(
+            "(yv)",
+            listOf(code.toUByte(), Message.JvmVariantPayload(variantSignature, value))
+        )
+
+    /** A complete, well-framed METHOD_RETURN whose header fields are whatever [fields] says. */
+    private fun frameWithHeaderFields(fields: List<Message.JvmStructPayload>): ByteArray {
+        val writer = DBusWriter(Endian.LITTLE)
+        writer.marshal(
+            DBusSignatureParser.parse("yyyyuua(yv)"),
+            listOf(
+                Endian.LITTLE.code,
+                WireMessageType.METHOD_RETURN.code.toUByte(),
+                0.toUByte(),
+                1.toUByte(),
+                0u,
+                1u,
+                fields
+            )
+        )
+        writer.align(8)
+        return writer.toByteArray()
+    }
+
+    /** [depth] nested variants wrapping a single byte: `(0x01 'v' 0x00) * depth`, then `y` = 42. */
+    private fun nestedVariantBody(depth: Int): ByteArray {
+        val body = ByteArray(depth * 3 + 4)
+        for (level in 0 until depth) {
+            body[level * 3] = 1
+            body[level * 3 + 1] = 'v'.code.toByte()
+            body[level * 3 + 2] = 0
+        }
+        val tail = depth * 3
+        body[tail] = 1
+        body[tail + 1] = 'y'.code.toByte()
+        body[tail + 2] = 0
+        body[tail + 3] = 42
+        return body
+    }
+}
+
+/**
+ * A fake AF_UNIX D-Bus peer: it completes the SERVER side of SASL EXTERNAL (+ `AGREE_UNIX_FD` +
+ * `BEGIN`), writes one hand-crafted [frame], and then holds the socket OPEN until [close]. Holding
+ * it open is the point — it is what distinguishes "the peer hung up" (which the reader has always
+ * reported) from "the peer is still there and we can no longer understand it".
+ */
+private class HostilePeer(private val frame: ByteArray) : AutoCloseable {
+    private val file = File.createTempFile("sdbus-hostile-", ".sock", File("/tmp"))
+        .also { it.delete() }
+    private val server = AFUNIXServerSocket.bindOn(AFUNIXSocketAddress.of(file))
+    private val frameSent = CountDownLatch(1)
+    private val stop = CountDownLatch(1)
+
+    val address: String = "unix:path=${file.absolutePath}"
+
+    private val acceptor = thread(isDaemon = true, name = "sdbus-hostile-peer") {
+        runCatching { server.accept().use(::serve) }
+    }
+
+    fun awaitFrameSent(): Boolean = frameSent.await(10, TimeUnit.SECONDS)
+
+    private fun serve(socket: Socket) {
+        val input = socket.getInputStream()
+        val output = socket.getOutputStream()
+        input.read() // the mandatory NUL that opens the auth conversation
+        readLine(input) // AUTH EXTERNAL <uid-hex>
+        writeLine(output, "OK 0123456789abcdef0123456789abcdef")
+        readLine(input) // NEGOTIATE_UNIX_FD
+        writeLine(output, "AGREE_UNIX_FD")
+        readLine(input) // BEGIN
+        output.write(frame)
+        output.flush()
+        frameSent.countDown()
+        stop.await()
+    }
+
+    private fun readLine(input: InputStream): String {
+        val line = StringBuilder()
+        var previous = -1
+        while (true) {
+            val c = input.read()
+            if (c < 0) return line.toString()
+            if (previous == '\r'.code && c == '\n'.code) return line.dropLast(1).toString()
+            line.append(c.toChar())
+            previous = c
+        }
+    }
+
+    private fun writeLine(output: OutputStream, line: String) {
+        output.write((line + "\r\n").toByteArray(StandardCharsets.US_ASCII))
+        output.flush()
+    }
+
+    override fun close() {
+        stop.countDown()
+        runCatching { server.close() }
+        runCatching { acceptor.join(2_000) }
+        file.delete()
+    }
+}


### PR DESCRIPTION
Fixes #190

The JVM wire backend trusted every length prefix and nesting depth a peer put on the wire, and the reader thread caught only `IOException` and `DBusMarshallingException`. Anything else escaped: the thread exited, the socket stayed open, `running` stayed `true` — so the connection reported itself healthy while delivering nothing, and every later call timed out.

## Red first

The audit's throwaway probes are now a real test — `src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/HostileWireInputTest.kt` — including a fake AF_UNIX peer that completes SASL EXTERNAL + `AGREE_UNIX_FD` + `BEGIN`, sends exactly **one** hostile frame, and then **holds the socket open** (that is the point: it distinguishes "the peer hung up", which the reader always reported, from "the peer is still there and we can no longer understand it").

Commit `1abd276` contains the tests only. Verbatim output of `./gradlew :jvmTest --tests "com.monkopedia.sdbus.internal.jvmdbus.HostileWireInputTest"` at that commit — **8 of 9 failed**:

```
FAIL  frameDeclaringA2GbBody_isRejectedWithoutAttemptingTheAllocation[jvm]
        java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was java.lang.OutOfMemoryError: Java heap space
FAIL  frameWithBodyLengthThatNarrowsNegative_isRejected[jvm]
        java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was java.lang.NegativeArraySizeException: -2147483648
FAIL  frameWithHeaderFieldsLengthThatNarrowsNegative_isRejected[jvm]
        java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was java.lang.NegativeArraySizeException: -2147483648
FAIL  nestedVariantsBeyondSpecDepth_areRejectedInsteadOfOverflowingTheStack[jvm]
        java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was java.lang.StackOverflowError
FAIL  stringLengthThatNarrowsNegative_isRejectedInsteadOfIndexingOutOfBounds[jvm]
        java.lang.AssertionError: string length 2147483648. Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was java.lang.StringIndexOutOfBoundsException: Range [4, 4 + -2147483648) out of bounds for length 6
FAIL  arrayLengthThatNarrowsNegative_isRejectedRatherThanSilentlyDecodingToEmpty[jvm]
        java.lang.AssertionError: array length 4294967280. Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was completed successfully with the result: <DBusUnmarshalResult(values=[[]], offset=4)>.
FAIL  headerFieldCarryingTheWrongVariantType_isRejectedAsAMarshallingFailure[jvm]
        java.lang.AssertionError: PATH as 'u'. Expected an exception of class com.monkopedia.sdbus.internal.jvmdbus.DBusMarshallingException to be thrown, but was java.lang.ClassCastException: class kotlin.UInt cannot be cast to class java.lang.String (kotlin.UInt is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')
FAIL  hostileFrameFromAPeer_failsTheConnectionVisiblyInsteadOfSilently[jvm]
        java.lang.AssertionError: Expected an exception of class java.io.IOException to be thrown, but was com.monkopedia.sdbus.internal.jvmdbus.DBusCallException: org.freedesktop.DBus.Error.Timeout: Method call timed out after 5000ms
PASS  nestedVariantsWithinSpecDepth_stillDecode[jvm]
```

That last `PASS` is the positive control: nesting the spec *permits* already decoded correctly before the fix, so the suite discriminates the defect rather than the input shape. All eight are green after `6e02cf5`.

Reproduce: `git checkout 1abd276 && ./gradlew :jvmTest --tests "com.monkopedia.sdbus.internal.jvmdbus.HostileWireInputTest"`. Use `:jvmTest`, not `jvmTest` — the unqualified name also matches `:cross_test:jvmTest`, which then fails the *filter* rather than the test.

## Which spec limits, and why those

The point of using the specification's own numbers is that this becomes a **conformance check rather than an invented threshold** — `dbus-daemon` enforces the same values on every message it relays, so nothing a conforming peer may legally send is refused.

| Constant | Value | Applied to |
|---|---|---|
| `DBUS_MAXIMUM_MESSAGE_LENGTH` | 2^27 = 128 MiB | declared body length; total frame (padded header + body) |
| `DBUS_MAXIMUM_ARRAY_LENGTH` | 2^26 = 64 MiB | any array's content byte-length, incl. the `a(yv)` header-fields array |
| container nesting depth | 64 | every container level in `DBusReader` and in `DBusSignatureParser` |

**On the nesting number — I used 64, not 32, deliberately.** The spec caps a signature at "32 array type codes **and** 32 open parentheses" — those are two separate budgets — and states the consequence explicitly: *"the maximum total depth of recursion is 64"*. A flat cap of 32 on a single combined counter would therefore reject spec-legal signatures (e.g. 20 arrays nested with 20 structs). Counting every container level against 64 rejects nothing the spec permits, while still turning the 10,000-deep variant bomb — 30 KB of body — into a clean `DBusMarshallingException`. Choosing 32 here would have been the *less* conformant option, which is the opposite of the goal.

## Fixing the comparison structurally, not adding another guard

This is the same defect class as #178/#180 (`absoluteTimeoutOf`), so it gets the same treatment: **make the overflow impossible rather than checking for it.**

The bug was ordering — `.toInt()` first, range-check second. A u32 at or above 2^31 narrows to a negative `Int`, and both guards were written as `x > bytes.size`, which a negative left-hand side passes silently.

Wire lengths are now validated **while still unsigned**, and there are exactly two places where a wire length becomes an `Int`:

- `DBusReader.readLength(limit, what)` — `readRaw(4)` zero-extends four bytes into a `Long`, so the comparison against the limit is exact and unsigned; the narrowing that follows is provably in `0..limit`.
- `WireMessageCodec.checkedLength(length: UInt, limit, what)` — same, in `UInt` space, for the two framing lengths.

Both can only *return* a value in `0..limit`. There is no remaining narrowing anywhere in the read path that could produce a negative length, so no downstream `> bytes.size` check can be handed one. That is the structural property, not a new guard sitting beside the old one.

## The silent one

`array len 0xFFFFFFF0 -> OK -> [[]]` is the case I fixed with the most conviction, and it is worth calling out separately because **it is not an attack**. The declared length narrowed to `-16`, which made `end < offset`, so the fill loop never ran and the caller received a **successful decode of an empty array** — indistinguishable from a genuinely empty one. Peer-driven data loss with no error anywhere. It is now a `DBusMarshallingException` like every other malformed length.

## Making the reader's death observable

I did **both** of the options in the issue, because they answer different halves of the complaint.

The reader now catches `Throwable`. A frame that fails to parse is unrecoverable either way — the stream is *framed*, so once a parse fails the byte offset is no longer known and nothing after it can be decoded — so the connection still dies. What changed is that it stops dying *quietly*:

- the cause is recorded in `readerFailure` before the thread exits;
- the socket is closed, so we stop pretending to be attached to a peer we can no longer read;
- in-flight callers get the **real** cause via `failAllPending`, not a generic `IOException("D-Bus connection closed")`;
- `checkAlive()` at the two entry points that put bytes on the wire (`dispatchCall`, `send`) refuses further traffic with that cause.

The net effect is the one the issue asked for: a call on a dead connection now fails **immediately** with `IOException: D-Bus connection is dead: …` instead of sitting out its full timeout against a black hole. `isReaderRunning` is still there and now agrees with reality (the reader clears `running` itself); `readerFailure` is the thing production code consults, and it is `private` — the reader-health signal callers actually need is "your send failed, here is why", which they now get.

## What is now rejected that previously "worked"

Stating this plainly, per the issue: a message above **128 MiB**, an array above **64 MiB**, or container nesting past depth **64** is now refused with a `DBusMarshallingException`. Previously those "worked" in the sense that they produced an `OutOfMemoryError`, a `NegativeArraySizeException` or a `StackOverflowError` — none of which is a usable outcome, and all of which are beyond what a conforming peer may send. Realistically nobody was relying on this, but it *is* a behaviour change and it is now a hard error rather than a crash.

Also newly rejected: a header field whose variant carries the wrong type (`PATH` as `u`, `MEMBER` as `ay`, …). Previously an unchecked `as String` / `as UInt` raised `ClassCastException`, which nothing on the reader path caught — that is precisely how the umbrella failure was reached.

## Known gaps (deliberately not fixed here)

- **Memory amplification by a *spec-legal* message.** A 128 MiB `ay` is legal, will be relayed by `dbus-daemon`, and demarshals to ~134M boxed `UByte` in an `ArrayList` — several GB of heap. Fixing that means a `ByteArray`-backed representation for `ay`, which is a value-model change well outside a hardening pass. Called out in #190 and still true.
- **Body-vs-declared-length consistency** is not validated; a body shorter than its signature demands still fails as an out-of-bounds read rather than a length mismatch. Same clean exception type, less specific message.

## Scope and verification

Scope is the JVM wire backend only. `:codegen` is untouched (#194 covers the codegen-side DoS) and the native backend is untouched.

- `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64 ktlintCheck apiCheck` — **BUILD SUCCESSFUL**.
- **`apiCheck` did not move**; there is no `api/*.api` diff. Everything changed is `internal` (`DBusMarshaller.kt`, `WireMessage.kt`, `DBusWireConnection.kt`), and `readerFailure` / `checkAlive` are `private`. The klib ABI consumed by `blue-falcon-sdbus` is unchanged.
- `DBUSMOCK_PYTHON=<venv>/bin/python3 dbus-run-session -- ./gradlew jvmTest linuxX64Test` — **BUILD SUCCESSFUL**, 759 tests, 0 failures, 0 skips (root jvmTest 336, root linuxX64Test 297, cross_test jvmTest 64, cross_test linuxX64Test 62). `DBUSMOCK_PYTHON` was set to a real `python-dbusmock` venv so the cross_test dbusmock suites genuinely ran rather than no-op passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
