### PR TITLE
ci(arm): fail arm-runtime-tests when a --gtest_filter measures nothing

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -174,19 +174,65 @@ jobs:
           chmod +x "${TEST_BINARY}"
           dbus-run-session --version
 
+          # #219: this job is the only instrument pointed at the published linuxArm64
+          # coordinate, and a `--gtest_filter` that matches nothing still exits 0 with
+          # "[  PASSED  ] 0 tests." — so if this package is ever renamed, no YAML changes and
+          # the suite silently becomes a no-op while the job stays green. Rather than commit a
+          # second magic number that drifts the same way the package name would, derive the
+          # expected counts from the binary itself: `--gtest_list_tests` ignores
+          # `--gtest_filter` and always prints every test as an indented line beneath its
+          # unindented class line.
+          ARM_INTEGRATION_PACKAGE="com.monkopedia.sdbus.integration."
+          "${TEST_BINARY}" --gtest_list_tests > arm-all-tests.txt
+          TOTAL_TESTS="$(awk '/^[ ]/ { n++ } END { print n + 0 }' arm-all-tests.txt)"
+          EXPECTED_INTEGRATION="$(awk -v pkg="${ARM_INTEGRATION_PACKAGE}" '
+            /^[^ ]/ { cls = $0; next }
+            /^[ ]/ && index(cls, pkg) == 1 { n++ }
+            END { print n + 0 }
+          ' arm-all-tests.txt)"
+          EXPECTED_NON_INTEGRATION=$((TOTAL_TESTS - EXPECTED_INTEGRATION))
+          if [ "${EXPECTED_INTEGRATION}" -eq 0 ] || [ "${EXPECTED_NON_INTEGRATION}" -eq 0 ]; then
+            echo "TEST-COUNT GUARD FAILED (#219): the binary lists ${TOTAL_TESTS} tests, of which"
+            echo "${EXPECTED_INTEGRATION} are under '${ARM_INTEGRATION_PACKAGE}' and ${EXPECTED_NON_INTEGRATION} are not."
+            echo "Both filters below would therefore measure nothing on one side while still exiting 0."
+            echo "If that package moved, update ARM_INTEGRATION_PACKAGE in this workflow to match."
+            exit 1
+          fi
+          echo "Expecting ${EXPECTED_INTEGRATION} integration and ${EXPECTED_NON_INTEGRATION} non-integration tests (${TOTAL_TESTS} listed)."
+
+          # Fails the step unless the runner's own summary reports exactly the count derived
+          # above. Deliberately parsed with `sed -n ...p` rather than `grep`: a grep that
+          # matches nothing exits 1 under `pipefail`, which would fail the job with a
+          # misleading message instead of this one.
+          assert_tests_ran() {
+            local label="$1" expected="$2" log="$3" ran
+            ran="$(sed -n 's/^\[=*\] \([0-9][0-9]*\) tests from [0-9][0-9]* test cases ran\..*$/\1/p' "${log}" | tail -n 1)"
+            if [ -z "${ran}" ]; then
+              echo "TEST-COUNT GUARD FAILED (#219): ${label}: the runner printed no 'N tests from M test cases ran.' summary, so there is no evidence it measured anything."
+              exit 1
+            fi
+            if [ "${ran}" -ne "${expected}" ]; then
+              echo "TEST-COUNT GUARD FAILED (#219): ${label}: ${ran} tests ran, expected ${expected} (derived from --gtest_list_tests)."
+              exit 1
+            fi
+            echo "Test-count guard OK (#219): ${label}: ${ran} tests ran."
+          }
+
           echo "Running non-integration suites directly on ARM"
-          "${TEST_BINARY}" '--gtest_filter=*-com.monkopedia.sdbus.integration.*'
+          "${TEST_BINARY}" "--gtest_filter=*-${ARM_INTEGRATION_PACKAGE}*" | tee arm-non-integration.log
+          assert_tests_ran "non-integration suites" "${EXPECTED_NON_INTEGRATION}" arm-non-integration.log
 
           echo "Running integration suites on ARM inside dbus-run-session"
           export TEST_BINARY
-          export ARM_INTEGRATION_FILTER="com.monkopedia.sdbus.integration.*"
+          export ARM_INTEGRATION_FILTER="${ARM_INTEGRATION_PACKAGE}*"
           dbus-run-session -- bash -lc '
             set -euo pipefail
             export DBUS_STARTER_BUS_TYPE=session
             export DBUS_STARTER_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
             export DBUS_SYSTEM_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}"
             "${TEST_BINARY}" "--gtest_filter=${ARM_INTEGRATION_FILTER}"
-          '
+          ' | tee arm-integration.log
+          assert_tests_ran "integration suites" "${EXPECTED_INTEGRATION}" arm-integration.log
 
       - name: Upload Failure Reports
         if: failure()


### PR DESCRIPTION
Fixes #219

## What was wrong

`arm-runtime-tests` is the only instrument pointed at the published `com.monkopedia:sdbus-kotlin-linuxarm64` coordinate, and it drives the cross-built binary through two hardcoded `--gtest_filter` expressions. A filter that matches zero tests exits **0**:

```
$ ./build/bin/linuxX64/debugTest/test.kexe '--gtest_filter=com.monkopedia.sdbus.doesnotexist.*'
[==========] 0 tests from 0 test cases ran. (0 ms total)
[  PASSED  ] 0 tests.        # exit 0
```

The package name lived in this YAML, decoupled from the source it names — a package rename touches no workflow file and would drop ARM integration coverage to zero silently.

**This is latent, not live.** The filter matches today; the job is demonstrably executing (it has gone red more than any other job here). The defect is that nothing would tell us if it stopped.

## The fix

Derive the expected counts from the binary rather than committing a second magic number that would drift exactly like the package name did. `--gtest_list_tests` ignores `--gtest_filter` and always prints every test (one indented line per test under its unindented class line), so the integration / non-integration split is computed from the single `ARM_INTEGRATION_PACKAGE` string that also builds both filters — the package name now appears **once** in the file instead of twice.

Two checks:

1. **Before running anything** — fail if either side of the split is empty. This is the rename detector; a `ran == expected` check alone would pass `0 == 0`.
2. **After each run** — fail if the runner's own `N tests from M test cases ran.` summary reports fewer than derived. This catches shrinkage as well as collapse, and it is applied to **both** invocations (the exclusion-form one is nearly free).

Parsing uses `sed -n ...p` rather than `grep`, deliberately: under `pipefail` a `grep` that matches nothing exits 1 and would fail the job with the wrong message. Every failure message names the check that failed and #219.

## Verified in both directions

The guard is only worth having if it fires, so the step's `run:` script was extracted from the YAML (`yaml.safe_load`) with only the `find` path retargeted from `linuxArm64` to `linuxX64`, and executed against the local `test.kexe`. Nothing else was edited.

**RED — the #219 scenario (package renamed out from under the filter):**

```
$ ARM_INTEGRATION_PACKAGE="com.monkopedia.sdbus.renamed."
TEST-COUNT GUARD FAILED (#219): the binary lists 298 tests, of which
0 are under 'com.monkopedia.sdbus.renamed.' and 298 are not.
Both filters below would therefore measure nothing on one side while still exiting 0.
If that package moved, update ARM_INTEGRATION_PACKAGE in this workflow to match.
EXIT=1
```

**RED — shrinkage (filter still valid, but selects one class fewer):**

```
Expecting 172 integration and 126 non-integration tests (298 listed).
[==========] 102 tests from 9 test cases ran. (168 ms total)
TEST-COUNT GUARD FAILED (#219): non-integration suites: 102 tests ran, expected 126 (derived from --gtest_list_tests).
EXIT=1
```

Note the runner itself printed `[  PASSED  ] 102 tests.` and exited 0 there — the guard is what turned it red.

**GREEN — unmodified script, real filters:**

```
Expecting 172 integration and 126 non-integration tests (298 listed).
Running non-integration suites directly on ARM
[==========] 126 tests from 10 test cases ran. (172 ms total)
Test-count guard OK (#219): non-integration suites: 126 tests ran.
Running integration suites on ARM inside dbus-run-session
[==========] 172 tests from 20 test cases ran. (36725 ms total)
Test-count guard OK (#219): integration suites: 172 tests ran.
EXIT=0
```

Derived counts matched actual runs exactly on both invocations, so the assertion is equality rather than a soft floor.

## Nothing else regressed

- Binary-absent hard-fail (`exit 1` + `find` listing) — re-checked, still `EXIT=1`.
- `dbus-run-session` wrapping with starter/system addresses pointed at the session bus — unchanged.
- Failure-report upload on failure — unchanged.
- A genuinely failing test still fails the step through the new `| tee` pipeline: exercised with a stub binary that prints a well-formed full-count summary and exits 1, and the step died at the run (`EXIT=1`) before the guard could report OK.

Scope is `.github/workflows/arm-build-test.yaml` only; no action-version or SHA-pinning work (#198) is included.
