### PR TITLE
fix(native): bind SD_BUS_VTABLE_METHOD_NO_REPLY so hasNoReply reaches sd-bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   `sdbus-kotlin-codegen` or the `com.monkopedia.sdbus.plugin` Gradle plugin; declare it directly instead.
   (#167)
 
+### Fixed
+
+- **A method registered with `hasNoReply = true` now advertises
+  `org.freedesktop.DBus.Method.NoReply` in the introspection the native backend serves.** The vtable
+  translation tested the flag and then OR-ed the result with a literal `0u` — the constant named in
+  the adjacent comment, `SD_BUS_VTABLE_METHOD_NO_REPLY`, was never bound — so the branch was a
+  no-op and the bit never reached sd-bus. Behavior is unchanged: the fire-and-forget half already
+  worked on both backends, and this only corrects what the adaptor tells an external introspector
+  (`busctl`, d-feet, other language bindings), which previously described a fire-and-forget method
+  as ordinary request/reply. The JVM backend still does not serve this annotation; that is part of
+  #193. (#197)
+
 ## [1.0.1] - 2026-07-15
 
 A maintenance release: refreshed external dependencies to their latest stable versions. There are

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Flags.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Flags.native.kt
@@ -29,6 +29,7 @@ import com.monkopedia.sdbus.Flags.GeneralFlags.METHOD_NO_REPLY
 import com.monkopedia.sdbus.Flags.GeneralFlags.PRIVILEGED
 import kotlinx.cinterop.ExperimentalForeignApi
 import sdbus.SD_BUS_VTABLE_DEPRECATED
+import sdbus.SD_BUS_VTABLE_METHOD_NO_REPLY
 import sdbus.SD_BUS_VTABLE_PROPERTY_CONST
 import sdbus.SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE
 import sdbus.SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION
@@ -59,7 +60,7 @@ internal fun Flags.toSdBusMethodFlags(): ULong {
         sdbusFlags = sdbusFlags or SD_BUS_VTABLE_UNPRIVILEGED
     }
     if (has(METHOD_NO_REPLY)) {
-        sdbusFlags = sdbusFlags or 0u // SD_BUS_VTABLE_METHOD_NO_REPLY
+        sdbusFlags = sdbusFlags or SD_BUS_VTABLE_METHOD_NO_REPLY
     }
 
     return sdbusFlags

--- a/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
+++ b/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
@@ -10,6 +10,6 @@ internal actual val backendServesInterfaceLevelDeprecated: Boolean = true
 // is deliberately left implicit).
 internal actual val backendServesEmitsChangedSignal: Boolean = true
 
-// Not served: Flags.toSdBusMethodFlags ORs METHOD_NO_REPLY with a literal 0u instead of
-// SD_BUS_VTABLE_METHOD_NO_REPLY, so the bit never reaches sd-bus. Defect, not capability -- #197.
-internal actual val backendServesMethodNoReply: Boolean = false
+// sd-bus writes org.freedesktop.DBus.Method.NoReply for SD_BUS_VTABLE_METHOD_NO_REPLY. Until #197
+// that bit never reached it: Flags.toSdBusMethodFlags OR-ed the branch with a literal 0u.
+internal actual val backendServesMethodNoReply: Boolean = true


### PR DESCRIPTION
Fixes #197

`Flags.toSdBusMethodFlags` tested `METHOD_NO_REPLY` and then OR-ed the result with a literal zero:

```kotlin
if (has(METHOD_NO_REPLY)) {
    sdbusFlags = sdbusFlags or 0u // SD_BUS_VTABLE_METHOD_NO_REPLY
}
```

The comment names the constant that was meant to go there. It was never bound, so the branch is a no-op: it tests the flag, then ORs nothing. `hasNoReply = true` never reached the sd-bus vtable, and the served introspection never carried `org.freedesktop.DBus.Method.NoReply`.

## Was it stubbed because cinterop could not see the constant?

No. `SD_BUS_VTABLE_METHOD_NO_REPLY` sits in the same anonymous enum as `SD_BUS_VTABLE_DEPRECATED`, which this very file already imports and uses, and it is present in the generated cinterop bindings (verified in `package_sdbus` linkdata under `build/`, with `SD_BUS_VTABLE_DEPRECATED` as the positive control). No `.def` change is needed — the constant just was never wired up. sd-bus itself does emit the annotation for that bit; the string is in `libsystemd` for both the bundled 257.2 and the host's build.

## Behavior

Only the advertised metadata changes. `Method.NoReply`'s functional half already worked on both backends — the adaptor sends no reply and the generated proxy sets `dontExpectReply = true`. What was missing is what an external introspector (`busctl`, d-feet, another language's bindings) is told, and the previous state was the more confusing one: a method behaving as fire-and-forget while describing itself as ordinary request/reply, so a client reading the introspection waits for a reply that is never coming.

This is native-only. The JVM wire backend builds its introspection XML from a registry that captures the per-member deprecated bit and no other vtable flag, so it does not serve this annotation either way; that is part of the open #193 decision and is deliberately untouched here.

## Red-first

Stacked on #213, which adds the cross-backend introspection round-trip test. Two commits:

1. Flip `backendServesMethodNoReply` to `true` for the native backend — `VtableFlagIntrospectionTest.methodNoReplyIsServedOnlyWhereTheBackendCarriesIt` then fails on `:linuxX64Test` and still passes on `:jvmTest`.
2. Bind the real constant — it passes.

The failure, verbatim:

```
com.monkopedia.sdbus.integration.VtableFlagIntrospectionTest.methodNoReplyIsServedOnlyWhereTheBackendCarriesIt[linuxX64] FAILED
    kotlin.AssertionError at null:-1

kotlin.AssertionError: org.freedesktop.DBus.Method.NoReply="true" on <method name="FireAndForget">
should be served by this backend; full XML:
...
 <interface name="com.monkopedia.sdbus.flags.NoReply">
  <method name="FireAndForget"/>
 </interface>

4 tests completed, 1 failed
```

## Verification

`dbus-run-session -- ./gradlew :jvmTest :linuxX64Test`, plus `compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64 ktlintCheck apiCheck`. `apiCheck` does not move — `Flags.toSdBusMethodFlags` is `internal`, so the klib ABI consumed by `blue-falcon-sdbus` is unchanged.

## How the numbers were measured

Neither `BUILD SUCCESSFUL` nor a bare test count proves a suite ran — an all-UP-TO-DATE build reports success, and the JUnit XML persists across runs, so a stale file reads exactly like a fresh one. Both states below were measured by **deleting `build/test-results/`, running with `--rerun-tasks`, confirming no result file predates the run, then counting**.

**Before the fix** (`Flags.native.kt` restored to the `or 0u` form, test flip in place) — `11 actionable tasks: 11 executed`, 0 result files older than the run:

- `:linuxX64Test` — 4 executions, **1 failure** (the one above)
- `:jvmTest` — 331 executions, 0 failures

**After the fix** — `11 actionable tasks: 11 executed`, 0 stale files:

- `:linuxX64Test` — **301 executions, 0 failures**
- `:jvmTest` — **331 executions, 0 failures**

So the failure is one this change caused and then removed, not one inherited from an earlier run. Branch checked clean of embedded NUL bytes (the #161 failure mode) with a verified positive control.
