### PR TITLE
feat(codegen): name generated types from XML annotations, behind an opt-in flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added — codegen
 
+- **New opt-in option `honorNamingAnnotations` (`--honor-naming-annotations`) names generated types
+  from `org.qtproject.QtDBus.QtTypeName` annotations in the XML.** The annotation is read plain from
+  a `<property>` or an `<arg>` and suffixed `.In<n>` / `.Out<n>` from a `<method>` or `<signal>` —
+  the three placements `qdbusxml2cpp` uses. A signature that already generates a class of its own is
+  renamed; one that does not (a map, a list, a primitive) gets a `typealias`, so e.g. a `Metadata`
+  property annotated `QVariantMap` is typed `QVariantMap` and is still a `Map<String, Variant>` at
+  the call site. Only `<annotation>` elements can be seen — the `tp:type` / `tp:name-for-bindings`
+  *attributes* some XML carries are not retained by the parser and are not hints.
+
+  This is a new option rather than a behavior change: a hint can only ever *replace* a name the
+  generator would otherwise derive, so applying hints unconditionally would rename types that
+  already-compiled consumer code refers to. It is therefore off by default, and with it off the
+  generator emits exactly what it emitted before whatever annotations the XML carries — the
+  checked-in fixtures are asserted byte-for-byte on both sides of the flag from the same XML. (#158)
 - **Generated code now carries KDoc taken from the introspection XML.** Documentation reaches the
   generated interface, proxy and adaptor from both carriers the parser already understood and
   previously discarded: `org.gtk.GDBus.DocString` / `DocString.Short` annotations, and `<doc:doc>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed — codegen
 
+- **⚠️ Binary-incompatible change to the `com.monkopedia:sdbus-kotlin-codegen` artifact.** Carrying
+  the `honorNamingAnnotations` option above into the generators changed their constructor signatures
+  rather than adding to them: `BaseGenerator`, `InterfaceGenerator`, `AdaptorGenerator` and
+  `ProxyGenerator` go from `<init>(String)` to `<init>(String, boolean)`, and `NamingManager` from
+  `<init>(XmlRootNode, String)` to `<init>(XmlRootNode, String, boolean)` (the synthetic `$default`
+  bridges move with them). The parameter is defaulted, so Kotlin **source** that constructs a
+  generator still compiles unchanged — but code already **linked** against those constructors, and
+  Java callers passing the arguments explicitly, must be recompiled. Everything else in
+  `codegen/api/codegen.api` is additive (`NamingManager.AliasType`, `GeneratedType.nameHint`,
+  `generateAlias`, `Xml2Kotlin.honorNamingAnnotations`), and the `Xml2Kotlin` CLI entry point and the
+  Gradle plugin do not construct the generators directly, so neither is affected. The
+  `com.monkopedia:sdbus-kotlin` library artifact is untouched: no entry in `api/sdbus-kotlin.api` or
+  `api/sdbus-kotlin.klib.api` moves. (#158)
 - **Standard D-Bus annotations are now mapped onto the runtime vtable/proxy flags.** The generated
   adaptor carries `org.freedesktop.DBus.Deprecated` (on the interface, methods, signals and
   properties) and `org.freedesktop.DBus.Property.EmitsChangedSignal` into its `addVTable` block, and

--- a/README.md
+++ b/README.md
@@ -82,9 +82,47 @@ sdbus {
 | `generateProxies` | Generate client-side `<Interface>Proxy` classes. |
 | `generateAdapters` | Generate service-side abstract `<Interface>Adaptor` classes for you to implement. |
 | `outputPackage` | Override the package of the generated code. By default it is derived from the D-Bus interface name (e.g. `org.bluez.Adapter1` generates into package `org.bluez`). |
+| `honorNamingAnnotations` | Take generated type names from `org.qtproject.QtDBus.QtTypeName` annotations in the XML instead of deriving them from member names. Off by default; see below. |
 
 For each `<interface>` in the XML the generator emits a Kotlin interface (e.g. `Adapter1`) plus,
 depending on the flags above, an `Adapter1Proxy` and/or an abstract `Adapter1Adaptor`.
+
+### Naming types from the XML
+
+By default every generated type name is derived from the members that use it, so `<arg
+name="origin" type="(dd)"/>` produces a `data class Origin`. Introspection XML written for
+`qdbusxml2cpp` often carries the intended name already, as an `org.qtproject.QtDBus.QtTypeName`
+annotation. Setting `honorNamingAnnotations = true` (`--honor-naming-annotations` on the CLI) uses
+those names:
+
+```xml
+<method name="Transform">
+  <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QPointF"/>
+  <arg name="origin" type="(dd)" direction="in"/>
+</method>
+<property name="Metadata" type="a{sv}" access="read">
+  <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
+</property>
+```
+
+- The annotation is read plain from a `<property>` or an `<arg>`, and suffixed `.In<n>` / `.Out<n>`
+  from a `<method>` or `<signal>` — the three places `qdbusxml2cpp` writes it. Nothing else is a
+  naming hint: in particular the `tp:type` / `tp:name-for-bindings` **attributes** of the telepathy
+  DTD are not `<annotation>` elements and the parser does not retain them.
+- A signature that already generates a class of its own (a struct) is simply renamed: `Origin`
+  above becomes `QPointF`.
+- A signature that does not — a map, a list, a primitive — gets a `typealias` for the name instead,
+  so `Metadata` above is typed `QVariantMap` while still being a `Map<String, Variant>` at the call
+  site.
+- Hints are keyed by D-Bus signature, like every other type the generator resolves, so a hint names
+  every member whose own type is that signature rather than the single member it was written on.
+  A signature nested *inside* a generated struct keeps its structural rendering.
+- A value that is not usable as a Kotlin name (`QMap<QString,QVariant>`) fails the build rather
+  than being ignored.
+
+It is off by default because a hint *replaces* a name the generator would otherwise derive, which
+renames types that already-compiled code refers to. With it unset, generated output is unchanged
+whatever annotations the XML carries.
 
 ## Build Setup
 

--- a/codegen/api/codegen.api
+++ b/codegen/api/codegen.api
@@ -14,8 +14,8 @@ public final class com/monkopedia/sdbus/Access$Companion {
 
 public final class com/monkopedia/sdbus/AdaptorGenerator : com/monkopedia/sdbus/BaseGenerator {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/monkopedia/sdbus/Annotation {
@@ -89,8 +89,8 @@ public final class com/monkopedia/sdbus/Arg$Companion {
 public abstract class com/monkopedia/sdbus/BaseGenerator {
 	protected field namingManager Lcom/monkopedia/sdbus/NamingManager;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected abstract fun buildRegistration (Lcom/squareup/kotlinpoet/FunSpec$Builder;Lcom/monkopedia/sdbus/Interface;)V
 	protected abstract fun classBuilder (Lcom/monkopedia/sdbus/Interface;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	protected abstract fun constructorBuilder (Lcom/monkopedia/sdbus/Interface;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
@@ -223,8 +223,8 @@ public final class com/monkopedia/sdbus/Interface$Companion {
 
 public final class com/monkopedia/sdbus/InterfaceGenerator : com/monkopedia/sdbus/BaseGenerator {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun transformXmlToFile (Lcom/monkopedia/sdbus/XmlRootNode;)Ljava/util/List;
 }
 
@@ -270,8 +270,8 @@ public final class com/monkopedia/sdbus/Method$Companion {
 }
 
 public final class com/monkopedia/sdbus/NamingManager {
-	public fun <init> (Lcom/monkopedia/sdbus/XmlRootNode;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/monkopedia/sdbus/XmlRootNode;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/monkopedia/sdbus/XmlRootNode;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lcom/monkopedia/sdbus/XmlRootNode;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun get (Lcom/monkopedia/sdbus/Arg;)Lcom/monkopedia/sdbus/NamingManager$NamingType;
 	public final fun get (Lcom/monkopedia/sdbus/Property;)Lcom/squareup/kotlinpoet/TypeName;
 	public final fun get (Ljava/util/List;)Lcom/monkopedia/sdbus/NamingManager$NamingType;
@@ -279,15 +279,33 @@ public final class com/monkopedia/sdbus/NamingManager {
 	public final fun getTypeMap ()Ljava/util/Map;
 }
 
+public final class com/monkopedia/sdbus/NamingManager$AliasType : com/monkopedia/sdbus/NamingManager$NamingType {
+	public fun <init> (Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/monkopedia/sdbus/NamingManager$NamingType;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/squareup/kotlinpoet/ClassName;
+	public final fun component3 ()Lcom/monkopedia/sdbus/NamingManager$NamingType;
+	public final fun copy (Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/monkopedia/sdbus/NamingManager$NamingType;)Lcom/monkopedia/sdbus/NamingManager$AliasType;
+	public static synthetic fun copy$default (Lcom/monkopedia/sdbus/NamingManager$AliasType;Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/monkopedia/sdbus/NamingManager$NamingType;ILjava/lang/Object;)Lcom/monkopedia/sdbus/NamingManager$AliasType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAliased ()Lcom/monkopedia/sdbus/NamingManager$NamingType;
+	public fun getReference ()Lcom/squareup/kotlinpoet/ClassName;
+	public synthetic fun getReference ()Lcom/squareup/kotlinpoet/TypeName;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/monkopedia/sdbus/NamingManager$GeneratedType : com/monkopedia/sdbus/NamingManager$NamingType {
 	public fun <init> (Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/lang/String;)V
 	public final fun generateName (Ljava/util/List;)V
 	public final fun getArgs ()Ljava/util/List;
+	public final fun getNameHint ()Ljava/lang/String;
 	public final fun getNameReferences ()Ljava/util/Set;
 	public final fun getPkgs ()Ljava/util/List;
 	public fun getReference ()Lcom/squareup/kotlinpoet/ClassName;
 	public synthetic fun getReference ()Lcom/squareup/kotlinpoet/TypeName;
 	public fun getType ()Ljava/lang/String;
+	public final fun setNameHint (Ljava/lang/String;)V
 	public final fun suggestNames (Ljava/util/List;)V
 }
 
@@ -396,8 +414,8 @@ public final class com/monkopedia/sdbus/Property$Companion {
 
 public final class com/monkopedia/sdbus/ProxyGenerator : com/monkopedia/sdbus/BaseGenerator {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/monkopedia/sdbus/Signal {
@@ -464,12 +482,14 @@ public final class com/monkopedia/sdbus/Summary$Companion {
 }
 
 public final class com/monkopedia/sdbus/TypeGenerationKt {
+	public static final fun generateAlias (Lcom/monkopedia/sdbus/NamingManager$AliasType;)Lcom/squareup/kotlinpoet/FileSpec;
 	public static final fun generateType (Lcom/monkopedia/sdbus/NamingManager$GeneratedType;)Lcom/squareup/kotlinpoet/FileSpec;
 }
 
 public final class com/monkopedia/sdbus/Xml2Kotlin : com/github/ajalt/clikt/core/CliktCommand {
 	public fun <init> ()V
 	public final fun getAdaptor ()Z
+	public final fun getHonorNamingAnnotations ()Z
 	public final fun getInput ()Ljava/io/File;
 	public final fun getKeep ()Z
 	public final fun getOutput ()Ljava/io/File;

--- a/codegen/src/main/kotlin/AdaptorGenerator.kt
+++ b/codegen/src/main/kotlin/AdaptorGenerator.kt
@@ -42,7 +42,8 @@ import com.squareup.kotlinpoet.TypeSpec.Builder
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.withIndent
 
-class AdaptorGenerator(packageOverride: String? = null) : BaseGenerator(packageOverride) {
+class AdaptorGenerator(packageOverride: String? = null, honorNamingAnnotations: Boolean = false) :
+    BaseGenerator(packageOverride, honorNamingAnnotations) {
 
     private val obj = ClassName.bestGuess("com.monkopedia.sdbus.Object")
     override val fileSuffix: String

--- a/codegen/src/main/kotlin/BaseGenerator.kt
+++ b/codegen/src/main/kotlin/BaseGenerator.kt
@@ -29,7 +29,10 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import java.util.*
 
-abstract class BaseGenerator(private val packageOverride: String? = null) {
+abstract class BaseGenerator(
+    private val packageOverride: String? = null,
+    private val honorNamingAnnotations: Boolean = false
+) {
 
     protected lateinit var namingManager: NamingManager
     protected abstract val fileSuffix: String
@@ -39,7 +42,7 @@ abstract class BaseGenerator(private val packageOverride: String? = null) {
         }
 
     open fun transformXmlToFile(doc: XmlRootNode): List<FileSpec> {
-        namingManager = NamingManager(doc, packageOverride)
+        namingManager = NamingManager(doc, packageOverride, honorNamingAnnotations)
         return fileSpecs(doc) + doc.nodes.flatMap { fileSpecs(it) }
     }
 

--- a/codegen/src/main/kotlin/InterfaceGenerator.kt
+++ b/codegen/src/main/kotlin/InterfaceGenerator.kt
@@ -56,7 +56,8 @@ val String.decapitalized: String
 val String.capitalCamelCase: String
     get() = decapitalCamelCase.capitalized
 
-class InterfaceGenerator(packageOverride: String? = null) : BaseGenerator(packageOverride) {
+class InterfaceGenerator(packageOverride: String? = null, honorNamingAnnotations: Boolean = false) :
+    BaseGenerator(packageOverride, honorNamingAnnotations) {
     override val fileSuffix: String
         get() = ""
 

--- a/codegen/src/main/kotlin/NamingManager.kt
+++ b/codegen/src/main/kotlin/NamingManager.kt
@@ -24,6 +24,7 @@ package com.monkopedia.sdbus
 
 import com.monkopedia.sdbus.Direction.IN
 import com.monkopedia.sdbus.Direction.OUT
+import com.monkopedia.sdbus.NamingManager.AliasType
 import com.monkopedia.sdbus.NamingManager.GeneratedType
 import com.monkopedia.sdbus.NamingManager.LazyType
 import com.monkopedia.sdbus.NamingManager.NamingType
@@ -51,7 +52,20 @@ import com.squareup.kotlinpoet.U_LONG
 import com.squareup.kotlinpoet.U_SHORT
 import com.squareup.kotlinpoet.WildcardTypeName
 
-class NamingManager(doc: XmlRootNode, packageOverride: String? = null) {
+/**
+ * Resolves every D-Bus signature in [doc] to the Kotlin type that represents it, generating a name
+ * for the ones that need a class of their own.
+ *
+ * When [honorNamingAnnotations] is set the naming annotations the XML carries are applied on top of
+ * the derived names; see [applyNamingHints]. It is opt-in because a hint can only ever *replace* a
+ * name the generator would otherwise derive, which would be a source break for anyone already
+ * compiling against generated output. With it unset nothing on that path runs.
+ */
+class NamingManager(
+    doc: XmlRootNode,
+    packageOverride: String? = null,
+    honorNamingAnnotations: Boolean = false
+) {
 
     sealed class NamingType {
         abstract val type: String
@@ -71,6 +85,12 @@ class NamingManager(doc: XmlRootNode, packageOverride: String? = null) {
         lateinit var args: List<Pair<String, TypeName>>
             private set
 
+        /**
+         * Name taken from a naming annotation, replacing whatever [nameReferences] would derive.
+         * Only ever set when the generator was asked to honor naming annotations.
+         */
+        var nameHint: String? = null
+
         fun suggestNames(list: List<Arg>) {
             nameSuggestions.add(list)
         }
@@ -87,7 +107,10 @@ class NamingManager(doc: XmlRootNode, packageOverride: String? = null) {
             val pkg = pkgs.groupBy { it }.values.maxByOrNull { it.single() }?.firstOrNull()
                 ?.lowercase()
                 ?: "sdbus.generated"
-            if (nameReferences.size == 1) {
+            val hint = nameHint
+            if (hint != null) {
+                reference = ClassName(pkg, hint.capitalCamelCase)
+            } else if (nameReferences.size == 1) {
                 val selectedName = nameReferences.single().capitalCamelCase
                 reference = ClassName(pkg, selectedName)
             } else if (nameReferences.size == 0) {
@@ -143,15 +166,33 @@ class NamingManager(doc: XmlRootNode, packageOverride: String? = null) {
         }
     }
 
+    /**
+     * A signature a naming annotation named but that generates no class of its own — a map, a list
+     * or a primitive. The name is emitted as a `typealias` for [aliased] so that it can be used
+     * without changing the type it stands for.
+     */
+    data class AliasType(
+        override val type: String,
+        override val reference: ClassName,
+        val aliased: NamingType
+    ) : NamingType()
+
     val typeMap: Map<String, NamingType> = buildMap {
         buildRootTypes(doc, packageOverride)
+        if (honorNamingAnnotations) {
+            applyNamingHints(doc, packageOverride)
+        }
     }
 
     val extraFiles: List<FileSpec>
-        get() = typeMap.values.filterIsInstance<GeneratedType>().map { it.generateType() }
+        get() = typeMap.values.filterIsInstance<GeneratedType>().map { it.generateType() } +
+            typeMap.values.filterIsInstance<AliasType>().map { it.generateAlias() }
 
     init {
-        val usedNames = mutableListOf<String>()
+        // Empty unless a naming annotation introduced an alias, so a derived name only ever has to
+        // dodge a collision on the opt-in path.
+        val usedNames = typeMap.values.filterIsInstance<AliasType>()
+            .mapTo(mutableListOf()) { it.reference.toString() }
         typeMap.values.filterIsInstance<GeneratedType>()
             .sortedByDescending { it.nameReferences.size }
             .forEach { it.generateName(usedNames) }
@@ -205,16 +246,6 @@ private fun MutableMap<String, NamingType>.buildInterfaceTypes(
     buildSignalsTypes(pkg, intf.signals)
     buildMethodsTypes(pkg, intf.methods)
     buildPropertiesTypes(pkg, intf.properties)
-    buildAnnotationsTypes(pkg, intf.annotations)
-}
-
-private fun MutableMap<String, NamingType>.buildAnnotationsTypes(
-    pkg: String,
-    annotations: List<Annotation>
-) {
-    annotations.forEach {
-        buildAnnotationTypes(pkg, it)
-    }
 }
 
 private fun MutableMap<String, NamingType>.buildPropertiesTypes(
@@ -238,15 +269,8 @@ private fun MutableMap<String, NamingType>.buildSignalsTypes(pkg: String, signal
     }
 }
 
-private fun MutableMap<String, NamingType>.buildAnnotationTypes(
-    pkg: String,
-    annotation: Annotation
-) {
-}
-
 private fun MutableMap<String, NamingType>.buildPropertyTypes(pkg: String, property: Property) {
     buildType(pkg, property.name, property.type)
-    buildAnnotationsTypes(pkg, property.annotations)
 }
 
 private fun MutableMap<String, NamingType>.buildMethodTypes(pkg: String, method: Method) {
@@ -254,17 +278,14 @@ private fun MutableMap<String, NamingType>.buildMethodTypes(pkg: String, method:
         buildArgTypes(pkg, index, arg)
     }
     buildSingleType(pkg, method.name, method.args.filter { it.direction == OUT })
-    buildAnnotationsTypes(pkg, method.annotations)
 }
 
 private fun MutableMap<String, NamingType>.buildSignalTypes(pkg: String, signal: Signal) {
     buildSingleType(pkg, signal.name, signal.args)
-    buildAnnotationsTypes(pkg, signal.annotations)
 }
 
 private fun MutableMap<String, NamingType>.buildArgTypes(pkg: String, index: Int, arg: Arg) {
     buildType(pkg, arg.name ?: "arg$index", arg.type)
-    buildAnnotationsTypes(pkg, arg.annotations)
 }
 
 private fun MutableMap<String, NamingType>.buildSingleType(
@@ -423,3 +444,88 @@ private fun MutableMap<String, NamingType>.generatedType(
 }
 
 private fun structKey(types: List<NamingType>) = "(${types.joinToString("") { it.type }})"
+
+/**
+ * The naming annotation the generator understands. `qdbusxml2cpp` writes it plain on a `<property>`
+ * or an `<arg>`, and suffixed `.In<n>` / `.Out<n>` on a `<method>` or `<signal>` to name the n-th
+ * argument in that direction.
+ *
+ * Note this is the only kind of hint that can reach here: the `tp:type` /
+ * `tp:name-for-bindings` attributes some introspection XML carries are XML *attributes* rather than
+ * `<annotation>` elements, and the parser drops them.
+ */
+private const val NAMING_ANNOTATION = "org.qtproject.QtDBus.QtTypeName"
+
+private val KOTLIN_SIMPLE_NAME = Regex("[A-Za-z_][A-Za-z0-9_]*")
+
+/**
+ * Applies the naming annotations in [node] on top of the already-derived names.
+ *
+ * Hints are keyed by D-Bus signature like everything else in the type map, so a hint names every
+ * member whose own type is that signature rather than the single member it was written on. A
+ * signature nested inside a generated struct keeps its structural rendering.
+ */
+private fun MutableMap<String, NamingType>.applyNamingHints(
+    node: XmlRootNode,
+    packageOverride: String?
+) {
+    node.nodes.forEach { applyNamingHints(it, packageOverride) }
+    for (intf in node.interfaces) {
+        val pkg = packageOverride ?: intf.name.pkg
+        for ((signature, name) in intf.namingHints()) {
+            applyNamingHint(pkg, signature, name)
+        }
+    }
+}
+
+private fun MutableMap<String, NamingType>.applyNamingHint(
+    pkg: String,
+    signature: String,
+    name: String
+) {
+    require(KOTLIN_SIMPLE_NAME.matches(name)) {
+        "$NAMING_ANNOTATION value \"$name\" on signature $signature is not a usable Kotlin name"
+    }
+    val existing = this[signature] ?: error("Naming hint for unknown signature $signature")
+    if (existing is GeneratedType) {
+        // A struct already generates a class of its own, so the hint just renames it.
+        existing.nameHint = name
+    } else {
+        // Anything else is a map, a list or a primitive; the hint becomes a typealias for it, so
+        // the name is usable without changing the type it stands for.
+        val aliased = (existing as? AliasType)?.aliased ?: existing
+        this[signature] = AliasType(signature, ClassName(pkg, name.capitalCamelCase), aliased)
+    }
+}
+
+/** Every `signature to hinted-name` pair the annotations of this interface carry. */
+private fun Interface.namingHints(): List<Pair<String, String>> = buildList {
+    for (property in properties) {
+        property.annotations.namingHint()?.let { add(property.type to it) }
+    }
+    for (method in methods) {
+        addAll(argHints(method.annotations, method.args.filter { it.direction == IN }, "In"))
+        addAll(argHints(method.annotations, method.args.filter { it.direction == OUT }, "Out"))
+        addAll(method.args.ownHints())
+    }
+    for (signal in signals) {
+        addAll(argHints(signal.annotations, signal.args, "Out"))
+        addAll(signal.args.ownHints())
+    }
+}
+
+private fun argHints(
+    annotations: List<Annotation>,
+    args: List<Arg>,
+    direction: String
+): List<Pair<String, String>> = args.mapIndexedNotNull { index, arg ->
+    annotations.hintValue("$NAMING_ANNOTATION.$direction$index")?.let { arg.type to it }
+}
+
+private fun List<Arg>.ownHints(): List<Pair<String, String>> =
+    mapNotNull { arg -> arg.annotations.namingHint()?.let { arg.type to it } }
+
+private fun List<Annotation>.namingHint(): String? = hintValue(NAMING_ANNOTATION)
+
+private fun List<Annotation>.hintValue(name: String): String? =
+    firstOrNull { it.name == name }?.value?.trim()?.takeUnless(String::isEmpty)

--- a/codegen/src/main/kotlin/ProxyGenerator.kt
+++ b/codegen/src/main/kotlin/ProxyGenerator.kt
@@ -38,7 +38,8 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.withIndent
 
-class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOverride) {
+class ProxyGenerator(packageOverride: String? = null, honorNamingAnnotations: Boolean = false) :
+    BaseGenerator(packageOverride, honorNamingAnnotations) {
 
     private val proxy = ClassName.bestGuess("com.monkopedia.sdbus.Proxy")
     override val fileSuffix: String

--- a/codegen/src/main/kotlin/TypeGeneration.kt
+++ b/codegen/src/main/kotlin/TypeGeneration.kt
@@ -22,12 +22,14 @@
  */
 package com.monkopedia.sdbus
 
+import com.monkopedia.sdbus.NamingManager.AliasType
 import com.monkopedia.sdbus.NamingManager.GeneratedType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeAliasSpec
 import com.squareup.kotlinpoet.TypeSpec
 
 fun GeneratedType.generateType(): FileSpec =
@@ -49,6 +51,11 @@ fun GeneratedType.generateType(): FileSpec =
             }.build()
         )
     }.build()
+
+fun AliasType.generateAlias(): FileSpec =
+    FileSpec.builder(reference.packageName, reference.simpleName)
+        .addTypeAlias(TypeAliasSpec.builder(reference.simpleName, aliased.reference).build())
+        .build()
 
 private fun makeUnique(baseName: String, usedNames: MutableSet<String>): String {
     var name = baseName

--- a/codegen/src/main/kotlin/Xml2Kotlin.kt
+++ b/codegen/src/main/kotlin/Xml2Kotlin.kt
@@ -95,6 +95,10 @@ class Xml2Kotlin : CliktCommand() {
         "--output-package",
         help = "Override Kotlin package for generated files"
     )
+    val honorNamingAnnotations by option(
+        "--honor-naming-annotations",
+        help = "Name generated types from org.qtproject.QtDBus.QtTypeName annotations in the XML"
+    ).flag()
 
     override fun run() {
         val packageOverride = outputPackage?.trim()?.takeUnless { it.isEmpty() }
@@ -103,18 +107,13 @@ class Xml2Kotlin : CliktCommand() {
             output.deleteRecursively()
         }
         output.mkdirs()
-        InterfaceGenerator(packageOverride).transformXmlToFile(xml).forEach {
-            it.writeTo(output)
+        val generators = buildList {
+            add(InterfaceGenerator(packageOverride, honorNamingAnnotations))
+            if (adaptor) add(AdaptorGenerator(packageOverride, honorNamingAnnotations))
+            if (proxy) add(ProxyGenerator(packageOverride, honorNamingAnnotations))
         }
-        if (adaptor) {
-            AdaptorGenerator(packageOverride).transformXmlToFile(xml).forEach {
-                it.writeTo(output)
-            }
-        }
-        if (proxy) {
-            ProxyGenerator(packageOverride).transformXmlToFile(xml).forEach {
-                it.writeTo(output)
-            }
+        generators.forEach { generator ->
+            generator.transformXmlToFile(xml).forEach { it.writeTo(output) }
         }
     }
 }

--- a/codegen/src/test/kotlin/CodegenNamingAndTypeTest.kt
+++ b/codegen/src/test/kotlin/CodegenNamingAndTypeTest.kt
@@ -4,6 +4,7 @@ import com.monkopedia.sdbus.NamingManager.GeneratedType
 import com.monkopedia.sdbus.NamingManager.NamingType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -142,5 +143,78 @@ class CodegenNamingAndTypeTest {
             adaptorFile.contains("call(`interface`, `object`)"),
             "Adaptor signal call() should backtick-escape keywords: $adaptorFile"
         )
+    }
+
+    @Test
+    fun namingAnnotationsAreInertUnlessHonored() {
+        val root = TestXmlSupport.parse(HINTED_XML)
+
+        val default = InterfaceGenerator().transformXmlToFile(root)
+            .associate { it.name to it.toString() }
+
+        assertEquals(setOf("Hinted", "Corner"), default.keys)
+        assertTrue(default.getValue("Hinted").contains("val corner: Corner"), default.toString())
+        assertTrue(
+            default.getValue("Hinted").contains("val extra: Map<String, Variant>"),
+            default.toString()
+        )
+    }
+
+    @Test
+    fun honoredNamingAnnotationsRenameStructsAndAliasEverythingElse() {
+        val root = TestXmlSupport.parse(HINTED_XML)
+
+        val hinted = InterfaceGenerator(honorNamingAnnotations = true)
+            .transformXmlToFile(root)
+            .associate { it.name to it.toString() }
+
+        assertEquals(setOf("Hinted", "QPoint", "QVariantMap"), hinted.keys)
+        // The struct had a generated class already, so the hint renamed it in place.
+        assertTrue(hinted.getValue("QPoint").contains("data class QPoint"), hinted.toString())
+        // a{sv} generates nothing, so the hint is a typealias and stays a Map at the call site.
+        assertTrue(
+            hinted.getValue("QVariantMap")
+                .contains("typealias QVariantMap = Map<String, Variant>"),
+            hinted.toString()
+        )
+        assertTrue(hinted.getValue("Hinted").contains("val corner: QPoint"), hinted.toString())
+        assertTrue(hinted.getValue("Hinted").contains("val extra: QVariantMap"), hinted.toString())
+    }
+
+    @Test
+    fun namingAnnotationThatIsNotAKotlinNameFailsLoudly() {
+        val root = TestXmlSupport.parse(
+            """
+            <node>
+              <interface name="org.example.Hinted">
+                <property name="Corner" type="(ii)" access="read">
+                  <annotation name="org.qtproject.QtDBus.QtTypeName"
+                              value="QMap&lt;QString,QVariant&gt;"/>
+                </property>
+              </interface>
+            </node>
+            """
+        )
+
+        val message = assertFailsWith<IllegalArgumentException> {
+            InterfaceGenerator(honorNamingAnnotations = true).transformXmlToFile(root)
+        }.message
+
+        assertTrue(message.orEmpty().contains("QMap<QString,QVariant>"), message)
+    }
+
+    private companion object {
+        private val HINTED_XML = """
+            <node>
+              <interface name="org.example.Hinted">
+                <property name="Corner" type="(ii)" access="read">
+                  <annotation name="org.qtproject.QtDBus.QtTypeName" value="QPoint"/>
+                </property>
+                <property name="Extra" type="a{sv}" access="read">
+                  <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
+                </property>
+              </interface>
+            </node>
+        """
     }
 }

--- a/codegen/src/test/kotlin/CompilationIntegrationTest.kt
+++ b/codegen/src/test/kotlin/CompilationIntegrationTest.kt
@@ -1,8 +1,10 @@
 package com.monkopedia.sdbus
 
+import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.serialization.decodeFromString
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -32,9 +34,26 @@ class CompilationIntegrationTest {
         """
 
         val root = TestXmlSupport.parse(xml)
-        val interfaceFiles = InterfaceGenerator().transformXmlToFile(root)
-        val proxyFiles = ProxyGenerator().transformXmlToFile(root)
-        val adaptorFiles = AdaptorGenerator().transformXmlToFile(root)
+        assertGeneratedCodeCompiles(root, honorNamingAnnotations = false)
+    }
+
+    @Test
+    fun generatedCodeNamedFromAnnotationsCompiles() {
+        val xml = File("src/test/resources/NamingHintsTest/test.xml").readText()
+
+        val root = introspectionXml.decodeFromString<XmlRootNode>(xml)
+        assertGeneratedCodeCompiles(root, honorNamingAnnotations = true)
+    }
+
+    private fun assertGeneratedCodeCompiles(root: XmlRootNode, honorNamingAnnotations: Boolean) {
+        val interfaceFiles = InterfaceGenerator(
+            honorNamingAnnotations = honorNamingAnnotations
+        ).transformXmlToFile(root)
+        val proxyFiles =
+            ProxyGenerator(honorNamingAnnotations = honorNamingAnnotations).transformXmlToFile(root)
+        val adaptorFiles = AdaptorGenerator(
+            honorNamingAnnotations = honorNamingAnnotations
+        ).transformXmlToFile(root)
 
         val srcDir = Files.createTempDirectory("codegen-compile-test-src").toFile()
         val outDir = Files.createTempDirectory("codegen-compile-test-out").toFile()

--- a/codegen/src/test/kotlin/GoldenFixture.kt
+++ b/codegen/src/test/kotlin/GoldenFixture.kt
@@ -29,22 +29,44 @@ import java.io.File
  * The three sets of golden files each fixture directory under `codegen/src/test/resources` holds,
  * named after the file prefix they are stored under (`interface.0.kt`, `adaptor.0.kt`, ...).
  *
- * [GeneratorTest] verifies the checked-in goldens against this, and `:codegen:regenerateGoldens`
- * rewrites them from this — the single definition keeps the writer and the verifier in lockstep
- * without either being able to stand in for the other.
+ * Each set has two sides: the default output, and — for the fixtures whose XML carries naming
+ * annotations — the `hinted-` output of the same XML with `honorNamingAnnotations` on.
+ *
+ * [GeneratorTest] and [NamingHintTest] verify the checked-in goldens against this, and
+ * `:codegen:regenerateGoldens` rewrites them from this — the single definition keeps the writer and
+ * the verifiers in lockstep without either being able to stand in for the other.
  */
-internal enum class GoldenFixture(val prefix: String, private val generator: () -> BaseGenerator) {
-    INTERFACE("interface", ::InterfaceGenerator),
-    ADAPTOR("adaptor", ::AdaptorGenerator),
-    PROXY("proxy", ::ProxyGenerator);
+internal enum class GoldenFixture(
+    val prefix: String,
+    private val generator: (Boolean) -> BaseGenerator
+) {
+    INTERFACE("interface", { InterfaceGenerator(honorNamingAnnotations = it) }),
+    ADAPTOR("adaptor", { AdaptorGenerator(honorNamingAnnotations = it) }),
+    PROXY("proxy", { ProxyGenerator(honorNamingAnnotations = it) });
 
-    fun generate(testRoot: File): List<FileSpec> {
+    /** The file prefix this kind of golden is stored under, on either side of the flag. */
+    fun prefix(hinted: Boolean): String = if (hinted) "$HINTED_PREFIX$prefix" else prefix
+
+    fun generate(testRoot: File, hinted: Boolean = false): List<FileSpec> {
         val xml = parseIntrospectionXml(File(testRoot, "test.xml").readText())
-        return generator().transformXmlToFile(xml).sortedBy { it.name }
+        return generator(hinted).transformXmlToFile(xml).sortedBy { it.name }
     }
 
     /** The golden files checked in for this fixture, in the order [generate] produces them. */
-    fun goldenFiles(testRoot: File): List<File> = testRoot.listFiles().orEmpty()
-        .filter { it.name.startsWith("$prefix.") && it.name.endsWith(".kt") }
-        .sortedBy { it.name }
+    fun goldenFiles(testRoot: File, hinted: Boolean = false): List<File> =
+        testRoot.listFiles().orEmpty()
+            .filter { it.name.startsWith("${prefix(hinted)}.") && it.name.endsWith(".kt") }
+            .sortedBy { it.name }
+
+    companion object {
+        private const val HINTED_PREFIX = "hinted-"
+
+        /**
+         * Whether [testRoot] pins the naming-annotation side of the flag as well as the default
+         * one. Only the fixtures whose XML carries naming annotations do; the rest would generate
+         * a byte-identical second copy of themselves.
+         */
+        fun hasHintedGoldens(testRoot: File): Boolean =
+            testRoot.listFiles().orEmpty().any { it.name.startsWith(HINTED_PREFIX) }
+    }
 }

--- a/codegen/src/test/kotlin/NamingHintTest.kt
+++ b/codegen/src/test/kotlin/NamingHintTest.kt
@@ -1,0 +1,55 @@
+package com.monkopedia.sdbus
+
+import java.io.File
+import kotlinx.serialization.decodeFromString
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * The opt-in half of [GeneratorTest]. It runs over the same fixture directories with naming
+ * annotations honored and compares against the `hinted-` goldens, so a fixture that carries both
+ * `interface.0.kt` and `hinted-interface.0.kt` pins both sides of the flag from one XML.
+ *
+ * There is deliberately no write-the-goldens switch here — the goldens are only ever compared.
+ */
+class NamingHintTest {
+
+    @ParameterizedTest
+    @MethodSource("data")
+    fun testInterface(testRoot: File) =
+        assertHinted(testRoot, "interface", InterfaceGenerator(honorNamingAnnotations = true))
+
+    @ParameterizedTest
+    @MethodSource("data")
+    fun testAdaptor(testRoot: File) =
+        assertHinted(testRoot, "adaptor", AdaptorGenerator(honorNamingAnnotations = true))
+
+    @ParameterizedTest
+    @MethodSource("data")
+    fun testProxy(testRoot: File) =
+        assertHinted(testRoot, "proxy", ProxyGenerator(honorNamingAnnotations = true))
+
+    private fun assertHinted(root: File, prefix: String, generator: BaseGenerator) {
+        val xml = introspectionXml.decodeFromString<XmlRootNode>(File(root, "test.xml").readText())
+        val actual = generator.transformXmlToFile(xml).sortedBy { it.name }
+        val expected = root.listFiles().orEmpty()
+            .filter { it.name.startsWith("hinted-$prefix.") && it.name.endsWith(".kt") }
+            .sortedBy { it.name }
+        assertEquals(expected.size, actual.size)
+        expected.zip(actual).forEach { (expectedFile, actualFile) ->
+            assertEquals(expectedFile.readText(), actualFile.toString())
+        }
+    }
+
+    companion object {
+        /** The fixtures that carry `hinted-` goldens; the rest have no naming annotations. */
+        @JvmStatic
+        fun data(): Iterable<Array<Any>> = NamingHintTest::class.java.getResource("/MediaPlayer2")
+            ?.file
+            ?.let { File(it).parentFile.listFiles() }
+            .orEmpty()
+            .filter { dir -> dir.listFiles().orEmpty().any { it.name.startsWith("hinted-") } }
+            .map { arrayOf(it) }
+    }
+}

--- a/codegen/src/test/kotlin/NamingHintTest.kt
+++ b/codegen/src/test/kotlin/NamingHintTest.kt
@@ -1,8 +1,8 @@
 package com.monkopedia.sdbus
 
 import java.io.File
-import kotlinx.serialization.decodeFromString
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -11,31 +11,32 @@ import org.junit.jupiter.params.provider.MethodSource
  * annotations honored and compares against the `hinted-` goldens, so a fixture that carries both
  * `interface.0.kt` and `hinted-interface.0.kt` pins both sides of the flag from one XML.
  *
- * There is deliberately no write-the-goldens switch here — the goldens are only ever compared.
+ * Like [GeneratorTest] it only ever reads the goldens; `./gradlew :codegen:regenerateGoldens`
+ * rewrites both sides.
  */
 class NamingHintTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    fun testInterface(testRoot: File) =
-        assertHinted(testRoot, "interface", InterfaceGenerator(honorNamingAnnotations = true))
+    fun testInterface(testRoot: File) = assertHinted(testRoot, GoldenFixture.INTERFACE)
 
     @ParameterizedTest
     @MethodSource("data")
-    fun testAdaptor(testRoot: File) =
-        assertHinted(testRoot, "adaptor", AdaptorGenerator(honorNamingAnnotations = true))
+    fun testAdaptor(testRoot: File) = assertHinted(testRoot, GoldenFixture.ADAPTOR)
 
     @ParameterizedTest
     @MethodSource("data")
-    fun testProxy(testRoot: File) =
-        assertHinted(testRoot, "proxy", ProxyGenerator(honorNamingAnnotations = true))
+    fun testProxy(testRoot: File) = assertHinted(testRoot, GoldenFixture.PROXY)
 
-    private fun assertHinted(root: File, prefix: String, generator: BaseGenerator) {
-        val xml = introspectionXml.decodeFromString<XmlRootNode>(File(root, "test.xml").readText())
-        val actual = generator.transformXmlToFile(xml).sortedBy { it.name }
-        val expected = root.listFiles().orEmpty()
-            .filter { it.name.startsWith("hinted-$prefix.") && it.name.endsWith(".kt") }
-            .sortedBy { it.name }
+    private fun assertHinted(testRoot: File, fixture: GoldenFixture) {
+        val expected = fixture.goldenFiles(testRoot, hinted = true)
+        // Without this, a fixture with no goldens of this kind would compare nothing and pass.
+        assertTrue(
+            expected.isNotEmpty(),
+            "No ${fixture.prefix(hinted = true)}.*.kt golden files in ${testRoot.name}; " +
+                "run :codegen:regenerateGoldens and commit them"
+        )
+        val actual = fixture.generate(testRoot, hinted = true)
         assertEquals(expected.size, actual.size)
         expected.zip(actual).forEach { (expectedFile, actualFile) ->
             assertEquals(expectedFile.readText(), actualFile.toString())
@@ -49,7 +50,7 @@ class NamingHintTest {
             ?.file
             ?.let { File(it).parentFile.listFiles() }
             .orEmpty()
-            .filter { dir -> dir.listFiles().orEmpty().any { it.name.startsWith("hinted-") } }
+            .filter { GoldenFixture.hasHintedGoldens(it) }
             .map { arrayOf(it) }
     }
 }

--- a/codegen/src/test/kotlin/RegenerateGoldens.kt
+++ b/codegen/src/test/kotlin/RegenerateGoldens.kt
@@ -26,11 +26,13 @@ import java.io.File
 
 /**
  * Rewrites the checked-in golden files of every fixture directory under the test-resources
- * directory named by the single argument, from its `test.xml`. For use after an intentional
- * generator change: `./gradlew :codegen:regenerateGoldens`, then review the resulting `git diff`
- * before committing it.
+ * directory named by the single argument, from its `test.xml` — the default output for every
+ * fixture, plus the `hinted-` output for those that pin the naming-annotation side of the flag too.
+ * For use after an intentional generator change: `./gradlew :codegen:regenerateGoldens`, then
+ * review the resulting `git diff` before committing it.
  *
- * This is deliberately a separate entry point from [GeneratorTest], which only ever compares.
+ * This is deliberately a separate entry point from [GeneratorTest] and [NamingHintTest], which only
+ * ever compare.
  * Regenerating and verifying are then different operations that cannot be mistaken for each other —
  * no run of the test suite can write the answer it is about to check.
  */
@@ -44,12 +46,19 @@ fun main(args: Array<String>) {
 
     var written = 0
     for (testRoot in fixtures) {
+        // A fixture only carries `hinted-` goldens if its XML has naming annotations to honor;
+        // writing them everywhere would invent goldens no test asserts.
+        val sides =
+            if (GoldenFixture.hasHintedGoldens(testRoot)) listOf(false, true) else listOf(false)
         for (fixture in GoldenFixture.entries) {
-            val generated = fixture.generate(testRoot)
-            fixture.goldenFiles(testRoot).forEach { it.delete() }
-            generated.forEachIndexed { index, fileSpec ->
-                File(testRoot, "${fixture.prefix}.$index.kt").writeText(fileSpec.toString())
-                written++
+            for (hinted in sides) {
+                val generated = fixture.generate(testRoot, hinted)
+                fixture.goldenFiles(testRoot, hinted).forEach { it.delete() }
+                generated.forEachIndexed { index, fileSpec ->
+                    File(testRoot, "${fixture.prefix(hinted)}.$index.kt")
+                        .writeText(fileSpec.toString())
+                    written++
+                }
             }
         }
     }

--- a/codegen/src/test/kotlin/Xml2KotlinOptionsTest.kt
+++ b/codegen/src/test/kotlin/Xml2KotlinOptionsTest.kt
@@ -78,8 +78,22 @@ class Xml2KotlinOptionsTest {
         }
     }
 
+    @Test
+    fun namingAnnotationsAreIgnoredWithoutTheFlag() = withGeneratedOutput(xml = HINTED_XML) {
+        assertEquals(setOf("org/foo/Hinted.kt", "org/foo/Corner.kt"), generatedFileNames(it))
+    }
+
+    @Test
+    fun namingAnnotationsNameGeneratedTypesWithTheFlag() = withGeneratedOutput(
+        "--honor-naming-annotations",
+        xml = HINTED_XML
+    ) {
+        assertEquals(setOf("org/foo/Hinted.kt", "org/foo/QPoint.kt"), generatedFileNames(it))
+    }
+
     private fun withGeneratedOutput(
         vararg flags: String,
+        xml: String = SIMPLE_XML,
         prepopulate: (File) -> Unit = {},
         block: (File) -> Unit
     ) {
@@ -88,7 +102,7 @@ class Xml2KotlinOptionsTest {
         val output = File(root, "out")
         output.mkdirs()
         prepopulate(output)
-        input.writeText(SIMPLE_XML)
+        input.writeText(xml)
 
         try {
             Xml2Kotlin().main(
@@ -116,6 +130,16 @@ class Xml2KotlinOptionsTest {
                 <method name="currentBackground">
                   <arg type="s" direction="out"/>
                 </method>
+              </interface>
+            </node>
+        """.trimIndent()
+
+        private val HINTED_XML = """
+            <node>
+              <interface name="org.foo.Hinted">
+                <property name="Corner" type="(ii)" access="read">
+                  <annotation name="org.qtproject.QtDBus.QtTypeName" value="QPoint"/>
+                </property>
               </interface>
             </node>
         """.trimIndent()

--- a/codegen/src/test/resources/MediaPlayer2/hinted-adaptor.0.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-adaptor.0.kt
@@ -1,0 +1,55 @@
+package org.mpris
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.notifying
+import com.monkopedia.sdbus.prop
+import kotlin.Boolean
+
+public abstract class MediaPlayer2Adaptor(
+  public val obj: Object,
+) : MediaPlayer2 {
+  override var fullscreen: Boolean by
+      obj.notifying(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("Fullscreen"), false)
+
+  public override fun register() {
+    obj.addVTable(MediaPlayer2.Companion.INTERFACE_NAME) {
+      method(MethodName("Raise")) {
+        asyncCall(this@MediaPlayer2Adaptor::raise)
+      }
+      method(MethodName("Quit")) {
+        asyncCall(this@MediaPlayer2Adaptor::quit)
+      }
+      prop(PropertyName("CanQuit")) {
+        with(this@MediaPlayer2Adaptor::canQuit)
+      }
+      prop(PropertyName("Fullscreen")) {
+        with(this@MediaPlayer2Adaptor::fullscreen)
+      }
+      prop(PropertyName("CanSetFullscreen")) {
+        with(this@MediaPlayer2Adaptor::canSetFullscreen)
+      }
+      prop(PropertyName("CanRaise")) {
+        with(this@MediaPlayer2Adaptor::canRaise)
+      }
+      prop(PropertyName("HasTrackList")) {
+        with(this@MediaPlayer2Adaptor::hasTrackList)
+      }
+      prop(PropertyName("Identity")) {
+        with(this@MediaPlayer2Adaptor::identity)
+      }
+      prop(PropertyName("DesktopEntry")) {
+        with(this@MediaPlayer2Adaptor::desktopEntry)
+      }
+      prop(PropertyName("SupportedUriSchemes")) {
+        with(this@MediaPlayer2Adaptor::supportedUriSchemes)
+      }
+      prop(PropertyName("SupportedMimeTypes")) {
+        with(this@MediaPlayer2Adaptor::supportedMimeTypes)
+      }
+    }
+  }
+}

--- a/codegen/src/test/resources/MediaPlayer2/hinted-adaptor.1.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-adaptor.1.kt
@@ -1,0 +1,123 @@
+package org.mpris.mediaplayer2
+
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.notifying
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import kotlin.Boolean
+import kotlin.Double
+import kotlin.Long
+import kotlin.String
+import kotlin.Unit
+
+public abstract class PlayerAdaptor(
+  public val obj: Object,
+) : Player {
+  override var loopStatus: String by
+      obj.notifying(Player.Companion.INTERFACE_NAME, PropertyName("LoopStatus"), "")
+
+  override var rate: Double by
+      obj.notifying(Player.Companion.INTERFACE_NAME, PropertyName("Rate"), 0.0)
+
+  override var shuffle: Boolean by
+      obj.notifying(Player.Companion.INTERFACE_NAME, PropertyName("Shuffle"), false)
+
+  override var volume: Double by
+      obj.notifying(Player.Companion.INTERFACE_NAME, PropertyName("Volume"), 0.0)
+
+  public override fun register() {
+    obj.addVTable(Player.Companion.INTERFACE_NAME) {
+      method(MethodName("Next")) {
+        asyncCall(this@PlayerAdaptor::next)
+      }
+      method(MethodName("Previous")) {
+        asyncCall(this@PlayerAdaptor::previous)
+      }
+      method(MethodName("Pause")) {
+        asyncCall(this@PlayerAdaptor::pause)
+      }
+      method(MethodName("PlayPause")) {
+        asyncCall(this@PlayerAdaptor::playPause)
+      }
+      method(MethodName("Stop")) {
+        asyncCall(this@PlayerAdaptor::stop)
+      }
+      method(MethodName("Play")) {
+        asyncCall(this@PlayerAdaptor::play)
+      }
+      method(MethodName("Seek")) {
+        inputParamNames = listOf("Offset")
+        asyncCall(this@PlayerAdaptor::seek)
+      }
+      method(MethodName("SetPosition")) {
+        inputParamNames = listOf("TrackId", "Position")
+        asyncCall(this@PlayerAdaptor::setPosition)
+      }
+      method(MethodName("OpenUri")) {
+        inputParamNames = listOf("Uri")
+        asyncCall(this@PlayerAdaptor::openUri)
+      }
+      signal(SignalName("Seeked")) {
+        with<Long>("Position")
+      }
+      prop(PropertyName("PlaybackStatus")) {
+        with(this@PlayerAdaptor::playbackStatus)
+      }
+      prop(PropertyName("LoopStatus")) {
+        with(this@PlayerAdaptor::loopStatus)
+      }
+      prop(PropertyName("Rate")) {
+        with(this@PlayerAdaptor::rate)
+      }
+      prop(PropertyName("Shuffle")) {
+        with(this@PlayerAdaptor::shuffle)
+      }
+      prop(PropertyName("Metadata")) {
+        with(this@PlayerAdaptor::metadata)
+      }
+      prop(PropertyName("Volume")) {
+        with(this@PlayerAdaptor::volume)
+      }
+      prop(PropertyName("Position")) {
+        with(this@PlayerAdaptor::position)
+        +EMITS_NO_SIGNAL
+      }
+      prop(PropertyName("MinimumRate")) {
+        with(this@PlayerAdaptor::minimumRate)
+      }
+      prop(PropertyName("MaximumRate")) {
+        with(this@PlayerAdaptor::maximumRate)
+      }
+      prop(PropertyName("CanGoNext")) {
+        with(this@PlayerAdaptor::canGoNext)
+      }
+      prop(PropertyName("CanGoPrevious")) {
+        with(this@PlayerAdaptor::canGoPrevious)
+      }
+      prop(PropertyName("CanPlay")) {
+        with(this@PlayerAdaptor::canPlay)
+      }
+      prop(PropertyName("CanPause")) {
+        with(this@PlayerAdaptor::canPause)
+      }
+      prop(PropertyName("CanSeek")) {
+        with(this@PlayerAdaptor::canSeek)
+      }
+      prop(PropertyName("CanControl")) {
+        with(this@PlayerAdaptor::canControl)
+        +EMITS_NO_SIGNAL
+      }
+    }
+  }
+
+  public suspend fun onSeeked(position: Long): Unit = obj.emitSignal(Player.Companion.INTERFACE_NAME, SignalName("Seeked")) {
+    call(position)
+  }
+}

--- a/codegen/src/test/resources/MediaPlayer2/hinted-interface.0.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-interface.0.kt
@@ -1,0 +1,36 @@
+package org.mpris
+
+import com.monkopedia.sdbus.InterfaceName
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+public interface MediaPlayer2 {
+  public val canQuit: Boolean
+
+  public var fullscreen: Boolean
+
+  public val canSetFullscreen: Boolean
+
+  public val canRaise: Boolean
+
+  public val hasTrackList: Boolean
+
+  public val identity: String
+
+  public val desktopEntry: String
+
+  public val supportedUriSchemes: List<String>
+
+  public val supportedMimeTypes: List<String>
+
+  public fun register()
+
+  public suspend fun raise()
+
+  public suspend fun quit()
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.mpris.MediaPlayer2")
+  }
+}

--- a/codegen/src/test/resources/MediaPlayer2/hinted-interface.1.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-interface.1.kt
@@ -1,0 +1,64 @@
+package org.mpris.mediaplayer2
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.ObjectPath
+import kotlin.Boolean
+import kotlin.Double
+import kotlin.Long
+import kotlin.String
+
+public interface Player {
+  public val playbackStatus: String
+
+  public var loopStatus: String
+
+  public var rate: Double
+
+  public var shuffle: Boolean
+
+  public val metadata: QVariantMap
+
+  public var volume: Double
+
+  public val position: Long
+
+  public val minimumRate: Double
+
+  public val maximumRate: Double
+
+  public val canGoNext: Boolean
+
+  public val canGoPrevious: Boolean
+
+  public val canPlay: Boolean
+
+  public val canPause: Boolean
+
+  public val canSeek: Boolean
+
+  public val canControl: Boolean
+
+  public fun register()
+
+  public suspend fun next()
+
+  public suspend fun previous()
+
+  public suspend fun pause()
+
+  public suspend fun playPause()
+
+  public suspend fun stop()
+
+  public suspend fun play()
+
+  public suspend fun seek(offset: Long)
+
+  public suspend fun setPosition(trackId: ObjectPath, position: Long)
+
+  public suspend fun openUri(uri: String)
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.mpris.MediaPlayer2.Player")
+  }
+}

--- a/codegen/src/test/resources/MediaPlayer2/hinted-interface.2.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-interface.2.kt
@@ -1,0 +1,7 @@
+package org.mpris.mediaplayer2
+
+import com.monkopedia.sdbus.Variant
+import kotlin.String
+import kotlin.collections.Map
+
+public typealias QVariantMap = Map<String, Variant>

--- a/codegen/src/test/resources/MediaPlayer2/hinted-proxy.0.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-proxy.0.kt
@@ -1,0 +1,74 @@
+package org.mpris
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.MutablePropertyDelegate
+import com.monkopedia.sdbus.PropertyDelegate
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.callMethodAsync
+import com.monkopedia.sdbus.mutableDelegate
+import com.monkopedia.sdbus.propDelegate
+import kotlin.Boolean
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.List
+
+public class MediaPlayer2Proxy(
+  public val proxy: Proxy,
+) : MediaPlayer2 {
+  public val canQuitProperty: PropertyDelegate<MediaPlayer2Proxy, Boolean> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("CanQuit")) 
+
+  public var fullscreenProperty: MutablePropertyDelegate<MediaPlayer2Proxy, Boolean> =
+      proxy.mutableDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("Fullscreen")) 
+
+  public val canSetFullscreenProperty: PropertyDelegate<MediaPlayer2Proxy, Boolean> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("CanSetFullscreen")) 
+
+  public val canRaiseProperty: PropertyDelegate<MediaPlayer2Proxy, Boolean> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("CanRaise")) 
+
+  public val hasTrackListProperty: PropertyDelegate<MediaPlayer2Proxy, Boolean> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("HasTrackList")) 
+
+  public val identityProperty: PropertyDelegate<MediaPlayer2Proxy, String> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("Identity")) 
+
+  public val desktopEntryProperty: PropertyDelegate<MediaPlayer2Proxy, String> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("DesktopEntry")) 
+
+  public val supportedUriSchemesProperty: PropertyDelegate<MediaPlayer2Proxy, List<String>> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("SupportedUriSchemes")) 
+
+  public val supportedMimeTypesProperty: PropertyDelegate<MediaPlayer2Proxy, List<String>> =
+      proxy.propDelegate(MediaPlayer2.Companion.INTERFACE_NAME, PropertyName("SupportedMimeTypes")) 
+
+  override val canQuit: Boolean by canQuitProperty
+
+  override var fullscreen: Boolean by fullscreenProperty
+
+  override val canSetFullscreen: Boolean by canSetFullscreenProperty
+
+  override val canRaise: Boolean by canRaiseProperty
+
+  override val hasTrackList: Boolean by hasTrackListProperty
+
+  override val identity: String by identityProperty
+
+  override val desktopEntry: String by desktopEntryProperty
+
+  override val supportedUriSchemes: List<String> by supportedUriSchemesProperty
+
+  override val supportedMimeTypes: List<String> by supportedMimeTypesProperty
+
+  public override fun register() {
+  }
+
+  override suspend fun raise(): Unit = proxy.callMethodAsync(MediaPlayer2.Companion.INTERFACE_NAME, MethodName("Raise")) {
+    call()
+  }
+
+  override suspend fun quit(): Unit = proxy.callMethodAsync(MediaPlayer2.Companion.INTERFACE_NAME, MethodName("Quit")) {
+    call()
+  }
+}

--- a/codegen/src/test/resources/MediaPlayer2/hinted-proxy.1.kt
+++ b/codegen/src/test/resources/MediaPlayer2/hinted-proxy.1.kt
@@ -1,0 +1,142 @@
+package org.mpris.mediaplayer2
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.MutablePropertyDelegate
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyDelegate
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.callMethodAsync
+import com.monkopedia.sdbus.mutableDelegate
+import com.monkopedia.sdbus.propDelegate
+import com.monkopedia.sdbus.signalFlow
+import kotlin.Boolean
+import kotlin.Double
+import kotlin.Long
+import kotlin.String
+import kotlin.Unit
+import kotlinx.coroutines.flow.Flow
+
+public class PlayerProxy(
+  public val proxy: Proxy,
+) : Player {
+  public val playbackStatusProperty: PropertyDelegate<PlayerProxy, String> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("PlaybackStatus")) 
+
+  public var loopStatusProperty: MutablePropertyDelegate<PlayerProxy, String> =
+      proxy.mutableDelegate(Player.Companion.INTERFACE_NAME, PropertyName("LoopStatus")) 
+
+  public var rateProperty: MutablePropertyDelegate<PlayerProxy, Double> =
+      proxy.mutableDelegate(Player.Companion.INTERFACE_NAME, PropertyName("Rate")) 
+
+  public var shuffleProperty: MutablePropertyDelegate<PlayerProxy, Boolean> =
+      proxy.mutableDelegate(Player.Companion.INTERFACE_NAME, PropertyName("Shuffle")) 
+
+  public val metadataProperty: PropertyDelegate<PlayerProxy, QVariantMap> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("Metadata")) 
+
+  public var volumeProperty: MutablePropertyDelegate<PlayerProxy, Double> =
+      proxy.mutableDelegate(Player.Companion.INTERFACE_NAME, PropertyName("Volume")) 
+
+  public val positionProperty: PropertyDelegate<PlayerProxy, Long> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("Position")) 
+
+  public val minimumRateProperty: PropertyDelegate<PlayerProxy, Double> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("MinimumRate")) 
+
+  public val maximumRateProperty: PropertyDelegate<PlayerProxy, Double> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("MaximumRate")) 
+
+  public val canGoNextProperty: PropertyDelegate<PlayerProxy, Boolean> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("CanGoNext")) 
+
+  public val canGoPreviousProperty: PropertyDelegate<PlayerProxy, Boolean> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("CanGoPrevious")) 
+
+  public val canPlayProperty: PropertyDelegate<PlayerProxy, Boolean> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("CanPlay")) 
+
+  public val canPauseProperty: PropertyDelegate<PlayerProxy, Boolean> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("CanPause")) 
+
+  public val canSeekProperty: PropertyDelegate<PlayerProxy, Boolean> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("CanSeek")) 
+
+  public val canControlProperty: PropertyDelegate<PlayerProxy, Boolean> =
+      proxy.propDelegate(Player.Companion.INTERFACE_NAME, PropertyName("CanControl")) 
+
+  override val playbackStatus: String by playbackStatusProperty
+
+  override var loopStatus: String by loopStatusProperty
+
+  override var rate: Double by rateProperty
+
+  override var shuffle: Boolean by shuffleProperty
+
+  override val metadata: QVariantMap by metadataProperty
+
+  override var volume: Double by volumeProperty
+
+  override val position: Long by positionProperty
+
+  override val minimumRate: Double by minimumRateProperty
+
+  override val maximumRate: Double by maximumRateProperty
+
+  override val canGoNext: Boolean by canGoNextProperty
+
+  override val canGoPrevious: Boolean by canGoPreviousProperty
+
+  override val canPlay: Boolean by canPlayProperty
+
+  override val canPause: Boolean by canPauseProperty
+
+  override val canSeek: Boolean by canSeekProperty
+
+  override val canControl: Boolean by canControlProperty
+
+  public val seeked: Flow<Long> =
+      proxy.signalFlow(Player.Companion.INTERFACE_NAME, SignalName("Seeked")) {
+        call { a: Long -> a }
+      }
+
+  public override fun register() {
+  }
+
+  override suspend fun next(): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("Next")) {
+    call()
+  }
+
+  override suspend fun previous(): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("Previous")) {
+    call()
+  }
+
+  override suspend fun pause(): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("Pause")) {
+    call()
+  }
+
+  override suspend fun playPause(): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("PlayPause")) {
+    call()
+  }
+
+  override suspend fun stop(): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("Stop")) {
+    call()
+  }
+
+  override suspend fun play(): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("Play")) {
+    call()
+  }
+
+  override suspend fun seek(offset: Long): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("Seek")) {
+    call(offset)
+  }
+
+  override suspend fun setPosition(trackId: ObjectPath, position: Long): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("SetPosition")) {
+    call(trackId, position)
+  }
+
+  override suspend fun openUri(uri: String): Unit = proxy.callMethodAsync(Player.Companion.INTERFACE_NAME, MethodName("OpenUri")) {
+    call(uri)
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/adaptor.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/adaptor.0.kt
@@ -1,0 +1,48 @@
+package org.example
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import kotlin.Unit
+
+public abstract class NamingAdaptor(
+  public val obj: Object,
+) : Naming {
+  public override fun register() {
+    obj.addVTable(Naming.Companion.INTERFACE_NAME) {
+      method(MethodName("Transform")) {
+        inputParamNames = listOf("origin")
+        outputParamNames = listOf("path")
+        asyncCall(this@NamingAdaptor::transform)
+      }
+      method(MethodName("Describe")) {
+        inputParamNames = listOf("spec")
+        outputParamNames = listOf("text")
+        asyncCall(this@NamingAdaptor::describe)
+      }
+      method(MethodName("Bounds")) {
+        outputParamNames = listOf("extent")
+        asyncCall(this@NamingAdaptor::bounds)
+      }
+      signal(SignalName("Resized")) {
+        with<Size>("size")
+      }
+      prop(PropertyName("Geometry")) {
+        with(this@NamingAdaptor::geometry)
+      }
+      prop(PropertyName("Metadata")) {
+        with(this@NamingAdaptor::metadata)
+      }
+    }
+  }
+
+  public suspend fun onResized(size: Size): Unit = obj.emitSignal(Naming.Companion.INTERFACE_NAME, SignalName("Resized")) {
+    call(size)
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/hinted-adaptor.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-adaptor.0.kt
@@ -1,0 +1,48 @@
+package org.example
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.method
+import com.monkopedia.sdbus.prop
+import com.monkopedia.sdbus.signal
+import kotlin.Unit
+
+public abstract class NamingAdaptor(
+  public val obj: Object,
+) : Naming {
+  public override fun register() {
+    obj.addVTable(Naming.Companion.INTERFACE_NAME) {
+      method(MethodName("Transform")) {
+        inputParamNames = listOf("origin")
+        outputParamNames = listOf("path")
+        asyncCall(this@NamingAdaptor::transform)
+      }
+      method(MethodName("Describe")) {
+        inputParamNames = listOf("spec")
+        outputParamNames = listOf("text")
+        asyncCall(this@NamingAdaptor::describe)
+      }
+      method(MethodName("Bounds")) {
+        outputParamNames = listOf("extent")
+        asyncCall(this@NamingAdaptor::bounds)
+      }
+      signal(SignalName("Resized")) {
+        with<QSize>("size")
+      }
+      prop(PropertyName("Geometry")) {
+        with(this@NamingAdaptor::geometry)
+      }
+      prop(PropertyName("Metadata")) {
+        with(this@NamingAdaptor::metadata)
+      }
+    }
+  }
+
+  public suspend fun onResized(size: QSize): Unit = obj.emitSignal(Naming.Companion.INTERFACE_NAME, SignalName("Resized")) {
+    call(size)
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.0.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import kotlin.UInt
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Extent(
+  public val uInt: UInt,
+  public val uInt1: UInt,
+)

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.1.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.1.kt
@@ -1,0 +1,22 @@
+package org.example
+
+import com.monkopedia.sdbus.InterfaceName
+import kotlin.String
+
+public interface Naming {
+  public val geometry: QRect
+
+  public val metadata: QVariantMap
+
+  public fun register()
+
+  public suspend fun transform(origin: QPointF): QPolygonF
+
+  public suspend fun describe(spec: QVersionSpec): String
+
+  public suspend fun bounds(): Extent
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.example.Naming")
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.2.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.2.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import kotlin.Double
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class QPointF(
+  public val double: Double,
+  public val double1: Double,
+)

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.3.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.3.kt
@@ -1,0 +1,5 @@
+package org.example
+
+import kotlin.collections.List
+
+public typealias QPolygonF = List<QPointF>

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.4.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.4.kt
@@ -1,0 +1,12 @@
+package org.example
+
+import kotlin.Int
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class QRect(
+  public val int: Int,
+  public val int1: Int,
+  public val int2: Int,
+  public val int3: Int,
+)

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.5.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.5.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import kotlin.Short
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class QSize(
+  public val short: Short,
+  public val short1: Short,
+)

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.6.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.6.kt
@@ -1,0 +1,7 @@
+package org.example
+
+import com.monkopedia.sdbus.Variant
+import kotlin.String
+import kotlin.collections.Map
+
+public typealias QVariantMap = Map<String, Variant>

--- a/codegen/src/test/resources/NamingHintsTest/hinted-interface.7.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-interface.7.kt
@@ -1,0 +1,11 @@
+package org.example
+
+import kotlin.String
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class QVersionSpec(
+  public val string: String,
+  public val string1: String,
+  public val string2: String,
+)

--- a/codegen/src/test/resources/NamingHintsTest/hinted-proxy.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-proxy.0.kt
@@ -26,7 +26,7 @@ public class NamingProxy(
 
   public val resized: Flow<QSize> =
       proxy.signalFlow(Naming.Companion.INTERFACE_NAME, SignalName("Resized")) {
-        call(::QSize)
+        call { a: QSize -> a }
       }
 
   public override fun register() {

--- a/codegen/src/test/resources/NamingHintsTest/hinted-proxy.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/hinted-proxy.0.kt
@@ -1,0 +1,46 @@
+package org.example
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.PropertyDelegate
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.callMethodAsync
+import com.monkopedia.sdbus.propDelegate
+import com.monkopedia.sdbus.signalFlow
+import kotlin.String
+import kotlinx.coroutines.flow.Flow
+
+public class NamingProxy(
+  public val proxy: Proxy,
+) : Naming {
+  public val geometryProperty: PropertyDelegate<NamingProxy, QRect> =
+      proxy.propDelegate(Naming.Companion.INTERFACE_NAME, PropertyName("Geometry")) 
+
+  public val metadataProperty: PropertyDelegate<NamingProxy, QVariantMap> =
+      proxy.propDelegate(Naming.Companion.INTERFACE_NAME, PropertyName("Metadata")) 
+
+  override val geometry: QRect by geometryProperty
+
+  override val metadata: QVariantMap by metadataProperty
+
+  public val resized: Flow<QSize> =
+      proxy.signalFlow(Naming.Companion.INTERFACE_NAME, SignalName("Resized")) {
+        call(::QSize)
+      }
+
+  public override fun register() {
+  }
+
+  override suspend fun transform(origin: QPointF): QPolygonF = proxy.callMethodAsync(Naming.Companion.INTERFACE_NAME, MethodName("Transform")) {
+    call(origin)
+  }
+
+  override suspend fun describe(spec: QVersionSpec): String = proxy.callMethodAsync(Naming.Companion.INTERFACE_NAME, MethodName("Describe")) {
+    call(spec)
+  }
+
+  override suspend fun bounds(): Extent = proxy.callMethodAsync(Naming.Companion.INTERFACE_NAME, MethodName("Bounds")) {
+    call()
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/interface.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/interface.0.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import kotlin.UInt
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Extent(
+  public val uInt: UInt,
+  public val uInt1: UInt,
+)

--- a/codegen/src/test/resources/NamingHintsTest/interface.1.kt
+++ b/codegen/src/test/resources/NamingHintsTest/interface.1.kt
@@ -1,0 +1,12 @@
+package org.example
+
+import kotlin.Int
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Geometry(
+  public val int: Int,
+  public val int1: Int,
+  public val int2: Int,
+  public val int3: Int,
+)

--- a/codegen/src/test/resources/NamingHintsTest/interface.2.kt
+++ b/codegen/src/test/resources/NamingHintsTest/interface.2.kt
@@ -1,0 +1,25 @@
+package org.example
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.Variant
+import kotlin.String
+import kotlin.collections.List
+import kotlin.collections.Map
+
+public interface Naming {
+  public val geometry: Geometry
+
+  public val metadata: Map<String, Variant>
+
+  public fun register()
+
+  public suspend fun transform(origin: OriginType): List<OriginType>
+
+  public suspend fun describe(spec: Spec): String
+
+  public suspend fun bounds(): Extent
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.example.Naming")
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/interface.3.kt
+++ b/codegen/src/test/resources/NamingHintsTest/interface.3.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import kotlin.Double
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class OriginType(
+  public val double: Double,
+  public val double1: Double,
+)

--- a/codegen/src/test/resources/NamingHintsTest/interface.4.kt
+++ b/codegen/src/test/resources/NamingHintsTest/interface.4.kt
@@ -1,0 +1,10 @@
+package org.example
+
+import kotlin.Short
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Size(
+  public val short: Short,
+  public val short1: Short,
+)

--- a/codegen/src/test/resources/NamingHintsTest/interface.5.kt
+++ b/codegen/src/test/resources/NamingHintsTest/interface.5.kt
@@ -1,0 +1,11 @@
+package org.example
+
+import kotlin.String
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Spec(
+  public val string: String,
+  public val string1: String,
+  public val string2: String,
+)

--- a/codegen/src/test/resources/NamingHintsTest/proxy.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/proxy.0.kt
@@ -29,7 +29,7 @@ public class NamingProxy(
 
   public val resized: Flow<Size> =
       proxy.signalFlow(Naming.Companion.INTERFACE_NAME, SignalName("Resized")) {
-        call(::Size)
+        call { a: Size -> a }
       }
 
   public override fun register() {

--- a/codegen/src/test/resources/NamingHintsTest/proxy.0.kt
+++ b/codegen/src/test/resources/NamingHintsTest/proxy.0.kt
@@ -1,0 +1,49 @@
+package org.example
+
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.PropertyDelegate
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.callMethodAsync
+import com.monkopedia.sdbus.propDelegate
+import com.monkopedia.sdbus.signalFlow
+import kotlin.String
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlinx.coroutines.flow.Flow
+
+public class NamingProxy(
+  public val proxy: Proxy,
+) : Naming {
+  public val geometryProperty: PropertyDelegate<NamingProxy, Geometry> =
+      proxy.propDelegate(Naming.Companion.INTERFACE_NAME, PropertyName("Geometry")) 
+
+  public val metadataProperty: PropertyDelegate<NamingProxy, Map<String, Variant>> =
+      proxy.propDelegate(Naming.Companion.INTERFACE_NAME, PropertyName("Metadata")) 
+
+  override val geometry: Geometry by geometryProperty
+
+  override val metadata: Map<String, Variant> by metadataProperty
+
+  public val resized: Flow<Size> =
+      proxy.signalFlow(Naming.Companion.INTERFACE_NAME, SignalName("Resized")) {
+        call(::Size)
+      }
+
+  public override fun register() {
+  }
+
+  override suspend fun transform(origin: OriginType): List<OriginType> = proxy.callMethodAsync(Naming.Companion.INTERFACE_NAME, MethodName("Transform")) {
+    call(origin)
+  }
+
+  override suspend fun describe(spec: Spec): String = proxy.callMethodAsync(Naming.Companion.INTERFACE_NAME, MethodName("Describe")) {
+    call(spec)
+  }
+
+  override suspend fun bounds(): Extent = proxy.callMethodAsync(Naming.Companion.INTERFACE_NAME, MethodName("Bounds")) {
+    call()
+  }
+}

--- a/codegen/src/test/resources/NamingHintsTest/test.xml
+++ b/codegen/src/test/resources/NamingHintsTest/test.xml
@@ -1,0 +1,47 @@
+<!--
+  Exercises every placement of org.qtproject.QtDBus.QtTypeName the generator understands.
+  The interface.*.kt / adaptor.*.kt / proxy.*.kt goldens are the default (flag off) output and must
+  not react to any of these annotations; the hinted-*.kt goldens are the same XML generated with
+  naming annotations honored.
+-->
+<node>
+  <interface name="org.example.Naming">
+
+    <!-- Struct property: the hint replaces the name derived from the member name. -->
+    <property name="Geometry" type="(iiii)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="QRect"/>
+    </property>
+
+    <!-- Map property: nothing is generated for a{sv}, so the hint becomes a typealias for it. -->
+    <property name="Metadata" type="a{sv}" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
+    </property>
+
+    <!-- Indexed hints on the method, which is where qdbusxml2cpp writes them. -->
+    <method name="Transform">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QPointF"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QPolygonF"/>
+      <arg name="origin" type="(dd)" direction="in"/>
+      <arg name="path" type="a(dd)" direction="out"/>
+    </method>
+
+    <!-- A hint written directly on the arg it names. -->
+    <method name="Describe">
+      <arg name="spec" type="(sss)" direction="in">
+        <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVersionSpec"/>
+      </arg>
+      <arg name="text" type="s" direction="out"/>
+    </method>
+
+    <!-- No hint anywhere: the name stays derived from the member name either way. -->
+    <method name="Bounds">
+      <arg name="extent" type="(uu)" direction="out"/>
+    </method>
+
+    <signal name="Resized">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QSize"/>
+      <arg name="size" type="(nn)"/>
+    </signal>
+
+  </interface>
+</node>

--- a/compile_test/build.gradle.kts
+++ b/compile_test/build.gradle.kts
@@ -26,6 +26,10 @@ kotlin {
     applyDefaultHierarchyTemplate()
     sourceSets {
         getByName("nativeMain") {
+            // TestFiles symlinks the whole codegen fixture tree into one compilation. The
+            // `hinted-*` goldens are the same interfaces named from annotations, so they would
+            // redeclare their default counterparts; :codegen compiles that output on its own.
+            kotlin.exclude("**/hinted-*.kt")
             dependencies {
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization)

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -3,12 +3,14 @@ public class com/monkopedia/sdbus/plugin/SdbusExtension {
 	public synthetic fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGenerateAdapters ()Z
 	public fun getGenerateProxies ()Z
+	public fun getHonorNamingAnnotations ()Z
 	public fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
 	public fun getOutputPackage ()Ljava/lang/String;
 	public fun getOutputs ()Ljava/util/List;
 	public fun getSources ()Lorg/gradle/api/file/SourceDirectorySet;
 	public fun setGenerateAdapters (Z)V
 	public fun setGenerateProxies (Z)V
+	public fun setHonorNamingAnnotations (Z)V
 	public fun setOutputPackage (Ljava/lang/String;)V
 }
 
@@ -17,11 +19,13 @@ public class com/monkopedia/sdbus/plugin/SdbusGenerationTask : org/gradle/api/De
 	public final fun execute ()V
 	public fun getGenerateAdapters ()Z
 	public fun getGenerateProxies ()Z
+	public fun getHonorNamingAnnotations ()Z
 	public fun getInputXmlFile ()Ljava/io/File;
 	public fun getOutputDir ()Ljava/io/File;
 	public fun getOutputPackage ()Ljava/lang/String;
 	public fun setGenerateAdapters (Z)V
 	public fun setGenerateProxies (Z)V
+	public fun setHonorNamingAnnotations (Z)V
 	public fun setInputXmlFile (Ljava/io/File;)V
 	public fun setOutputDir (Ljava/io/File;)V
 	public fun setOutputPackage (Ljava/lang/String;)V

--- a/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusExtension.kt
+++ b/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusExtension.kt
@@ -23,6 +23,14 @@ open class SdbusExtension(
     @get:Optional
     open var outputPackage: String? = null
 
+    /**
+     * Name generated types from `org.qtproject.QtDBus.QtTypeName` annotations in the XML rather
+     * than deriving every name from the member names. Off by default because a hint replaces a
+     * derived name, which would rename types that already-compiled code refers to.
+     */
+    @Input
+    open var honorNamingAnnotations: Boolean = false
+
     @get:InputDirectory
     open val sources: SourceDirectorySet by lazy {
         objectFactory.sourceDirectorySet("sdbusXml", "XML Inputs for Sdbus Kotlin import")

--- a/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusGenerationTask.kt
+++ b/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusGenerationTask.kt
@@ -33,6 +33,9 @@ open class SdbusGenerationTask : DefaultTask() {
     @get:Optional
     open var outputPackage: String? = null
 
+    @Input
+    open var honorNamingAnnotations: Boolean = false
+
     @TaskAction
     fun execute() {
         inputXmlFile.collection().forEach {
@@ -44,6 +47,9 @@ open class SdbusGenerationTask : DefaultTask() {
             }
             if (generateAdapters) {
                 args.add("--adaptor")
+            }
+            if (honorNamingAnnotations) {
+                args.add("--honor-naming-annotations")
             }
             outputPackage?.takeUnless(String::isBlank)?.let { packageName ->
                 args.add("--output-package")

--- a/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusPlugin.kt
+++ b/plugin/src/main/kotlin/com/monkopedia/sdbus/plugin/SdbusPlugin.kt
@@ -32,6 +32,7 @@ class SdbusPlugin : Plugin<Project> {
                     it.generateProxies = ext.generateProxies
                     it.generateAdapters = ext.generateAdapters
                     it.outputPackage = ext.outputPackage
+                    it.honorNamingAnnotations = ext.honorNamingAnnotations
                 }
                 rootTask.dependsOn(task)
             }

--- a/plugin/src/test/kotlin/com/monkopedia/sdbus/plugin/SdbusPluginTest.kt
+++ b/plugin/src/test/kotlin/com/monkopedia/sdbus/plugin/SdbusPluginTest.kt
@@ -92,10 +92,26 @@ class SdbusPluginTest {
         )
     }
 
+    @Test
+    fun honorsNamingAnnotationsWhenEnabled() = withProject(
+        generateProxies = false,
+        generateAdapters = false,
+        honorNamingAnnotations = true,
+        xml = HINTED_XML
+    ) { dir ->
+        runTask(dir, "generateSdbusWrappers")
+
+        val generatedRoot = File(dir, "build/generated/sdbus/sample/sampleOut/org/foo")
+        assertTrue(File(generatedRoot, "QPoint.kt").exists())
+        assertFalse(File(generatedRoot, "Corner.kt").exists())
+    }
+
     private fun withProject(
         generateProxies: Boolean,
         generateAdapters: Boolean,
         outputPackage: String? = null,
+        honorNamingAnnotations: Boolean = false,
+        xml: String = SAMPLE_XML,
         compileTargetJvm: Boolean = false,
         includeCompileFixture: Boolean = false,
         applyMavenPublish: Boolean = false,
@@ -135,24 +151,14 @@ class SdbusPluginTest {
                     sdbus {
                       generateProxies = $generateProxies
                       generateAdapters = $generateAdapters
+                      honorNamingAnnotations = $honorNamingAnnotations
                       ${outputPackage?.let { "outputPackage = \"$it\"" } ?: ""}
                       outputs.add("${if (compileTargetJvm) "jvmMain" else "linuxMain"}")
                       sources.srcDir("src/sdbus")
                     }
                 """
             )
-            writeFile(
-                File(root, "src/sdbus/sample.xml"),
-                """
-                    <node>
-                      <interface name="org.foo.Background">
-                        <method name="currentBackground">
-                          <arg type="s" direction="out"/>
-                        </method>
-                      </interface>
-                    </node>
-                """
-            )
+            writeFile(File(root, "src/sdbus/sample.xml"), xml)
             if (includeCompileFixture) {
                 val sourceSetDir = if (compileTargetJvm) "jvmMain" else "linuxMain"
                 writeFile(
@@ -212,5 +218,27 @@ class SdbusPluginTest {
     private fun writeFile(file: File, content: String) {
         file.parentFile.mkdirs()
         file.writeText(content.trimIndent())
+    }
+
+    private companion object {
+        private val SAMPLE_XML = """
+            <node>
+              <interface name="org.foo.Background">
+                <method name="currentBackground">
+                  <arg type="s" direction="out"/>
+                </method>
+              </interface>
+            </node>
+        """
+
+        private val HINTED_XML = """
+            <node>
+              <interface name="org.foo.Hinted">
+                <property name="Corner" type="(ii)" access="read">
+                  <annotation name="org.qtproject.QtDBus.QtTypeName" value="QPoint"/>
+                </property>
+              </interface>
+            </node>
+        """
     }
 }


### PR DESCRIPTION
Fixes #158.

## Authority

Implemented per the owner ruling recorded at
https://github.com/Monkopedia/sdbus-kotlin/issues/158#issuecomment-5179298860 — Jason selected
**"Opt-in generator flag (agent's rec)"** over `Accept the source break + changelog it`,
`Revert to documenting the hook` and `Delete the walker`, having been shown that the flag costs a
second code path and is the only option that implements the feature without breaking anyone. That
comment also sets the load-bearing condition this PR has to meet: *"Default-off behavior must be
byte-identical to today — that is the property the whole decision rests on, and it should be proven
by the existing golden fixtures being unchanged with the flag off, not asserted."*

## What it does

`NamingManager.buildAnnotationTypes` had an empty body from the first commit, reached from five call
sites. It could never have been filled in place — it receives a package and an annotation and
nothing else, so it cannot resolve a hint to a signature. **It is deleted**, and the hints are
applied in a second pass over the document, after the type map is built, where the signature and the
annotation are both in hand. Net effect on the annotation fan-out: it is gone, and annotations now
genuinely feed naming.

`org.qtproject.QtDBus.QtTypeName` is read from the three placements `qdbusxml2cpp` uses:

| Placement | Form |
| --- | --- |
| `<property>` | `org.qtproject.QtDBus.QtTypeName` |
| `<arg>` | `org.qtproject.QtDBus.QtTypeName` |
| `<method>` / `<signal>` | `org.qtproject.QtDBus.QtTypeName.In<n>` / `.Out<n>`, indexing that direction's args |

- A signature that **already generates a class of its own** (a struct) is renamed in place.
- A signature that **does not** — a map, a list, a primitive — gets a `typealias`, so the hinted
  name is usable without changing the type it stands for.
- Hints are keyed by D-Bus signature, like everything else in the type map, so a hint names every
  member whose own type is that signature. A signature nested *inside* a generated struct keeps its
  structural rendering.
- A value that is not a usable Kotlin name (`QMap<QString,QVariant>`) fails the build rather than
  being silently ignored.

The option is `honorNamingAnnotations` on the Gradle `sdbus { }` extension and
`--honor-naming-annotations` on `Xml2Kotlin`, matching how `outputPackage` is already plumbed
(extension → task → CLI arg). README documents it in the existing options table plus a subsection.

## What the flag can and cannot reach

**Can:** `<annotation>` elements only. That is the whole of its reach.

**Cannot:** `tp:type` and `tp:name-for-bindings`. `MediaPlayer2/test.xml` is full of those
(`tp:type="Metadata_Map"`, `tp:name-for-bindings="Can_Set_Fullscreen"`) and they are genuine naming
metadata — but they are XML **attributes**, not `<annotation>` elements, and `XmlFormat.kt` does not
retain them. No amount of work in this pass reaches them; that would be parser work. This PR does
not do it and does not claim to.

## The `QtTypeName` / `LazyType` case (the sharpest one)

`MediaPlayer2/test.xml:95` carries the repo's only real `QtTypeName`, `QVariantMap`, on
`<property name="Metadata" type="a{sv}">`. `a{sv}` resolves to a `LazyType` with no generated class,
so the earlier investigation correctly flagged that naively honouring it would *introduce* a class
where `Map<String, Variant>` is today and break `player.metadata["xesam:title"]` at the call site.

Honouring it as a **typealias** is what makes that case safe. With the flag on, `MediaPlayer2`
generates one extra file and the property changes type — and `metadata["xesam:title"]` still
compiles, because `QVariantMap` *is* `Map<String, Variant>`:

```
$ diff codegen/src/test/resources/MediaPlayer2/interface.1.kt \
       codegen/src/test/resources/MediaPlayer2/hinted-interface.1.kt
5d4
< import com.monkopedia.sdbus.Variant
10d8
< import kotlin.collections.Map
21c19
<   public val metadata: Map<String, Variant>
---
>   public val metadata: QVariantMap

$ cat codegen/src/test/resources/MediaPlayer2/hinted-interface.2.kt
package org.mpris.mediaplayer2

import com.monkopedia.sdbus.Variant
import kotlin.String
import kotlin.collections.Map

public typealias QVariantMap = Map<String, Variant>
```

## Proof that default-off is byte-identical

Two independent forms, both run on the committed tree. **Method matters here**, because a stale
`UP-TO-DATE` task, a stale JUnit XML, or a flipped `WRITE_FILES` each produce "green, no diff"
without having measured anything.

**1 — assertion form.** `codegen/build/test-results` deleted first so an unrun build reads as absent
rather than as confirmation, then `--rerun-tasks` so generation genuinely happens:

```
$ rm -rf codegen/build/test-results plugin/build/test-results
$ ./gradlew --rerun-tasks :codegen:test :plugin:test
BUILD SUCCESSFUL

name="com.monkopedia.sdbus.CodegenNamingAndTypeTest" tests="8"  skipped="0" failures="0" errors="0"
name="com.monkopedia.sdbus.CodegenParsingEdgeCaseTest" tests="4"  skipped="0" failures="0" errors="0"
name="com.monkopedia.sdbus.CompilationIntegrationTest" tests="2"  skipped="0" failures="0" errors="0"
name="com.monkopedia.sdbus.GeneratorTest" tests="69" skipped="0" failures="0" errors="0"
name="com.monkopedia.sdbus.NamingHintTest" tests="6"  skipped="0" failures="0" errors="0"
name="com.monkopedia.sdbus.plugin.SdbusPluginTest" tests="7"  skipped="0" failures="0" errors="0"
```

`GeneratorTest` is the byte-identity assertion: it string-compares every checked-in golden against
freshly generated default-off output. 69 = the 66 pre-existing fixtures plus 3 for the new
`NamingHintsTest` directory (interface/adaptor/proxy), which is also asserted flag-off.

**2 — materialized form.** `GeneratorTest` compares rather than writes, so a clean `git diff` proves
nothing on its own. To make the bytes real, `WRITE_FILES` was flipped to `true` locally, the suite
re-run with `--rerun-tasks` so every golden was physically rewritten by the default-off generator,
then flipped back:

```
$ git status --porcelain codegen/src/test/resources/
$ git status --porcelain
$
```

Both empty: every one of the rewritten goldens is byte-for-byte what is checked in, and the flip was
reverted. **`WRITE_FILES` is `false` in the pushed tree** —
`git show HEAD:codegen/src/test/kotlin/GeneratorTest.kt` line 88 reads
`private const val WRITE_FILES = false` (see #206 for why that matters).

The strongest single piece of evidence is `MediaPlayer2`: it carries a real `QtTypeName`, and its
default goldens are unchanged while its `hinted-` goldens differ. Same XML, both sides of the flag.

## ⚠️ `api/*.api` moved, and one entry is a binary break

Both dumps are regenerated and committed. `plugin/api/plugin.api` is **purely additive**
(`get/setHonorNamingAnnotations` on the extension and the task).

`codegen/api/codegen.api` is **not purely additive**. The generator constructors gained a parameter,
so their JVM signatures changed rather than grew:

```
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Z)V
```

on `BaseGenerator`, `InterfaceGenerator`, `AdaptorGenerator`, `ProxyGenerator` and (with the
`XmlRootNode` prefix) `NamingManager`. Source-compatible via default arguments; **binary-incompatible
for anyone linking against `:codegen` and calling those constructors directly**. The CLI and the
Gradle plugin paths are unaffected. Additive entries: `NamingManager$AliasType`,
`GeneratedType.get/setNameHint`, `TypeGenerationKt.generateAlias`, `Xml2Kotlin.getHonorNamingAnnotations`.

I chose to take the signature change rather than annotate five declarations `@JvmOverloads` purely to
retain overloads a build-time tool artifact is unlikely to have programmatic callers for. **That is a
judgement call and it is cheap to reverse** — one annotation per class makes the dump additive. Flag
it if you would rather have that.

## Tests and fixtures

- **`codegen/src/test/resources/NamingHintsTest/`** — new fixture exercising every placement:
  struct property (`QRect`), map property (`QVariantMap` typealias), indexed `.In0`/`.Out0` on a
  method (`QPointF`, and `QPolygonF = List<QPointF>`), an `<arg>`-level hint (`QVersionSpec`),
  `.Out0` on a signal (`QSize`), and one member with no hint at all whose name is derived either way.
- **`hinted-*` goldens next to the default ones** in `NamingHintsTest` and `MediaPlayer2`, so one XML
  pins both sides of the flag. `GeneratorTest` asserts the default set; the new `NamingHintTest`
  asserts the `hinted-` set. `NamingHintTest` deliberately has **no** write-the-goldens switch.
- `CodegenNamingAndTypeTest` gains three unit tests: inertness with the flag off on hint-carrying
  XML, rename-plus-typealias with it on, and the loud failure on an unusable hint value.
- `Xml2KotlinOptionsTest` and `SdbusPluginTest` cover the CLI flag and the Gradle option end to end.
- `CompilationIntegrationTest` gains a case that compiles the **hinted** output of the new fixture,
  so the typealias path is proven to produce compilable Kotlin, not just matching text.

## One build-file change worth a look

`compile_test` symlinks the entire codegen fixture tree into a single native compilation, so the
`hinted-` goldens would redeclare their default counterparts. `compile_test/build.gradle.kts` now
excludes `**/hinted-*.kt` from `nativeMain`, with a comment saying why. The default goldens —
including the new fixture's — are still native-compiled there; the hinted output is compile-checked
on the JVM by `CompilationIntegrationTest` instead.

## Verification run locally

`:codegen:test` (98 tests, 0 failures), `:plugin:test` (7, 0), `ktlintCheck`, `apiDump` + `apiCheck`,
`:compile_test:compileKotlinLinuxX64`. All green. JDK 21.
