### PR TITLE
fix(native): stop swapping ALLOW_REPLACEMENT and REPLACE_EXISTING in requestName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   as ordinary request/reply. The JVM backend still does not serve this annotation; that is part of
   #193. (#197)
 
+- **`RequestNameFlag.ALLOW_REPLACEMENT` and `RequestNameFlag.REPLACE_EXISTING` were swapped on the
+  native backend.** `Connection.requestName` translates the D-Bus wire bits the enum carries into
+  sd-bus's own flag enum, where the two are transposed (`SD_BUS_NAME_REPLACE_EXISTING` is bit 0 and
+  `SD_BUS_NAME_ALLOW_REPLACEMENT` is bit 1), and the mapping asserted they coincided. So on native a
+  request that meant "I allow replacement" reached sd-bus as "replace the current owner" and vice
+  versa: a name whose owner had allowed replacement could not be taken over, and the challenger was
+  queued instead. The JVM backend hands the wire bits to the daemon directly and always matched the
+  semantics documented on `RequestNameFlag`, so this affected native only. The mapping now names the
+  cinterop `SD_BUS_NAME_*` constants, making it compiler-checked rather than comment-checked. (#212)
+
 ## [1.0.1] - 2026-07-15
 
 A maintenance release: refreshed external dependencies to their latest stable versions. There are

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/CommonApiIntegrationTest.kt
@@ -1164,6 +1164,38 @@ class CommonApiIntegrationTest {
         }
     }
 
+    // Regression for #212: ALLOW_REPLACEMENT and REPLACE_EXISTING are transposed between the D-Bus
+    // wire bits RequestNameFlag carries and sd-bus's own flag enum, and the native backend used to
+    // map them straight across — so a name its owner had marked replaceable could not be taken over,
+    // and the second caller was queued instead. The JVM backend passes the wire bits to the daemon
+    // directly and always matched the documented semantics; this runs on BOTH backends.
+    @Test
+    fun requestName_replaceExistingTakesOverANameThatAllowedReplacement() {
+        val ids = uniqueFixtureIds("replaceName")
+        val name = ServiceName("${ids.service.value}.Replaceable")
+        val incumbent = createBusConnection()
+        val challenger = createBusConnection()
+
+        try {
+            assertEquals(
+                RequestNameReply.PRIMARY_OWNER,
+                incumbent.requestName(name, RequestNameFlag.ALLOW_REPLACEMENT)
+            )
+
+            // The incumbent allowed replacement, so REPLACE_EXISTING must hand ownership over
+            // rather than queue behind it.
+            assertEquals(
+                RequestNameReply.PRIMARY_OWNER,
+                challenger.requestName(name, RequestNameFlag.REPLACE_EXISTING)
+            )
+        } finally {
+            runCatching { challenger.releaseName(name) }
+            runCatching { incumbent.releaseName(name) }
+            incumbent.release()
+            challenger.release()
+        }
+    }
+
     // Coverage for #110: the direct two-arg property accessors on Proxy
     // (getPropertyAsync / setPropertyAsync / getAllProperties / getAllPropertiesAsync). Confirms the
     // async variants agree with the sync getProperty/setProperty results and that the Variant unwrap

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/internal/ConnectionImpl.kt
@@ -97,6 +97,9 @@ import platform.posix.poll
 import platform.posix.pollfd
 import platform.posix.uint64_tVar
 import platform.posix.usleep
+import sdbus.SD_BUS_NAME_ALLOW_REPLACEMENT
+import sdbus.SD_BUS_NAME_QUEUE
+import sdbus.SD_BUS_NAME_REPLACE_EXISTING
 import sdbus._SD_BUS_MESSAGE_TYPE_INVALID
 import sdbus.sd_bus_error
 import sdbus.sd_bus_interface_name_is_valid
@@ -269,17 +272,22 @@ internal class ConnectionImpl(private val sdbus: ISdBus, private val bus: BusPtr
         checkNotReleased()
         checkServiceName(name.value)
 
-        // RequestNameFlag carries the D-Bus WIRE bits (DO_NOT_QUEUE=0x4); the C `sd_bus_request_name`
-        // takes sd-bus's OWN flag enum, where bit 0x4 is SD_BUS_NAME_QUEUE — the INVERSE (opt-in
-        // queueing). ALLOW_REPLACEMENT (0x1) / REPLACE_EXISTING (0x2) coincide; the queue bit must be
-        // inverted. Feeding the wire bits straight in would flip queueing and diverge from the JVM
-        // backend, which passes the wire flags to the daemon directly.
-        // sd-bus flag bits: SD_BUS_NAME_ALLOW_REPLACEMENT=0x1, SD_BUS_NAME_REPLACE_EXISTING=0x2,
-        // SD_BUS_NAME_QUEUE=0x4 (set when NOT DO_NOT_QUEUE, i.e. the inverted queue bit).
+        // RequestNameFlag carries the D-Bus WIRE bits; the C `sd_bus_request_name` takes sd-bus's
+        // OWN flag enum, and no bit of it lines up with the wire: replacement and allow-replacement
+        // are transposed, and sd-bus's queue bit is the INVERSE of the wire's DO_NOT_QUEUE (opt-in
+        // rather than opt-out). Feeding the wire bits straight in would diverge from the JVM
+        // backend, which passes them to the daemon directly. Naming the cinterop constants keeps
+        // this mapping compiler-checked rather than comment-checked (#212).
         var sdbusMask = 0u
-        if (RequestNameFlag.ALLOW_REPLACEMENT in flags) sdbusMask = sdbusMask or 0x1u
-        if (RequestNameFlag.REPLACE_EXISTING in flags) sdbusMask = sdbusMask or 0x2u
-        if (RequestNameFlag.DO_NOT_QUEUE !in flags) sdbusMask = sdbusMask or 0x4u
+        if (RequestNameFlag.ALLOW_REPLACEMENT in flags) {
+            sdbusMask = sdbusMask or SD_BUS_NAME_ALLOW_REPLACEMENT
+        }
+        if (RequestNameFlag.REPLACE_EXISTING in flags) {
+            sdbusMask = sdbusMask or SD_BUS_NAME_REPLACE_EXISTING
+        }
+        if (RequestNameFlag.DO_NOT_QUEUE !in flags) {
+            sdbusMask = sdbusMask or SD_BUS_NAME_QUEUE
+        }
         val r = sdbus.sd_bus_request_name(bus.value, name.value, sdbusMask.convert())
         // sd_bus_request_name collapses the four RequestName reply codes onto its return value:
         //   PRIMARY_OWNER -> 1, IN_QUEUE -> 0, EXISTS -> -EEXIST, ALREADY_OWNER -> -EALREADY.


### PR DESCRIPTION
Fixes #212

`Connection.requestName` takes `RequestNameFlag`s that carry the **D-Bus wire** bits. The C `sd_bus_request_name` takes sd-bus's **own** flag enum, and the two are not the same numbering:

```c
/* sd-bus-protocol.h:172-174 */
SD_BUS_NAME_REPLACE_EXISTING  = 1ULL << 0,
SD_BUS_NAME_ALLOW_REPLACEMENT = 1ULL << 1,
SD_BUS_NAME_QUEUE             = 1ULL << 2
```

The native mapping wrote `ALLOW_REPLACEMENT → 0x1` and `REPLACE_EXISTING → 0x2`, i.e. each flag into the other's bit. The consequence is exactly the inverse of the documented behavior: a name whose owner had *allowed replacement* could not be taken over, and a caller asking to *replace the existing owner* was queued behind it instead.

## Why it survived

The comment sitting directly above the code asserted the wrong mapping as fact:

> `ALLOW_REPLACEMENT (0x1) / REPLACE_EXISTING (0x2) coincide; the queue bit must be inverted.`

Only the queue bit was actually checked against the header. The other two were asserted to coincide and then encoded as hex literals, so nothing could catch the error — not the compiler, not a reader trusting the comment. That comment is corrected here, and more usefully the mapping now **names the cinterop `SD_BUS_NAME_*` constants** rather than hex, so the binding is compiler-checked. That is the same lesson as #197: a constant that is spelled out in a comment instead of imported is a constant nothing verifies.

The `SD_BUS_NAME_*` constants are already exposed by the existing cinterop bindings (verified in the generated `package_sdbus` linkdata alongside `SD_BUS_VTABLE_DEPRECATED`, which is already imported), so no `.def` change is needed.

## Not a convention to choose

The public KDoc on `RequestNameFlag` (`Connection.kt:179-183`) already documents the correct semantics and cites the right `DBUS_NAME_FLAG_*` names, and the JVM backend passes the wire bits straight to the daemon and honours them. So this is the native backend disagreeing with its own documented contract — there was no second defensible reading to pick between.

## Red-first

A cross-backend regression sits beside the existing `requestName_reportsConsistentReplyCodesAcrossBackends` in `CommonApiIntegrationTest`, reusing its fixtures: the incumbent takes the name with `ALLOW_REPLACEMENT`, the challenger takes it with `REPLACE_EXISTING`, and the daemon must report the challenger as `PRIMARY_OWNER`. Because it lives in `commonTest` it runs on both backends — it passed on `:jvmTest` and failed on `:linuxX64Test` before the fix, which is the shape the issue predicted.

Before the fix, `:linuxX64Test`:

```
com.monkopedia.sdbus.integration.CommonApiIntegrationTest.requestName_replaceExistingTakesOverANameThatAllowedReplacement[linuxX64] FAILED
    kotlin.AssertionError at null:-1

kotlin.AssertionError: Expected <PRIMARY_OWNER>, actual <IN_QUEUE>.

1 test completed, 1 failed
```

## Verification

`dbus-run-session -- ./gradlew :jvmTest :linuxX64Test`, plus `compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64 ktlintCheck apiCheck`. `apiCheck` does not move — the change is inside an `internal` implementation and the public enum is untouched, so the klib ABI consumed by `blue-falcon-sdbus` is unchanged.

## One thing the fix surfaced that the comment could not

Writing the accumulator as `ULong` failed to compile:

```
e: ConnectionImpl.kt:283:38 Argument type mismatch: actual type is 'UInt', but 'ULong' was expected.
```

cinterop types the `SD_BUS_NAME_*` constants as `UInt` (the enum's largest value is 4), unlike the `SD_BUS_VTABLE_*` constants which are `ULong`. The hex-literal version could never have surfaced that, because `0x1u` is whatever the accumulator says it is. That is the argument for naming the constants in miniature.

## How the numbers were measured

`BUILD SUCCESSFUL` cannot distinguish a passing suite from an all-UP-TO-DATE one, and JUnit XML persists across runs, so a stale result file is indistinguishable from a fresh one by content. Both states below were measured by **deleting `build/test-results/`, running with `--rerun-tasks`, confirming no result file predates the run, then counting**.

**Before the fix** (production change reverted, new test in place) — `11 actionable tasks: 11 executed`, 0 stale result files:

- `:linuxX64Test` — 298 executions, **1 failure** (the one above)
- `:jvmTest` — 328 executions, 0 failures — the new test passes on JVM unchanged, which is the cross-backend half of the claim

**After the fix** — `11 actionable tasks: 11 executed`, 0 stale files:

- `:linuxX64Test` — **298 executions, 0 failures**
- `:jvmTest` — **328 executions, 0 failures**

Branch checked clean of embedded NUL bytes (the #161 failure mode) with a verified positive control.
