### PR TITLE
test: assert what a served adaptor actually advertises in introspection (Refs #193)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/IntrospectionRoundTrip.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/IntrospectionRoundTrip.kt
@@ -1,0 +1,116 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.Resource
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.VTableBuilder
+import com.monkopedia.sdbus.VTableItem
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/** The standard D-Bus annotation marking an element deprecated. */
+internal const val DEPRECATED_ANNOTATION = "org.freedesktop.DBus.Deprecated"
+
+/** The standard D-Bus annotation marking a method as expecting no reply. */
+internal const val METHOD_NO_REPLY_ANNOTATION = "org.freedesktop.DBus.Method.NoReply"
+
+/** The standard D-Bus annotation declaring how a property signals changes. */
+internal const val EMITS_CHANGED_SIGNAL_ANNOTATION =
+    "org.freedesktop.DBus.Property.EmitsChangedSignal"
+
+/**
+ * Serves an object carrying [vtables] on a real bus, calls
+ * `org.freedesktop.DBus.Introspectable.Introspect` against it, and returns the XML it advertised.
+ *
+ * This is the instrument for asserting what a *running adaptor serves*, as opposed to what the
+ * codegen goldens already cover — what the *generator emits*. Nothing tested the former until
+ * [VtableFlagIntrospectionTest], which is how #197 survived. It lives in `commonTest` so every
+ * assertion built on it runs against both backends.
+ *
+ * The connections, object and registrations are all torn down before returning; only the XML
+ * escapes.
+ */
+internal suspend fun introspectServedObject(
+    vararg vtables: Pair<InterfaceName, VTableBuilder.() -> Unit>
+): IntrospectionXml {
+    val id = Random.nextInt(100_000, 999_999)
+    val service = ServiceName("com.monkopedia.sdbus.introspect$id")
+    val path = ObjectPath("/com/monkopedia/sdbus/introspect$id")
+
+    val server = createBusConnection(service)
+    val client = createBusConnection()
+    val obj = createObject(server, path)
+    val registrations = vtables.map { (name, vtable) ->
+        obj.addVTable(name, buildList<VTableItem> { VTableBuilder(this).vtable() })
+    }
+    server.startEventLoop()
+    val proxy = createProxy(client, service, path, runEventLoopThread = false)
+
+    try {
+        return IntrospectionXml(
+            proxy.callMethod<String>(
+                InterfaceName("org.freedesktop.DBus.Introspectable"),
+                MethodName("Introspect")
+            ) { }
+        )
+    } finally {
+        registrations.forEach(Resource::release)
+        proxy.release()
+        obj.release()
+        server.stopEventLoop()
+        client.release()
+        server.release()
+    }
+}
+
+/**
+ * The introspection XML a live adaptor advertised, with just enough structure to assert on a single
+ * element's annotations.
+ *
+ * D-Bus introspection never nests an element inside another of the same tag, so locating
+ * `<tag name="...">` and taking everything up to the following `</tag>` isolates exactly that
+ * element -- which is why this needs no XML parser on the test classpath.
+ */
+internal class IntrospectionXml(val raw: String) {
+
+    /**
+     * The children of `<[tag] name="[name]">`, or the empty string when the element is
+     * self-closing and so carries no annotations at all.
+     */
+    fun childrenOf(tag: String, name: String): String {
+        val open = raw.indexOf("<$tag name=\"$name\"")
+        if (open < 0) fail("no <$tag name=\"$name\"> in the served introspection:\n$raw")
+        val openEnd = raw.indexOf('>', open)
+        if (raw[openEnd - 1] == '/') return ""
+        val close = raw.indexOf("</$tag>", openEnd)
+        if (close < 0) fail("unterminated <$tag name=\"$name\"> in introspection:\n$raw")
+        return raw.substring(openEnd + 1, close)
+    }
+
+    /**
+     * Asserts whether `<[tag] name="[name]">` carries [annotation] with [value], pinning both
+     * polarities: pass `served = false` to assert the backend does *not* advertise it.
+     */
+    fun assertAnnotation(
+        tag: String,
+        name: String,
+        annotation: String,
+        value: String,
+        served: Boolean
+    ) {
+        val expected = "<annotation name=\"$annotation\" value=\"$value\"/>"
+        assertEquals(
+            served,
+            expected in childrenOf(tag, name),
+            "$annotation=\"$value\" on <$tag name=\"$name\"> should be " +
+                "${if (served) "served" else "absent"} by this backend; full XML:\n$raw"
+        )
+    }
+}

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.kt
@@ -13,3 +13,30 @@ package com.monkopedia.sdbus.integration
  * weaken the assertion).
  */
 internal expect val backendDeliversDirectedSignalsUnicast: Boolean
+
+/**
+ * Whether a served object advertises `org.freedesktop.DBus.Deprecated` for an interface marked
+ * deprecated via [com.monkopedia.sdbus.interfaceFlags].
+ *
+ * The same annotation on a *member* is served by both backends, so only the interface-level case
+ * needs a lever. Measured by [VtableFlagIntrospectionTest]; tracked in #193.
+ */
+internal expect val backendServesInterfaceLevelDeprecated: Boolean
+
+/**
+ * Whether a served object advertises `org.freedesktop.DBus.Property.EmitsChangedSignal` for a
+ * property registered with a non-default
+ * [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags].
+ *
+ * Measured by [VtableFlagIntrospectionTest]; tracked in #193.
+ */
+internal expect val backendServesEmitsChangedSignal: Boolean
+
+/**
+ * Whether a served object advertises `org.freedesktop.DBus.Method.NoReply` for a method registered
+ * with `hasNoReply = true`.
+ *
+ * Unlike the two above this is not a backend capability but a defect on whichever backend reports
+ * `false` -- both did until #197. Measured by [VtableFlagIntrospectionTest].
+ */
+internal expect val backendServesMethodNoReply: Boolean

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/VtableFlagIntrospectionTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/VtableFlagIntrospectionTest.kt
@@ -1,0 +1,141 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.CONST_PROPERTY_VALUE
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.interfaceFlags
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Cross-backend introspection round-trip: register vtable items with known flags, serve them, ask
+ * the running adaptor for its own `org.freedesktop.DBus.Introspectable.Introspect` XML, and pin
+ * what came back.
+ *
+ * The codegen goldens verify what the *generator emits*; before this test nothing verified what a
+ * *running adaptor advertises*. That gap is why #197 (`METHOD_NO_REPLY` OR-ed with a literal zero
+ * on native) went unnoticed and why #193's divergence table was wrong about a third of its scope.
+ *
+ * The two backends genuinely differ, so this pins each one rather than asserting a shared
+ * contract. The divergence lives in the `backendServes*` capability flags, whose per-target
+ * `actual`s are the record -- a backend that gained or lost a flag flips its `actual` rather than
+ * weakening an assertion here. Refs #193.
+ */
+class VtableFlagIntrospectionTest {
+
+    @Test
+    fun deprecatedOnMembersIsServedByBothBackends() = runBlocking {
+        val iface = InterfaceName("com.monkopedia.sdbus.flags.Members")
+        val xml = introspectServedObject(
+            iface to {
+                method(MethodName("DeprecatedMethod")) {
+                    isDeprecated = true
+                    call<Unit> { }
+                }
+                signal(SignalName("DeprecatedSignal")) {
+                    isDeprecated = true
+                    with<Int>("value")
+                }
+                prop(PropertyName("DeprecatedProperty")) {
+                    isDeprecated = true
+                    withGetter { 42 }
+                }
+            }
+        )
+
+        for ((tag, name) in listOf(
+            "method" to "DeprecatedMethod",
+            "signal" to "DeprecatedSignal",
+            "property" to "DeprecatedProperty"
+        )) {
+            xml.assertAnnotation(tag, name, DEPRECATED_ANNOTATION, "true", served = true)
+        }
+    }
+
+    @Test
+    fun deprecatedOnTheInterfaceIsServedOnlyWhereTheBackendCarriesIt() = runBlocking {
+        val iface = InterfaceName("com.monkopedia.sdbus.flags.DeprecatedInterface")
+        val xml = introspectServedObject(
+            iface to {
+                interfaceFlags { isDeprecated = true }
+                // Deliberately unannotated, so any Deprecated annotation inside the interface
+                // element must be the interface-level one.
+                method(MethodName("Plain")) { call<Unit> { } }
+            }
+        )
+
+        xml.assertAnnotation(
+            "interface",
+            iface.value,
+            DEPRECATED_ANNOTATION,
+            "true",
+            served = backendServesInterfaceLevelDeprecated
+        )
+        xml.assertAnnotation("method", "Plain", DEPRECATED_ANNOTATION, "true", served = false)
+    }
+
+    @Test
+    fun emitsChangedSignalIsServedOnlyWhereTheBackendCarriesIt() = runBlocking {
+        val iface = InterfaceName("com.monkopedia.sdbus.flags.Properties")
+        val xml = introspectServedObject(
+            iface to {
+                prop(PropertyName("ConstProperty")) {
+                    +CONST_PROPERTY_VALUE
+                    withGetter { 1 }
+                }
+                prop(PropertyName("InvalidatingProperty")) {
+                    +EMITS_INVALIDATION_SIGNAL
+                    withGetter { 2 }
+                }
+                prop(PropertyName("SilentProperty")) {
+                    +EMITS_NO_SIGNAL
+                    withGetter { 3 }
+                }
+            }
+        )
+
+        // The D-Bus default ("true") is left implicit by sd-bus, so only these three values can be
+        // observed at all.
+        for ((name, value) in listOf(
+            "ConstProperty" to "const",
+            "InvalidatingProperty" to "invalidates",
+            "SilentProperty" to "false"
+        )) {
+            xml.assertAnnotation(
+                "property",
+                name,
+                EMITS_CHANGED_SIGNAL_ANNOTATION,
+                value,
+                served = backendServesEmitsChangedSignal
+            )
+        }
+    }
+
+    @Test
+    fun methodNoReplyIsServedOnlyWhereTheBackendCarriesIt() = runBlocking {
+        val iface = InterfaceName("com.monkopedia.sdbus.flags.NoReply")
+        val xml = introspectServedObject(
+            iface to {
+                method(MethodName("FireAndForget")) {
+                    hasNoReply = true
+                    call<Unit> { }
+                }
+            }
+        )
+
+        xml.assertAnnotation(
+            "method",
+            "FireAndForget",
+            METHOD_NO_REPLY_ANNOTATION,
+            "true",
+            served = backendServesMethodNoReply
+        )
+    }
+}

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
@@ -3,3 +3,13 @@ package com.monkopedia.sdbus.integration
 // The JVM wire backend now threads Signal.setDestination onto the outgoing wire message, so the
 // daemon unicast-routes the directed signal and the recipient sees the destination header (#137).
 internal actual val backendDeliversDirectedSignalsUnicast: Boolean = true
+
+// WireServe builds the introspection XML from WireServeRegistry, which captures the per-member
+// deprecated bit and no other vtable flag -- so nothing interface-level reaches the XML.
+internal actual val backendServesInterfaceLevelDeprecated: Boolean = false
+
+// Same reason: the wire backend records no property update behavior to advertise.
+internal actual val backendServesEmitsChangedSignal: Boolean = false
+
+// Same reason: hasNoReply drives the reply-suppression path only, never the introspection XML.
+internal actual val backendServesMethodNoReply: Boolean = false

--- a/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
+++ b/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
@@ -2,3 +2,14 @@ package com.monkopedia.sdbus.integration
 
 // sd-bus routes directed signals to the destination alone and exposes the destination header.
 internal actual val backendDeliversDirectedSignalsUnicast: Boolean = true
+
+// sd-bus writes the interface's SD_BUS_VTABLE_DEPRECATED bit into the introspection it generates.
+internal actual val backendServesInterfaceLevelDeprecated: Boolean = true
+
+// sd-bus writes const / invalidates / false for the property emit bits (the D-Bus default, "true",
+// is deliberately left implicit).
+internal actual val backendServesEmitsChangedSignal: Boolean = true
+
+// Not served: Flags.toSdBusMethodFlags ORs METHOD_NO_REPLY with a literal 0u instead of
+// SD_BUS_VTABLE_METHOD_NO_REPLY, so the bit never reaches sd-bus. Defect, not capability -- #197.
+internal actual val backendServesMethodNoReply: Boolean = false


### PR DESCRIPTION
Adds a cross-backend introspection round-trip test: register vtable items with known flags, serve the object, call `org.freedesktop.DBus.Introspectable.Introspect` against it, and assert on the XML that came back. It lives in `commonTest`, so the identical assertions execute under both `:jvmTest` and `:linuxX64Test`.

Refs #193 — deliberately **not** `Fixes`. #193 is an open owner decision about whether the JVM backend should reach parity with native, and this does not pre-empt it either way.

## Why

Nothing in this repo asserted what a running adaptor actually **serves** in its introspection. The codegen goldens verify what the *generator emits*; that is a different thing, and the gap between them has been expensive:

- A merged CHANGELOG asserted a cross-backend round-trip that does not happen (corrected in #195).
- #193 was wrong about a third of its own scope — it listed `Method.NoReply` as a native-serves/JVM-does-not divergence when neither backend advertises it.
- #197 (`METHOD_NO_REPLY` OR-ed with a literal `0u` on native) went unnoticed.

An ad-hoc version of exactly this test was written and thrown away twice during #195's work. This makes it permanent and reusable.

## Shape

`IntrospectionRoundTrip.kt` is the instrument: `introspectServedObject(vararg InterfaceName to VTableBuilder.() -> Unit)` serves an object on a real bus, introspects it, tears everything down, and returns the XML wrapped in a small `IntrospectionXml` accessor. Locating `<tag name="…">` and taking everything up to the next `</tag>` is exact for D-Bus introspection (it never nests an element inside another of the same tag), so no XML parser joins the test classpath.

`assertAnnotation(..., served: Boolean)` pins **both** polarities, so a backend that does not serve a flag is asserted to not serve it rather than merely not checked.

## The asymmetries are expressed, not hidden

The backends genuinely differ, so this pins each one rather than asserting a shared contract it would have to fake. Three `expect`/`actual` capability flags carry the divergence, in the idiom `FdTestSupport.supportsFdDuplicationSemantics` already established:

| Annotation | Native | JVM |
| --- | --- | --- |
| `Deprecated` on method / signal / property | served | served |
| `Deprecated` on the **interface** | served | not served |
| `EmitsChangedSignal` (`const` / `invalidates` / `false`) | served | not served |
| `Method.NoReply` | not served | not served |

This reproduces, on both backends, the table measured during #195 — the same table that justified the merged doc correction. Member-level `Deprecated` needs no capability flag because both backends serve it; the other three get one each, and the `actual` values are now the machine-checked record of the divergence rather than prose.

`backendServesMethodNoReply` is documented as the odd one out: `false` on native is a **defect** (#197), not a capability. Flipping that one `actual` to `true` is the red-first proof for that fix.

## What this makes cheap

Either disposition of #193 gets easier:

- If the owner decides the JVM backend **should** reach parity, the flags flip to `true` one at a time and each flip is a red-first guard for the work that follows.
- If the owner decides to **document** the difference instead, this file is the truthful record of what each backend does, checked on every CI run, so the documentation cannot drift away from the behavior again.

## Verification

`dbus-run-session -- ./gradlew :jvmTest :linuxX64Test`, plus `compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64 ktlintCheck apiCheck`. Test-only change; `apiCheck` does not move and the klib ABI consumed by `blue-falcon-sdbus` is untouched.

## How the numbers were measured

Gradle's `BUILD SUCCESSFUL` does not distinguish a passing suite from one where every task resolved UP-TO-DATE, and the JUnit XML persists across runs, so neither the build status nor a bare test count proves anything ran. Every figure below comes from: **delete `build/test-results/` → run with `--rerun-tasks` → confirm no result file predates the run → count**.

- `dbus-run-session -- ./gradlew --rerun-tasks :jvmTest :linuxX64Test`, `11 actionable tasks: 11 executed` (zero up-to-date).
- Result files older than the run start: **0 of 66**.
- **331 test executions on `:jvmTest`, 301 on `:linuxX64Test`, 0 failures.**
- `VtableFlagIntrospectionTest` contributes **4 executions on each backend, 0 skipped** — so all four rows of the table above were actually exercised on both, not silently filtered away.

That matters more than usual here: this table is a first baseline, and a baseline recorded from a run that did nothing would agree with anything.

All tracked `.kt`/`.kts`/`.xml`/`.md` files on this branch were checked for embedded NUL bytes (the #161 failure mode, which makes a file vanish from `grep` silently) — clean, with a positive control confirming the detector fires.
