### PR TITLE
SPIKE / DO NOT MERGE: price JVM parity for interface-level Deprecated + EmitsChangedSignal (Refs #193)

### DIFF
--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
@@ -21,6 +21,11 @@
 package com.monkopedia.sdbus.internal.jvmdbus
 
 import com.monkopedia.sdbus.ActionResource
+import com.monkopedia.sdbus.Flags
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.CONST_PROPERTY_VALUE
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_CHANGE_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
+import com.monkopedia.sdbus.InterfaceFlagsVTableItem
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodCall
 import com.monkopedia.sdbus.MethodVTableItem
@@ -278,6 +283,7 @@ internal object WireServe {
 
     private fun StringBuilder.appendInterface(name: String, meta: WireServeRegistry.InterfaceMeta) {
         append("  <interface name=\"").append(name).append("\">\n")
+        if (meta.deprecated) appendAnnotation("    ", DEPRECATED_ANNOTATION, "true")
         meta.methods.values.sortedBy { it.name }.forEach { method ->
             append("    <method name=\"").append(method.name).append("\">\n")
             splitTypes(method.inputSignature).forEachIndexed { i, type ->
@@ -286,7 +292,7 @@ internal object WireServe {
             splitTypes(method.outputSignature).forEachIndexed { i, type ->
                 appendArg(type, method.outputNames.getOrNull(i), "out")
             }
-            if (method.deprecated) append(DEPRECATED_ANNOTATION)
+            if (method.deprecated) appendAnnotation("      ", DEPRECATED_ANNOTATION, "true")
             append("    </method>\n")
         }
         meta.signals.values.sortedBy { it.name }.forEach { signal ->
@@ -294,7 +300,7 @@ internal object WireServe {
             splitTypes(signal.signature).forEachIndexed { i, type ->
                 appendArg(type, signal.paramNames.getOrNull(i), null)
             }
-            if (signal.deprecated) append(DEPRECATED_ANNOTATION)
+            if (signal.deprecated) appendAnnotation("      ", DEPRECATED_ANNOTATION, "true")
             append("    </signal>\n")
         }
         meta.properties.values.sortedBy { it.name }.forEach { property ->
@@ -306,14 +312,24 @@ internal object WireServe {
             append("    <property name=\"").append(property.name)
                 .append("\" type=\"").append(property.signature)
                 .append("\" access=\"").append(access).append("\"")
-            if (property.deprecated) {
-                append(">\n").append("      ").append(DEPRECATED_ANNOTATION.trim()).append("\n")
-                    .append("    </property>\n")
-            } else {
+            val annotations = buildString {
+                if (property.deprecated) appendAnnotation("      ", DEPRECATED_ANNOTATION, "true")
+                property.emitsChangedSignal?.let {
+                    appendAnnotation("      ", EMITS_CHANGED_SIGNAL_ANNOTATION, it)
+                }
+            }
+            if (annotations.isEmpty()) {
                 append("/>\n")
+            } else {
+                append(">\n").append(annotations).append("    </property>\n")
             }
         }
         append("  </interface>\n")
+    }
+
+    private fun StringBuilder.appendAnnotation(indent: String, name: String, value: String) {
+        append(indent).append("<annotation name=\"").append(name)
+            .append("\" value=\"").append(value).append("\"/>\n")
     }
 
     // Splits a signature into its top-level complete types (e.g. "ia{sv}" -> [i, a{sv}]); empty
@@ -355,8 +371,10 @@ internal object WireServe {
         append("/>\n")
     }
 
-    private val DEPRECATED_ANNOTATION =
-        "      <annotation name=\"org.freedesktop.DBus.Deprecated\" value=\"true\"/>\n"
+    private const val DEPRECATED_ANNOTATION = "org.freedesktop.DBus.Deprecated"
+
+    private const val EMITS_CHANGED_SIGNAL_ANNOTATION =
+        "org.freedesktop.DBus.Property.EmitsChangedSignal"
 
     private val STANDARD_INTROSPECTION =
         "  <interface name=\"org.freedesktop.DBus.Peer\">\n" +
@@ -429,7 +447,12 @@ internal object WireServeRegistry {
         val signature: String,
         val readable: Boolean,
         val writable: Boolean,
-        val deprecated: Boolean
+        val deprecated: Boolean,
+        /**
+         * The `org.freedesktop.DBus.Property.EmitsChangedSignal` value to advertise, or `null` for
+         * the D-Bus default (`"true"`), which sd-bus leaves implicit and so is omitted here too.
+         */
+        val emitsChangedSignal: String? = null
     )
 
     data class SignalMeta(
@@ -443,7 +466,9 @@ internal object WireServeRegistry {
         val methods: Map<String, MethodMeta>,
         val properties: Map<String, PropertyMeta>,
         val signals: Map<String, SignalMeta>,
-        val objectManager: Boolean = false
+        val objectManager: Boolean = false,
+        /** Whether the interface itself was flagged deprecated via `interfaceFlags`. */
+        val deprecated: Boolean = false
     )
 
     private data class ObjectKey(val destination: String, val path: String)
@@ -535,6 +560,7 @@ internal object WireServeRegistry {
         val methods = mutableMapOf<String, MethodMeta>()
         val properties = mutableMapOf<String, PropertyMeta>()
         val signals = mutableMapOf<String, SignalMeta>()
+        var interfaceDeprecated = false
         vtable.forEach { item ->
             when (item) {
                 is MethodVTableItem -> methods[item.name.value] = MethodMeta(
@@ -551,7 +577,8 @@ internal object WireServeRegistry {
                     signature = item.signature?.value.orEmpty(),
                     readable = item.getter != null,
                     writable = item.setter != null,
-                    deprecated = item.isDeprecated
+                    deprecated = item.isDeprecated,
+                    emitsChangedSignal = item.flags.emitsChangedSignalValue()
                 )
 
                 is SignalVTableItem -> signals[item.name.value] = SignalMeta(
@@ -561,9 +588,26 @@ internal object WireServeRegistry {
                     deprecated = item.isDeprecated
                 )
 
-                else -> Unit
+                is InterfaceFlagsVTableItem ->
+                    interfaceDeprecated = interfaceDeprecated || item.isDeprecated
             }
         }
-        return InterfaceMeta(methods, properties, signals)
+        return InterfaceMeta(methods, properties, signals, deprecated = interfaceDeprecated)
+    }
+
+    /**
+     * The `org.freedesktop.DBus.Property.EmitsChangedSignal` value these flags advertise, or `null`
+     * for the D-Bus default (`"true"`), which sd-bus leaves implicit.
+     *
+     * The cascade mirrors sd-bus's `introspect_write_flags` exactly, including its final `else`:
+     * anything that is neither const, nor invalidating, nor explicitly emitting is advertised as
+     * `"false"`. [Flags.set] makes the four behaviors mutually exclusive, so only clearing the
+     * default without selecting a replacement reaches that branch.
+     */
+    private fun Flags.emitsChangedSignalValue(): String? = when {
+        has(CONST_PROPERTY_VALUE) -> "const"
+        has(EMITS_INVALIDATION_SIGNAL) -> "invalidates"
+        has(EMITS_CHANGE_SIGNAL) -> null
+        else -> "false"
     }
 }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
@@ -4,12 +4,16 @@ package com.monkopedia.sdbus.integration
 // daemon unicast-routes the directed signal and the recipient sees the destination header (#137).
 internal actual val backendDeliversDirectedSignalsUnicast: Boolean = true
 
-// WireServe builds the introspection XML from WireServeRegistry, which captures the per-member
-// deprecated bit and no other vtable flag -- so nothing interface-level reaches the XML.
-internal actual val backendServesInterfaceLevelDeprecated: Boolean = false
+// WireServeRegistry captures the interface-level deprecated bit off InterfaceFlagsVTableItem and
+// WireServe writes it as a child of <interface>, matching what sd-bus emits for
+// SD_BUS_VTABLE_DEPRECATED on the vtable start item (#193 spike).
+internal actual val backendServesInterfaceLevelDeprecated: Boolean = true
 
-// Same reason: the wire backend records no property update behavior to advertise.
-internal actual val backendServesEmitsChangedSignal: Boolean = false
+// WireServeRegistry captures each property's PropertyUpdateBehaviorFlags and WireServe writes
+// const / invalidates / false; the D-Bus default ("true") is left implicit, as sd-bus does
+// (#193 spike).
+internal actual val backendServesEmitsChangedSignal: Boolean = true
 
-// Same reason: hasNoReply drives the reply-suppression path only, never the introspection XML.
+// Still false: hasNoReply drives the reply-suppression path only, never the introspection XML.
+// Out of scope for #193 -- the native half of this row was fixed separately in #216/#197.
 internal actual val backendServesMethodNoReply: Boolean = false


### PR DESCRIPTION
**⚠️ SPIKE — DO NOT MERGE. Refs #193.**

#193 asks the owner an unpriced question: *should the JVM backend serve interface-level `Deprecated`
and `EmitsChangedSignal` in its introspection so it matches native, or should the mapping be
documented as native-only and frozen?*

This branch does **not** answer it. It builds the "implement" option so the decision can be made
against measurements instead of imagination. **No reviewer is requested, and the decision remains
entirely open.**

The spike found something that changes the shape of the question, so read §3 before §2.

---

## 1. The price

| | |
| --- | --- |
| Production files touched | **1** — `src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt` |
| Production diff | **+57 / −13** (net +44; ~16 of the added lines are KDoc) |
| Test files touched | **1** — `src/jvmTest/.../TestBackendCapabilities.jvm.kt`, two `actual`s flipped `false → true` |
| **New tests written** | **0** — the instrument already exists (`VtableFlagIntrospectionTest`, #213) |
| Public API change | **none** — everything lives inside `internal object WireServe` / `internal object WireServeRegistry` |
| `apiCheck` | **green, does not move.** No diff in `api/*.api`; `api/sdbus-kotlin.klib.api` (consumed by `blue-falcon-sdbus`) is untouched |
| `ktlintCheck` | green |

### What the change does

`WireServeRegistry.buildMeta` read only `isDeprecated` off Method/Property/Signal items;
`InterfaceFlagsVTableItem` fell into `else -> Unit` and `PropertyVTableItem.flags` was never read at
all (#193's `grep` positive control: 0 hits for `PropertyUpdateBehaviorFlags`/`GeneralFlags` in
`src/jvmMain`, 8 in `src/nativeMain` — reproduced). This teaches `buildMeta` to capture both and
`WireServe.appendInterface` to emit them.

The `EmitsChangedSignal` cascade mirrors sd-bus's `introspect_write_flags` exactly, including that
the D-Bus default (`"true"`) is left **implicit** — verified two ways: read from systemd's
`bus-introspect.c`, and confirmed empirically with `busctl introspect org.freedesktop.systemd1`,
where 133 of 134 properties carry `const` or `false` and `value="true"` never appears once.

### CI result — measured, not asserted

Ran under `dbus-run-session` with `rm -rf build/test-results` first and counts taken from fresh
JUnit XML (`BUILD SUCCESSFUL` alone was not trusted):

| Run | Result |
| --- | --- |
| `:jvmTest` | **37 XML files, 331 tests, 0 failures, 0 errors, 0 skipped** |
| `:linuxX64Test` | **29 XML files, 301 tests, 0 failures, 0 errors, 0 skipped** |
| `ktlintCheck apiCheck` | exit 0, no `api/*.api` diff |

**Both directions of the capability flag were verified**, per the pattern #216 established:

- **Unflipped (impl in, `actual`s left at `false`) → RED**, as required. `VtableFlagIntrospectionTest[jvm]`
  ran 4 tests, **2 failed**:
  - `deprecatedOnTheInterfaceIsServedOnlyWhereTheBackendCarriesIt[jvm]` —
    `AssertionError: org.freedesktop.DBus.Deprecated="true" on <interface name="com.monkopedia.sdbus.flags.DeprecatedInterface"> should be absent by this backend … expected:<false> but was:<true>`
  - `emitsChangedSignalIsServedOnlyWhereTheBackendCarriesIt[jvm]` —
    `AssertionError: org.freedesktop.DBus.Property.EmitsChangedSignal="const" on <property name="ConstProperty"> should be absent by this backend … expected:<false> but was:<true>`
- **Flipped → GREEN**, both backends, full suites, numbers above.

So the harness genuinely measures this; the flip is not decorative.

*Provenance note, so the numbers are not overclaimed:* the green run above was measured on a tree
whose `buildMeta` still carried a trailing `else -> Unit`. Once `InterfaceFlagsVTableItem` is
handled, that branch is unreachable — the Kotlin compiler said so itself
(`'when' is exhaustive so 'else' is redundant here`) — and it was deleted afterwards. That deletion
is the only delta between the measured tree and the pushed one, and the compiler had already proven
it to be a no-op.

`Method.NoReply` on JVM was **deliberately left `false`** — it is not part of #193's remaining
question (its native half was #197/#216) and it would need a `noReply` field threaded through
`MethodMeta`. It did **not** fall out of this work for free.

---

## 2. The case FOR taking this

- **The audience is external introspectors, which is exactly who #159 was filed for.** `busctl`,
  d-feet, another language's bindings. Today the *same generated adaptor*, from the *same XML*,
  advertises a different contract depending on which artifact it was built against. That is a
  cross-backend divergence in the one surface `docs/BACKENDS.md` otherwise claims parity on.
- **The generator really does emit these flags for real interfaces**, so this is not a synthetic
  gap: `codegen/src/test/resources/MediaPlayer2/adaptor.1.kt` carries `+EMITS_NO_SIGNAL` on genuine
  MPRIS properties, and `AdaptorGenerator.kt:278-281` maps `invalidates`/`const`/`false` straight
  from introspection XML. A JVM-hosted MPRIS or BlueZ adaptor silently drops what its source XML
  said.
- **The XML → adaptor → `Introspect` → XML round-trip is lossless on native and lossy on JVM.**
  Anything that regenerates bindings from a live service (including our own `:codegen`) gets
  different Kotlin depending on the host backend.
- **The price is small and the acceptance test already existed.** One production file, no API
  change, no new test infrastructure.
- **Interface-level `Deprecated` is a clean, risk-free row on its own.** It has no behavioural half
  on *either* backend — it is purely metadata, advisory to a human or a doc generator, and nothing
  in sd-bus or in our code acts on it. Implementing just that row is parity with zero downstream
  behavioural consequence. (This matters; see below.)

---

## 3. The case AGAINST taking this — including what building it turned up

### 3a. The strongest one: this closes the *smaller* half of the gap, and would make the larger half harder to see

`EmitsChangedSignal` is not decoration. It is an instruction **to the client** about how to keep a
cached property fresh:

- `const` → a well-behaved client may read once and cache forever.
- `invalidates` → the client must expect `PropertiesChanged` to carry the property **name only**,
  and re-`Get` it.
- `false` → the client should not subscribe at all.

**Native honours all three at emission time.** `ConnectionImpl.emitPropertiesChangedSignal`
(`ConnectionImpl.kt:616-631`) delegates to `sd_bus_emit_properties_changed_strv`, which in systemd's
`bus-objects.c` skips properties lacking `SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE`
(`if (!(v->flags & SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE)) continue;`) and routes
`EMITS_INVALIDATION` ones into the name-only `invalidated_properties` array.

**The JVM backend does none of that.** `WireDbusObject.emitPropertiesChangedSignal`
(`WireDbusObject.kt:253`) builds its payload from `resolveChangedProperties`, which splits
changed-vs-invalidated by **readability** — readable → `changed_properties` *with the value*,
write-only → `invalidated_properties` — and never looks at `PropertyVTableItem.flags` at all.

So merging this patch as scoped would make a JVM adaptor:

- advertise `EmitsChangedSignal="false"` on a property and then broadcast that property's new value
  in `PropertiesChanged` anyway;
- advertise `"const"` on a property whose changes it will happily broadcast;
- advertise `"invalidates"` and then send the full value rather than the bare name.

**Today the adaptor says nothing and therefore promises nothing.** After this patch it makes a
promise its own emitter breaks. A backend that is silent about a contract is a documentation gap; a
backend that states a contract it violates is a correctness bug, and a nastier one, because the
introspection now stands as evidence *against* what the client actually observes.

That is a real argument to decline this patch **as scoped**. The honest "implement" option is
introspection **plus** the emitter, and this branch prices only the first half.

*(Provenance: the sd-bus half of that comparison is read from systemd source, not executed here. The
sdbus-kotlin half is read from our own code. Neither is a live A/B of `PropertiesChanged` payloads
across backends — that experiment was not run.)*

### 3b. It changes what a released 1.0.1 artifact advertises

1.0.1 is live on Maven Central. Introspection XML is a *consumed* artifact. After this change, JVM
services that have been shipping since 0.5.0 start advertising `const` and `false` on properties
that previously carried no annotation — and a correct client is entitled to change its behaviour in
response (stop polling, stop subscribing, cache indefinitely). That is a consumer-visible
behavioural change, delivered with no opt-in, to code whose only change was a version bump.
Combined with 3a, the clients most likely to act on the new annotation are exactly the ones most
likely to be burned by it.

### 3c. It duplicates a third party's formatting rules with no contract behind them

That `value="true"` is implicit, and that the final `else` is `"false"`, are reverse-engineered from
systemd's `introspect_write_flags`. That is not a stability promise. After this we maintain a second,
independent implementation of sd-bus's introspection writer, and any upstream change silently
reopens the divergence. Only `VtableFlagIntrospectionTest`'s three pinned values would catch it, and
only for those three.

### 3d. Nobody has reported being misled, and "freeze" is nearly free

#159 and #193 were both filed by audit passes, not by a consumer. Meanwhile `docs/BACKENDS.md:45`
*already* carries the exact asymmetry row, so the "document and freeze" branch costs an edit to a
line that exists. **That line is in fact stale right now** — it still says `Method.NoReply` is
"served by **neither**", which #216 (`26e6301`, this afternoon) changed for native. So a doc pass is
owed regardless of which way #193 goes; noting it here rather than folding it into this spike.

### 3e. It does not actually deliver "the JVM matches native"

`Method.NoReply` stays `false` on JVM. The capability table goes from 3 divergent rows to 1, not to
0. If the goal is "one artifact, one advertised contract", this branch is not that, and the
remaining row would need its own change.

---

## 4. What I could not settle

- **Whether the emitter half (3a) is itself parity-safe.** Making JVM's `PropertiesChanged` honour
  the flags would change *observable signal traffic* for existing JVM services, not just their
  self-description. That is a strictly larger and riskier change than this one and it was not
  attempted, prototyped, or priced here.
- **Whether any real downstream sets these flags on a JVM-hosted object.** The generator emits them
  for real XML (MPRIS proven), but I did not survey `blue-falcon-sdbus` or any other consumer for
  adaptors actually served from the JVM backend. So 3b's blast radius is argued, not measured.
- **`cross_test` / `stress_test` were not run.** Only `:jvmTest` and `:linuxX64Test`. The one other
  place that asserts served introspection — `cross_test/.../WireServeExternalTest.kt:196-198` —
  checks by substring containment, so it *should* be unaffected, but that is inference, not a run.
- **Interface-level property flags.** `interfaceFlags { +CONST_PROPERTY_VALUE }` is expressible in
  our API. sd-bus does **not** inherit start-item flags into member introspection (read from
  `bus-introspect.c`; the START item writes only `Deprecated`), and this branch matches that by
  ignoring them — but that was settled by reading upstream source, **not** by a live probe, and no
  test pins it on either backend.
- **The 134th systemd property.** 103 `const` + 30 `false` = 133 of 134; I did not chase the
  remaining one. It does not affect the conclusion that `"true"` is never written.

---

## 5. Status

**The decision on #193 remains entirely open, and this PR must not be merged as-is.**

It exists to convert "how big is this?" into numbers. What it turned up is that the two options
#193 offers are not quite the two that exist:

- **"Document and freeze"** is *cheaper* than #193 implies — the `docs/BACKENDS.md` row is already
  written (and needs a correction anyway).
- **"Implement"** is *bigger* than #193 implies — the introspection half priced here is genuinely
  small, but shipping it alone converts a truthful silence into an unbacked promise (§3a), so the
  real implement option is introspection **+** the `PropertiesChanged` emitter, which was not priced.
- There is a **third option this spike surfaced**: implement *only* interface-level `Deprecated`
  (which has no behavioural half on either backend, so §3a does not apply to it) and freeze
  `EmitsChangedSignal` as native-only until the emitter question is settled separately. That would
  be roughly a third of this diff.

Whichever way it goes, the branch is disposable. Building it cost one worktree; it is not an
argument for merging it.
