### PR TITLE
docs: correct the Method.NoReply row in BACKENDS.md after #216

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -42,7 +42,7 @@ Every row below is pinned by tests on current `main`, not by intention:
 | Behavior when the bus is unreachable | ✅ throws `Error` | ✅ throws `Error` | JVM fixed in #81; the in-process stub backend is an explicit internal test opt-in only |
 | Event loop (`startEventLoop`/`stopEventLoop`) | no-op (always running) | required for dispatch; `createObject`/`createProxy` auto-start it | Same calling pattern works on both; `startEventLoop` is idempotent (#114), and each native connection gets its own loop thread (#128) |
 | Strict deserialization (signature mismatch rejected) | ✅ | ✅ | Same `System.Error.ENXIO` error |
-| Vtable-flag annotations in **served** `Introspect` XML | ⚠️ partial | ⚠️ partial | Member-level `Deprecated` served on both; interface-level `Deprecated` and `EmitsChangedSignal` (`const`/`invalidates`/`false`) **native only**; `org.freedesktop.DBus.Method.NoReply` served by **neither**. Affects what an adaptor *advertises*, not how it behaves — see #193 |
+| Vtable-flag annotations in **served** `Introspect` XML | ⚠️ partial | ⚠️ partial | Member-level `Deprecated` served on both; interface-level `Deprecated`, `EmitsChangedSignal` (`const`/`invalidates`/`false`) and `org.freedesktop.DBus.Method.NoReply` are **native only**. `Method.NoReply` was served by *neither* backend until #216 bound `SD_BUS_VTABLE_METHOD_NO_REPLY` on native. Affects what an adaptor *advertises*, not how it behaves — see #193 |
 
 ✅ = identical observable behavior, asserted on both backends.
 


### PR DESCRIPTION
`docs/BACKENDS.md:45` still said `org.freedesktop.DBus.Method.NoReply` was served by **neither** backend. #216 (`26e6301`, merged this afternoon) bound `SD_BUS_VTABLE_METHOD_NO_REPLY` — it had been mapped onto `0u`, a no-op — so **native serves it now**. JVM still does not.

The row now reads `Method.NoReply` as native-only alongside interface-level `Deprecated` and `EmitsChangedSignal`, and records that it was neither-until-#216 rather than silently rewriting history — the previous state is what #193 was filed against.

Doc-only. No code, no API surface, nothing to run locally.

## How this was missed

#216 moved a per-backend capability flag in `TestBackendCapabilities.native.kt` and updated `CHANGELOG.md`, but `BACKENDS.md` carries the same fact in prose and nothing links the two. The capability flags are machine-checked by #213's `VtableFlagIntrospectionTest`; this table is not, so it can drift without any test noticing. Worth a follow-up on whether the table should be generated from those flags — not attempted here.

Found while spiking #193 (see #220).