### PR TITLE
fix(native): bind SD_BUS_VTABLE_METHOD_NO_REPLY so hasNoReply reaches sd-bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   `sdbus-kotlin-codegen` or the `com.monkopedia.sdbus.plugin` Gradle plugin; declare it directly instead.
   (#167)
 
+### Fixed
+
+- **A method registered with `hasNoReply = true` now advertises
+  `org.freedesktop.DBus.Method.NoReply` in the introspection the native backend serves.** The vtable
+  translation tested the flag and then OR-ed the result with a literal `0u` — the constant named in
+  the adjacent comment, `SD_BUS_VTABLE_METHOD_NO_REPLY`, was never bound — so the branch was a
+  no-op and the bit never reached sd-bus. Behavior is unchanged: the fire-and-forget half already
+  worked on both backends, and this only corrects what the adaptor tells an external introspector
+  (`busctl`, d-feet, other language bindings), which previously described a fire-and-forget method
+  as ordinary request/reply. The JVM backend still does not serve this annotation; that is part of
+  #193. (#197)
+
 ## [1.0.1] - 2026-07-15
 
 A maintenance release: refreshed external dependencies to their latest stable versions. There are

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/Flags.native.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/Flags.native.kt
@@ -29,6 +29,7 @@ import com.monkopedia.sdbus.Flags.GeneralFlags.METHOD_NO_REPLY
 import com.monkopedia.sdbus.Flags.GeneralFlags.PRIVILEGED
 import kotlinx.cinterop.ExperimentalForeignApi
 import sdbus.SD_BUS_VTABLE_DEPRECATED
+import sdbus.SD_BUS_VTABLE_METHOD_NO_REPLY
 import sdbus.SD_BUS_VTABLE_PROPERTY_CONST
 import sdbus.SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE
 import sdbus.SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION
@@ -59,7 +60,7 @@ internal fun Flags.toSdBusMethodFlags(): ULong {
         sdbusFlags = sdbusFlags or SD_BUS_VTABLE_UNPRIVILEGED
     }
     if (has(METHOD_NO_REPLY)) {
-        sdbusFlags = sdbusFlags or 0u // SD_BUS_VTABLE_METHOD_NO_REPLY
+        sdbusFlags = sdbusFlags or SD_BUS_VTABLE_METHOD_NO_REPLY
     }
 
     return sdbusFlags

--- a/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
+++ b/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
@@ -10,6 +10,6 @@ internal actual val backendServesInterfaceLevelDeprecated: Boolean = true
 // is deliberately left implicit).
 internal actual val backendServesEmitsChangedSignal: Boolean = true
 
-// Not served: Flags.toSdBusMethodFlags ORs METHOD_NO_REPLY with a literal 0u instead of
-// SD_BUS_VTABLE_METHOD_NO_REPLY, so the bit never reaches sd-bus. Defect, not capability -- #197.
-internal actual val backendServesMethodNoReply: Boolean = false
+// sd-bus writes org.freedesktop.DBus.Method.NoReply for SD_BUS_VTABLE_METHOD_NO_REPLY. Until #197
+// that bit never reached it: Flags.toSdBusMethodFlags OR-ed the branch with a literal 0u.
+internal actual val backendServesMethodNoReply: Boolean = true


### PR DESCRIPTION
`Flags.native.kt` mapped `METHOD_NO_REPLY` onto **zero**, so `hasNoReply = true` never reached sd-bus's vtable and the annotation was never advertised in served introspection.

```kotlin
if (has(METHOD_NO_REPLY)) {
    sdbusFlags = sdbusFlags or 0u // SD_BUS_VTABLE_METHOD_NO_REPLY
}
```

The comment named the constant that was meant to go there. It was never bound, so the branch tested the flag and then OR'd nothing.

Fixes #197.

## Why this supersedes PR #214

This is the same work, rebased. #214 was stacked on the introspection-harness branch; when that merged as #213 (`16a89a3`) its branch was deleted, and **GitHub auto-closed #214 because its base ref disappeared**. The commits were never merged — only the PR was lost.

`issue-197` has been rebased onto current `main` with `git rebase --onto origin/main 09c0c14`, dropping the harness commit that is now in `main` in squashed form. The remaining two commits are exactly this issue's work.

## What changed

| File | Why |
| --- | --- |
| `Flags.native.kt` | bind the real `SD_BUS_VTABLE_METHOD_NO_REPLY` instead of `0u` |
| `TestBackendCapabilities.native.kt` | flip the native capability flag — native now *does* serve it |
| `CHANGELOG.md` | `[Unreleased]` entry |

**The capability-flag change is the harness proving its own worth.** #213's `VtableFlagIntrospectionTest` records, per backend, which annotations a running adaptor actually advertises. Before this fix that table said `Method.NoReply` was served by **neither** backend — which was measured, not assumed, and contradicted issue #193's original claim that it was a native-serves/JVM-doesn't divergence. Fixing native means the recorded truth moves, and the flag is where that is expressed. A fix that changed behaviour without moving that flag would fail the harness.

## Verification status — read this before approving

The **pre-rebase** commits were verified: red-first on `:linuxX64Test` gave

```
org.freedesktop.DBus.Method.NoReply="true" on <method name="FireAndForget">
should be served by this backend
```

with the served XML showing a bare `<method name="FireAndForget"/>`, and green after. `apiCheck` did not move — the change is inside `internal` code, so `api/sdbus-kotlin.klib.api` (consumed by `blue-falcon-sdbus`) is untouched.

**Those runs were against the pre-rebase tree.** The rebase is mechanical — it drops a commit already present in `main` — but it has **not been re-verified post-rebase**, and CI on this head is the first evidence that the composition with the merged harness holds. Stating that rather than carrying the old green forward as though it still applied.

## Not in scope

Whether the **JVM** backend should reach parity on interface-level `Deprecated` and `EmitsChangedSignal` is an open owner decision on #193. This changes native only, and does not pre-empt it.
