### PR TITLE
docs: make AGENTS.md's verification command actually run the library tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,65 @@
 # Repository Guidelines
 
+`CLAUDE.md` is the authority on build, verification, and release mechanics. This file is the
+contributor-facing summary; where the two disagree, `CLAUDE.md` wins and this file should be fixed.
+
 ## Project Structure & Module Organization
-This repository is a Kotlin Multiplatform project focused on native D-Bus support.
+This repository is a Kotlin Multiplatform D-Bus client targeting **jvm + linuxX64 + linuxArm64**.
+The native targets wrap `sd-bus` via cinterop; the JVM target is a pure-Kotlin implementation over
+an owned junixsocket connection (since 0.5.0 — no dbus-java, no native code).
 
 - `src/commonMain/kotlin`: shared API and serialization logic.
+- `src/commonTest/kotlin`: cross-backend tests — these run on *both* backends, so this is where
+  parity coverage belongs (see `docs/BACKENDS.md`).
+- `src/jvmMain/kotlin`: JVM backend (wire protocol, marshaller, dispatcher).
 - `src/nativeMain/kotlin` + `src/nativeInterop/cinterop`: Linux native implementation and C interop.
-- `src/nativeTest/kotlin/{unit,integration,mocks}`: native tests and test fixtures.
+- `src/jvmTest/kotlin`, `src/nativeTest/kotlin/{unit,integration,mocks}`: backend-specific tests and
+  test fixtures.
 - `codegen/`: JVM CLI/library for XML-to-Kotlin code generation.
 - `plugin/`: Gradle plugin (`com.monkopedia.sdbus.plugin`) built on top of `:codegen`.
 - `compile_test/`: compile-time integration module for dependency wiring.
-- `samples/bluez-scan/`: example consumer project.
+- `cross_test/`: cross-runtime interop suites (a client on one backend against a peer on the other,
+  plus `python3-dbusmock` peers).
+- `stress_test/`: long-running interop stress suites.
+- `samples/bluez-scan/`, `samples/demo-service/`: example consumer projects.
 
 ## Build, Test, and Development Commands
-Use the Gradle wrapper from repo root:
+Use the Gradle wrapper from repo root. **JDK 17+ required** (Gradle 9); the system default is often
+Java 8 and will fail — set `JAVA_HOME=/usr/lib/jvm/java-17-openjdk` (or java-21).
 
-- `./gradlew build`: full build across modules.
-- `./gradlew test`: run JVM/native tests configured in the project.
-- `./gradlew ktlintCheck`: run Kotlin style checks.
-- `./gradlew licenseCheck`: validate license headers and required checks.
-- `./gradlew dokkaHtml`: generate docs into `build/dokka`.
+Needs no D-Bus session bus:
+
+- `./gradlew compileKotlinJvm compileKotlinLinuxX64 compileKotlinLinuxArm64`: compile all targets.
+- `./gradlew ktlintCheck apiCheck`: the static gates CI runs. `apiCheck` is binary-compatibility
+  validator; if you intentionally change public API, regenerate with `./gradlew apiDump` and commit
+  the `api/*.api` diff.
 - `./gradlew codegen:fatJar`: build the standalone codegen JAR used in releases.
+- `./gradlew :dokkaGeneratePublicationHtml`: generate docs into `build/dokka` (this is what
+  `pages.yaml` runs; the older `dokkaHtml` task still exists but is not what CI publishes).
 
-CI release/docs workflows run `gradle publish codegen:fatJar` and `gradle dokkaHtml` on Ubuntu.
+Needs a D-Bus session bus — run under `dbus-run-session`:
+
+- `dbus-run-session -- ./gradlew allTests test`: the library's actual test suite. This is what CI
+  runs (`arm-build-test.yaml` adds `crossRuntimeInteropTests`). Both task names are needed:
+  `allTests` covers the Kotlin Multiplatform modules, `test` covers the plain-JVM `:codegen` and
+  `:plugin`.
+- `dbus-run-session -- ./gradlew build`: full build across modules, tests included.
+- `dbus-run-session -- ./gradlew licenseCheckForKotlin`: validate license headers. It deliberately
+  depends on the compile/link/test tasks, so it pulls the bus-requiring suites in with it.
+  (`licenseCheck` also works, but only by Gradle's abbreviation matching.)
+
+**⚠️ Do not verify with bare `./gradlew test`.** There is no `test` task on the root project, so the
+name resolves only in the two plain-JVM subprojects: the whole graph is `:codegen:test` and
+`:plugin:test`. Both are pure JVM and need no bus, so the command goes **green on a machine with no
+session bus while running none of the marshaller, wire-backend, sd-bus interop, or parity suites**.
+Confirm any test command with `--dry-run` before trusting it.
+
+The real suites fail loudly rather than silently when the bus is missing — measured on `main` with
+`DBUS_SESSION_BUS_ADDRESS` unset, `:jvmTest` failed 135 of 331 tests and `:linuxX64Test` failed 180
+of 301. A green run of those tasks is therefore real evidence; a green bare `./gradlew test` is not.
+
+The `samples/bluez-scan` and blue-falcon-sdbus integration suites need a real BlueZ adapter and a
+BLE peripheral, so they cannot run in CI.
 
 ## Coding Style & Naming Conventions
 - Follow `.editorconfig`: 4-space indentation, LF endings, max line length 100.
@@ -30,16 +68,26 @@ CI release/docs workflows run `gradle publish codegen:fatJar` and `gradle dokkaH
 - Keep public API changes intentional; this repo uses Kotlin binary compatibility validation (`apiValidation`).
 
 ## Testing Guidelines
-- Place tests alongside module scope (`src/nativeTest`, `codegen/src/test/kotlin`, `plugin` tests).
+- Place tests alongside module scope. Prefer `src/commonTest` for anything both backends must
+  satisfy — that is the mechanism that makes backend parity structural rather than aspirational.
+  Use `src/jvmTest` / `src/nativeTest` only for genuinely backend-specific behaviour, and
+  `codegen/src/test/kotlin` / `plugin/src/test/kotlin` for the JVM tooling.
 - Prefer descriptive test names that reflect behavior, e.g. `createsProxyFromXml`.
-- Run `./gradlew test` before PRs; include integration coverage when touching transport/interop paths.
+- Run `dbus-run-session -- ./gradlew allTests test` before PRs; include integration coverage when
+  touching transport/interop paths.
+- A test that cannot run its subject must say so. Skipping when a prerequisite is absent is fine;
+  passing when it is absent is not — a suite that reports green without having exercised anything is
+  worse than one that fails.
 - If a native test flake appears, stop feature work immediately and investigate first (reproduce, isolate, and identify the introducing change) before continuing.
 - TODO: add deterministic coverage for native `createCleaner` auto-release paths (without explicit `release()`), likely via a dedicated native test harness that can force/synchronize cleanup and assert expected unref/close side effects.
 
 ## Commit & Pull Request Guidelines
-- Keep commit messages short, imperative, and scoped (history examples: `Update dependencies`, `Bump patch`, `Minor cleanup`).
+- Use Conventional Commits, scoped where it helps: `fix(native): …`, `feat(codegen): …`,
+  `test(cross): …`, `docs: …`. Keep the subject short and imperative.
 - PRs should include:
   - purpose and module(s) changed,
   - linked issue/release context,
-  - test evidence (`./gradlew test ./gradlew ktlintCheck` results),
+  - test evidence — name the command you actually ran (e.g.
+    `dbus-run-session -- ./gradlew allTests test`, `./gradlew ktlintCheck apiCheck`) rather than
+    just asserting tests pass,
   - API impact notes for public-facing changes.


### PR DESCRIPTION
Doc-only. `AGENTS.md` told contributors to verify with `./gradlew test`. That command runs none of the library's tests and passes with no D-Bus session bus running, so a contributor who follows the documented instruction sees green and reasonably concludes the suite passed.

## What `./gradlew test` actually resolves to

There is no `test` task on the root project, so Gradle resolves the name only in the two plain-JVM subprojects. Verbatim, on `26e6301` with JDK 21:

```
$ ./gradlew --console=plain test --dry-run
:codegen:checkKotlinGradlePluginConfigurationErrors SKIPPED
:codegen:compileKotlin SKIPPED
:codegen:compileJava SKIPPED
:codegen:processResources SKIPPED
:codegen:classes SKIPPED
:codegen:jar SKIPPED
:kmpPartiallyResolvedDependenciesChecker SKIPPED
:checkKotlinGradlePluginConfigurationErrors SKIPPED
:compileKotlinJvm SKIPPED
:compileJvmMainJava SKIPPED
:jvmProcessResources SKIPPED
:processJvmMainResources SKIPPED
:jvmMainClasses SKIPPED
:jvmJar SKIPPED
:codegen:compileTestKotlin SKIPPED
:codegen:compileTestJava SKIPPED
:codegen:processTestResources SKIPPED
:codegen:testClasses SKIPPED
:codegen:test SKIPPED
:plugin:checkKotlinGradlePluginConfigurationErrors SKIPPED
:plugin:compileKotlin SKIPPED
:plugin:compileJava SKIPPED
:plugin:pluginDescriptors SKIPPED
:plugin:processResources SKIPPED
:plugin:classes SKIPPED
:plugin:jar SKIPPED
:plugin:compileTestKotlin SKIPPED
:plugin:compileTestJava SKIPPED
:plugin:pluginUnderTestMetadata SKIPPED
:plugin:processTestResources SKIPPED
:plugin:testClasses SKIPPED
:plugin:test SKIPPED

BUILD SUCCESSFUL in 774ms
```

32 tasks, exactly two of them test tasks — `:codegen:test` and `:plugin:test`, both pure JVM. This reproduces the issue's finding exactly.

Negative control that `--dry-run` really does fail on a name that does not exist, so the above is not silent name-matching:

```
$ ./gradlew licenseCheckXYZ --dry-run
FAILURE: Build failed with an exception.
  Task 'licenseCheckXYZ' not found in root project 'sdbus-kotlin' and its subprojects.
```

Positive control that the real suites exist and are simply absent from that graph — `allTests` is 71 tasks and contains:

```
:jvmTest SKIPPED
:linuxX64Test SKIPPED
:allTests SKIPPED
:compile_test:linuxX64Test SKIPPED
:compile_test:allTests SKIPPED
:cross_test:jvmTest SKIPPED
:cross_test:linuxX64Test SKIPPED
:cross_test:allTests SKIPPED
:stress_test:jvmTest SKIPPED
:stress_test:allTests SKIPPED
```

Note `allTests` does **not** include `:codegen:test` / `:plugin:test` — those are plain-JVM projects with no KMP `allTests` task. That is why `arm-build-test.yaml:81` runs `allTests test crossRuntimeInteropTests` rather than either name alone, and why the doc now says both.

## Bus-less behaviour, measured rather than assumed

Run under the shared build slot with `DBUS_SESSION_BUS_ADDRESS` unset (and `XDG_RUNTIME_DIR` also unset for the native run, so sd-bus cannot fall back to `$XDG_RUNTIME_DIR/bus`). Every number below is from live console output of a run started in that payload — no `build/test-results` was read, and each payload deleted `test-results` across every module first via `find . -type d -name test-results -prune -exec rm -rf {} +`.

| command | bus | result |
| --- | --- | --- |
| `./gradlew test` | none | **BUILD SUCCESSFUL** |
| `./gradlew :jvmTest` | none | BUILD FAILED — 135 of 331 failed |
| `./gradlew :linuxX64Test` | none | BUILD FAILED — 180 of 301 failed |
| `./gradlew :jvmTest :linuxX64Test` | `dbus-run-session` | BUILD SUCCESSFUL |

So the library's real suites already fail loudly without a bus — the quiet instrument was only the documented command, which is why this stays a doc fix. `:jvmTest`'s failure is well-formed too: `DBusWireConnection.kt:589` throws `IOException("DBUS_SESSION_BUS_ADDRESS is not set")`.

## The change

- Replaced `./gradlew test` with `dbus-run-session -- ./gradlew allTests test` in both places it appeared, and split the command list into what needs a bus and what does not, rather than blanket-prefixing everything with `dbus-run-session`. Compiles, `ktlintCheck`/`apiCheck`, `codegen:fatJar` and dokka genuinely do not need one.
- Added an explicit warning about bare `./gradlew test`, naming what it resolves to and why it is quiet, so the next reader does not have to rediscover it.
- Stated that `CLAUDE.md` is the authority and this file the summary, so the two have a precedence instead of silently disagreeing.

Folded in the adjacent staleness the same audit found in this file (all re-verified here, not taken on faith):

- The structure section predated the 0.5.0 JVM backend. Added `src/jvmMain`, `src/jvmTest`, `src/commonTest`, `cross_test/`, `stress_test/`, `samples/demo-service/`.
- The testing section omitted `src/commonTest`, which is where cross-backend parity coverage belongs (`docs/BACKENDS.md:12-13`: "parity by construction"). Not editing `docs/BACKENDS.md` — PR #221 is open against it — only linking to it.
- `dokkaHtml` → `:dokkaGeneratePublicationHtml`, which is what `pages.yaml:35` runs. The old task still exists (`dokkaHtml --dry-run` succeeds); it is just not the published one, and the doc now says so.
- `licenseCheck` → `licenseCheckForKotlin`. The short form works only via Gradle abbreviation matching, and the task's `dependsOn` block (`build.gradle.kts:331-344`) pulls in everything ending in `Test`/`Tests`/`test`, so it needs a bus too — worth knowing before running it.
- Commit guidance recommended `Update dependencies` / `Bump patch`; the last ~30 commits are Conventional Commits.

Also added one line to the testing section: skipping when a prerequisite is absent is fine, passing when it is absent is not. That is the general form of this bug, and it matches what `c5f874c` already did for the dbusmock harness.

## Follow-up not bundled here

A build-level guard would make this loud instead of only documented — e.g. registering a root `test` task that fails with a message pointing at `allTests`. That is a build change rather than a doc change, so it is filed separately as #225 rather than folded in.

## Verification

Per the issue's stated check, re-running `./gradlew test --dry-run` still yields the two-task graph — the fix is that no document now points at it. The command the doc now recommends was run for real and is green (row 4 above).

Fixes #192
