### PR TITLE
test(jvm): fail when a required bus is absent, and skip honestly when an optional peer is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,10 @@ session bus while running none of the marshaller, wire-backend, sd-bus interop, 
 Confirm any test command with `--dry-run` before trusting it.
 
 The real suites fail loudly rather than silently when the bus is missing — measured on `main` with
-`DBUS_SESSION_BUS_ADDRESS` unset, `:jvmTest` failed 135 of 331 tests and `:linuxX64Test` failed 180
+`DBUS_SESSION_BUS_ADDRESS` unset, `:jvmTest` failed 150 of 331 tests and `:linuxX64Test` failed 180
 of 301. A green run of those tasks is therefore real evidence; a green bare `./gradlew test` is not.
+(`:jvmTest` was 135 of 331 before #227 removed the suites that returned early — and so reported a
+pass — instead of failing when they could not reach a bus.)
 
 The `samples/bluez-scan` and blue-falcon-sdbus integration suites need a real BlueZ adapter and a
 BLE peripheral, so they cannot run in CI.

--- a/COVERAGE_TODO.md
+++ b/COVERAGE_TODO.md
@@ -19,8 +19,8 @@ This backlog is intentionally ordered by priority and should be worked top-to-bo
   - [x] Added JVM session-bus coverage for distinct real connections and connection-level ObjectManager signal routing (`JvmRealBusIntegrationTest`).
   - [x] Added JVM session-bus coverage for `GetManagedObjects` returning child interface/property data (`JvmRealBusIntegrationTest`).
   - [x] Added JVM session-bus coverage for signal callback sender credential resolution (`JvmRealBusIntegrationTest`).
-  - [x] Added JVM system-bus coverage for distinct real connections (`createSystemBusConnection`) with graceful skip when unavailable (`JvmRealBusIntegrationTest`).
-  - [x] Added JVM system-bus ObjectManager `GetManagedObjects` coverage using unique-name routing with graceful skip when unavailable (`JvmRealBusIntegrationTest`).
+  - [x] Added JVM system-bus coverage for distinct real connections (`createSystemBusConnection`), failing when the bus is unavailable (#227) (`JvmRealBusIntegrationTest`).
+  - [x] Added JVM system-bus ObjectManager `GetManagedObjects` coverage using unique-name routing, failing when the bus is unavailable (#227) (`JvmRealBusIntegrationTest`).
 - Done when:
   - [x] `:jvmTest` is green,
   - [x] `:cross_test:jvmTest` is green,

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireServeExternalTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireServeExternalTest.kt
@@ -37,6 +37,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 
 /**
  * Proves an object exported by a JVM sdbus-kotlin service on the OWNED wire backend is reachable by
@@ -51,20 +52,25 @@ import kotlinx.coroutines.runBlocking
  *    busctl gets correct results.
  *
  * The owned wire connection is now the only JVM backend (epic #93 phase 6 retired dbus-java), so
- * this always runs. Skips cleanly when no session bus or no `busctl` is available.
+ * this always runs. `busctl` is genuinely optional, so its absence is a real skip; a missing
+ * session bus is not — every job that runs this wraps the build in `dbus-run-session` — so that
+ * FAILS. Neither is an early return, which JUnit records as a pass (issue #227).
  */
 class WireServeExternalTest {
 
     @Test
     fun externalBusctl_reachesServedObject() = runBlocking {
-        val sessionBus = System.getenv("DBUS_SESSION_BUS_ADDRESS")
-        if (sessionBus == null) {
-            println("[WireServeExternalTest] SKIP: no DBUS_SESSION_BUS_ADDRESS.")
-            return@runBlocking
+        val sessionBus = checkNotNull(System.getenv("DBUS_SESSION_BUS_ADDRESS")) {
+            "DBUS_SESSION_BUS_ADDRESS is unset: this test serves an object on the session bus " +
+                "and hands its address to busctl. Run the suite under " +
+                "`dbus-run-session -- ./gradlew …`."
         }
         val busctl = findExecutable("busctl")
         if (busctl == null) {
-            println("[WireServeExternalTest] SKIP: busctl not on PATH.")
+            assumeTrue(
+                "busctl is not on PATH, so no external peer can call the served object.",
+                false
+            )
             return@runBlocking
         }
 

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireSignalEmissionExternalTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireSignalEmissionExternalTest.kt
@@ -35,6 +35,7 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 
 /**
  * Proves that a signal our object emits actually traverses the BUS and reaches an INDEPENDENT
@@ -47,21 +48,26 @@ import kotlinx.coroutines.runBlocking
  *  - dbus-java backend: always emitted over the real wire, so it captures it too.
  *
  * JVM-only (cross_test `jvmTest`) because the owned-connection backend is JVM-only and toggle-gated;
- * the native backend's over-the-wire emission is already covered elsewhere. Skips cleanly when no
- * session bus or no `dbus-monitor` is available.
+ * the native backend's over-the-wire emission is already covered elsewhere. `dbus-monitor` is
+ * genuinely optional, so its absence is a real skip; a missing session bus is not — every job that
+ * runs this wraps the build in `dbus-run-session` — so that FAILS. Neither is an early return,
+ * which JUnit records as a pass (issue #227).
  */
 class WireSignalEmissionExternalTest {
 
     @Test
     fun emittedSignal_reachesExternalDbusMonitor() = runBlocking {
-        val sessionBus = System.getenv("DBUS_SESSION_BUS_ADDRESS")
-        if (sessionBus == null) {
-            println("[WireSignalEmissionExternalTest] SKIP: no DBUS_SESSION_BUS_ADDRESS.")
-            return@runBlocking
+        checkNotNull(System.getenv("DBUS_SESSION_BUS_ADDRESS")) {
+            "DBUS_SESSION_BUS_ADDRESS is unset: this test emits a signal onto the session bus " +
+                "and watches for it with dbus-monitor --session. Run the suite under " +
+                "`dbus-run-session -- ./gradlew …`."
         }
         val dbusMonitor = findExecutable("dbus-monitor")
         if (dbusMonitor == null) {
-            println("[WireSignalEmissionExternalTest] SKIP: dbus-monitor not on PATH.")
+            assumeTrue(
+                "dbus-monitor is not on PATH, so no external observer can see the signal.",
+                false
+            )
             return@runBlocking
         }
 

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCredentialsTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmCredentialsTest.kt
@@ -16,14 +16,12 @@ import kotlinx.coroutines.withTimeout
  * is host-dependent — a label where SELinux is enforcing, or a thrown [SdbusException] otherwise.
  * The native backend covers the same surface against the live POSIX identity in
  * CredentialsIntegrationTest.
+ *
+ * Needs a real session bus, and every job that runs it wraps the build in `dbus-run-session`, so an
+ * unreachable bus is a broken environment: the factory's throw is left to FAIL the test rather than
+ * swallowed into an early return that JUnit would record as a pass (issue #227).
  */
 class JvmCredentialsTest {
-
-    private fun connectOrNull(connect: () -> Connection): Connection? = try {
-        connect()
-    } catch (e: Exception) {
-        null
-    }
 
     @Test
     fun receivedSignalResolvesSupportedCredentialsAndRejectsUnsupported() = runBlocking {
@@ -37,12 +35,8 @@ class JvmCredentialsTest {
         val expectedUid = unix.uid.toUInt()
         val expectedGid = unix.gid.toUInt()
 
-        val serverConnection = connectOrNull { createSessionBusConnection(service) }
-            ?: return@runBlocking
-        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
-            serverConnection.release()
-            return@runBlocking
-        }
+        val serverConnection = createSessionBusConnection(service)
+        val proxyConnection = createSessionBusConnection()
 
         val pidSeen = CompletableDeferred<Int>()
         val uidSeen = CompletableDeferred<UInt>()

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmRealBusIntegrationTest.kt
@@ -7,17 +7,15 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
+/**
+ * These tests need a *real* bus, and every job that runs them wraps the build in
+ * `dbus-run-session` (exporting `DBUS_SYSTEM_BUS_ADDRESS` alongside the session one), so an
+ * unreachable bus here is a broken environment rather than a legitimate absence. The connection
+ * factories throw an [SdbusException] ("Failed to open bus", issue #81) and that is left to FAIL
+ * the test: the early return they used to be swallowed into was recorded by JUnit as a PASS for a
+ * case that connected to nothing (issue #227).
+ */
 class JvmRealBusIntegrationTest {
-
-    // These tests need a *real* bus. The connection factories throw when the bus is
-    // unreachable (issue #81) instead of silently returning the in-process stub backend, so
-    // "no usable bus in this environment" now surfaces as a thrown SdbusException -- treat it as a
-    // skip, the way the old ":jvm-stub" unique-name gate did.
-    private fun connectOrNull(connect: () -> Connection): Connection? = try {
-        connect()
-    } catch (e: SdbusException) {
-        null
-    }
 
     // Regression for the BlueZ-on-JVM failure, exercised over the real wire (same-process
     // calls short-circuit through local dispatch and never serialize, so they can't catch
@@ -29,7 +27,7 @@ class JvmRealBusIntegrationTest {
     // serializes as "as" and succeeds; without it the connection is torn down.
     @Test
     fun methodCall_withEmptyArrayArg_overWire_doesNotDropConnection() = runBlocking {
-        val connection = connectOrNull { createBusConnection() } ?: return@runBlocking
+        val connection = createBusConnection()
         val proxy = createProxy(
             connection,
             ServiceName("org.freedesktop.DBus"),
@@ -51,12 +49,9 @@ class JvmRealBusIntegrationTest {
     }
 
     @Test
-    fun createSystemBusConnection_usesDistinctConnectionsWhenRealBusIsAvailable() {
-        val first = connectOrNull { createSystemBusConnection() } ?: return
-        val second = connectOrNull { createSystemBusConnection() } ?: run {
-            first.release()
-            return
-        }
+    fun createSystemBusConnection_usesDistinctConnections() {
+        val first = createSystemBusConnection()
+        val second = createSystemBusConnection()
         try {
             assertNotEquals(first.uniqueName.value, second.uniqueName.value)
         } finally {
@@ -66,12 +61,9 @@ class JvmRealBusIntegrationTest {
     }
 
     @Test
-    fun createSessionBusConnection_usesDistinctConnectionsWhenRealBusIsAvailable() {
-        val first = connectOrNull { createSessionBusConnection() } ?: return
-        val second = connectOrNull { createSessionBusConnection() } ?: run {
-            first.release()
-            return
-        }
+    fun createSessionBusConnection_usesDistinctConnections() {
+        val first = createSessionBusConnection()
+        val second = createSessionBusConnection()
         try {
             assertNotEquals(first.uniqueName.value, second.uniqueName.value)
         } finally {
@@ -90,12 +82,8 @@ class JvmRealBusIntegrationTest {
         val objectManagerInterface = InterfaceName("org.freedesktop.DBus.ObjectManager")
         val interfacesAdded = SignalName("InterfacesAdded")
 
-        val serverConnection = connectOrNull { createSessionBusConnection(service) }
-            ?: return@runBlocking
-        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
-            serverConnection.release()
-            return@runBlocking
-        }
+        val serverConnection = createSessionBusConnection(service)
+        val proxyConnection = createSessionBusConnection()
 
         serverConnection.startEventLoop()
         proxyConnection.startEventLoop()
@@ -138,12 +126,8 @@ class JvmRealBusIntegrationTest {
         val valueProperty = PropertyName("value")
         var value = 17
 
-        val serverConnection = connectOrNull { createSessionBusConnection(service) }
-            ?: return@runBlocking
-        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
-            serverConnection.release()
-            return@runBlocking
-        }
+        val serverConnection = createSessionBusConnection(service)
+        val proxyConnection = createSessionBusConnection()
 
         serverConnection.startEventLoop()
         proxyConnection.startEventLoop()
@@ -188,12 +172,8 @@ class JvmRealBusIntegrationTest {
         val valueProperty = PropertyName("value")
         var value = 23
 
-        val serverConnection = connectOrNull { createSystemBusConnection() }
-            ?: return@runBlocking
-        val proxyConnection = connectOrNull { createSystemBusConnection() } ?: run {
-            serverConnection.release()
-            return@runBlocking
-        }
+        val serverConnection = createSystemBusConnection()
+        val proxyConnection = createSystemBusConnection()
         val serverUnique = serverConnection.uniqueName.value
 
         serverConnection.startEventLoop()
@@ -243,12 +223,8 @@ class JvmRealBusIntegrationTest {
         val signalName = SignalName("Changed")
         val expectedPid = ProcessHandle.current().pid().toInt()
 
-        val serverConnection = connectOrNull { createSessionBusConnection(service) }
-            ?: return@runBlocking
-        val proxyConnection = connectOrNull { createSessionBusConnection() } ?: run {
-            serverConnection.release()
-            return@runBlocking
-        }
+        val serverConnection = createSessionBusConnection(service)
+        val proxyConnection = createSessionBusConnection()
         val serverUnique = serverConnection.uniqueName.value
 
         val senderSeen = CompletableDeferred<String>()

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmUnixFdTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmUnixFdTest.kt
@@ -2,11 +2,18 @@ package com.monkopedia.sdbus
 
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
+import org.junit.Assume.assumeTrue
 
 class JvmUnixFdTest {
     @Test
     fun constructorFromFd_duplicatesDescriptorWhenSupported() {
-        if (!JvmUnixFdSupport.supportsFdDuplicationSemantics) return
+        // junixsocket's native support is genuinely optional (it ships binaries per platform), so
+        // record a real skip rather than an early return JUnit would report as a pass (#227).
+        assumeTrue(
+            "junixsocket's native fd support is unavailable on this platform, so descriptor " +
+                "duplication cannot be exercised.",
+            JvmUnixFdSupport.supportsFdDuplicationSemantics
+        )
 
         val first = UnixFd(0)
         val second = UnixFd(first.fd)

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnectionTest.kt
@@ -18,23 +18,19 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.junit.Assume.assumeTrue
 
 /**
  * End-to-end tests for the owned low-level D-Bus connection (epic #93, phase 2) against a real
- * session bus. When no bus is reachable the connection factory throws [IOException]; we treat that
- * as a skip so the suite stays green outside `dbus-run-session`.
+ * session bus. Every job that runs them wraps the build in `dbus-run-session`, so an unreachable
+ * bus is a broken environment: [DBusWireConnection.connectSession]'s [IOException] is left to FAIL
+ * the test rather than swallowed into an early return that JUnit records as a pass (issue #227).
  */
 class DBusWireConnectionTest {
 
-    private fun connectOrNull(): DBusWireConnection? = try {
-        DBusWireConnection.connectSession()
-    } catch (_: IOException) {
-        null
-    }
-
     @Test
     fun connect_completesSaslAndHello_assignsUniqueName() {
-        val connection = connectOrNull() ?: return
+        val connection = DBusWireConnection.connectSession()
         try {
             val unique = connection.uniqueName
             assertNotNull(unique, "Hello should assign a unique name")
@@ -50,7 +46,7 @@ class DBusWireConnectionTest {
 
     @Test
     fun call_listNames_parsesReplyContainingDbusDaemon() = runBlocking {
-        val connection = connectOrNull() ?: return@runBlocking
+        val connection = DBusWireConnection.connectSession()
         try {
             val reply = withTimeout(5_000) {
                 connection.call(
@@ -81,7 +77,7 @@ class DBusWireConnectionTest {
 
     @Test
     fun call_getId_returnsBusId() = runBlocking {
-        val connection = connectOrNull() ?: return@runBlocking
+        val connection = DBusWireConnection.connectSession()
         try {
             val reply = withTimeout(5_000) {
                 connection.call(
@@ -104,7 +100,7 @@ class DBusWireConnectionTest {
 
     @Test
     fun addMatch_thenRequestName_deliversNameOwnerChangedSignal() = runBlocking {
-        val connection = connectOrNull() ?: return@runBlocking
+        val connection = DBusWireConnection.connectSession()
         val busName = "com.monkopedia.sdbus.wire.test.s${System.nanoTime()}"
         val signalSeen = CompletableDeferred<WireMessage>()
         val subscription = connection.onSignal { message ->
@@ -142,23 +138,20 @@ class DBusWireConnectionTest {
      */
     @Test
     fun unixFd_roundTripsAcrossConnections_throughDaemon_asLiveDuplicate() = runBlocking {
-        if (!JvmUnixFdSupport.supportsFdDuplicationSemantics) return@runBlocking
-        val server = connectOrNull() ?: return@runBlocking
-        val client = connectOrNull() ?: run {
-            server.close()
-            return@runBlocking
-        }
-        if (!server.unixFdNegotiated || !client.unixFdNegotiated) {
-            client.close()
-            server.close()
-            return@runBlocking
-        }
-        val pipe = JvmUnixFdSupport.createPipePair() ?: run {
-            client.close()
-            server.close()
-            return@runBlocking
-        }
-        val (readFd, writeFd) = pipe
+        // junixsocket's native support is genuinely optional (it ships binaries per platform), so
+        // its absence is a real skip. Everything below it — a pipe, and fd negotiation with the
+        // daemon — must then hold, and is asserted rather than returned from (#227).
+        assumeTrue(
+            "junixsocket's native fd support is unavailable on this platform, so SCM_RIGHTS " +
+                "cannot be exercised.",
+            JvmUnixFdSupport.supportsFdDuplicationSemantics
+        )
+        val (readFd, writeFd) = assertNotNull(
+            JvmUnixFdSupport.createPipePair(),
+            "could not create a pipe pair despite junixsocket native support"
+        )
+        val server = DBusWireConnection.connectSession()
+        val client = DBusWireConnection.connectSession()
         val busName = "com.monkopedia.sdbus.wire.fdtest.s${System.nanoTime()}"
         val path = "/com/monkopedia/sdbus/wire/fdtest"
         val iface = "com.monkopedia.sdbus.wire.FdTest"
@@ -193,6 +186,10 @@ class DBusWireConnectionTest {
         }
 
         try {
+            assertTrue(
+                server.unixFdNegotiated && client.unixFdNegotiated,
+                "both connections must negotiate UNIX-fd passing with the daemon"
+            )
             assertEquals(1, server.requestName(busName), "server should own $busName")
             // Buffer the known bytes in the pipe before sending the read-end, so the server can
             // read them straight out of the received duplicate.
@@ -259,11 +256,8 @@ class DBusWireConnectionTest {
      */
     @Test
     fun nestedSameConnectionDispatch_underBoundedPool_completesWithoutDeadlock() = runBlocking {
-        val server = connectOrNull() ?: return@runBlocking
-        val client = connectOrNull() ?: run {
-            server.close()
-            return@runBlocking
-        }
+        val server = DBusWireConnection.connectSession()
+        val client = DBusWireConnection.connectSession()
         val busName = "com.monkopedia.sdbus.wire.nest.s${System.nanoTime()}"
         val path = "/com/monkopedia/sdbus/wire/nest"
         val iface = "com.monkopedia.sdbus.wire.Nest"
@@ -346,11 +340,8 @@ class DBusWireConnectionTest {
      */
     @Test
     fun serveWorkerPool_underFloodOfSlowHandlers_staysBounded() = runBlocking {
-        val server = connectOrNull() ?: return@runBlocking
-        val client = connectOrNull() ?: run {
-            server.close()
-            return@runBlocking
-        }
+        val server = DBusWireConnection.connectSession()
+        val client = DBusWireConnection.connectSession()
         val busName = "com.monkopedia.sdbus.wire.flood.s${System.nanoTime()}"
         val path = "/com/monkopedia/sdbus/wire/flood"
         val iface = "com.monkopedia.sdbus.wire.Flood"
@@ -420,11 +411,8 @@ class DBusWireConnectionTest {
      */
     @Test
     fun externalLatchDependency_underBoundedPool_isRescuedByWatchdog() = runBlocking {
-        val server = connectOrNull() ?: return@runBlocking
-        val client = connectOrNull() ?: run {
-            server.close()
-            return@runBlocking
-        }
+        val server = DBusWireConnection.connectSession()
+        val client = DBusWireConnection.connectSession()
         val busName = "com.monkopedia.sdbus.wire.gate.s${System.nanoTime()}"
         val path = "/com/monkopedia/sdbus/wire/gate"
         val iface = "com.monkopedia.sdbus.wire.Gate"
@@ -520,7 +508,7 @@ class DBusWireConnectionTest {
 
     @Test
     fun close_stopsReaderThreadAndClosesSocket() {
-        val connection = connectOrNull() ?: return
+        val connection = DBusWireConnection.connectSession()
         assertTrue(connection.isReaderRunning, "Reader should run while open")
 
         connection.close()

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/unit/CleanerJvmLifecycleSoakTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/unit/CleanerJvmLifecycleSoakTest.kt
@@ -29,8 +29,9 @@ import kotlin.test.fail
  *
  * Uses ordinary JVM GC (no Kotlin/Native cleaner), but it is still GC-timing dependent, so — like the
  * native lifecycle soak — it is excluded from the default `jvmTest` run behind the `-PgcSoak` gate and
- * runs only on the nightly schedule. Needs a real session bus (run under `dbus-run-session`); when no
- * bus is available the connection factory throws and the test treats that as a skip.
+ * runs only on the nightly schedule. Needs a real session bus, and the nightly job runs it inside
+ * `dbus-run-session`, so an unreachable bus is a broken environment: the factory's throw is left to
+ * FAIL the test rather than swallowed into an early return that JUnit records as a pass (#227).
  */
 class CleanerJvmLifecycleSoakTest {
 
@@ -66,7 +67,7 @@ class CleanerJvmLifecycleSoakTest {
 
     @Test
     fun servedObjectWithPropertyIsCollectedAfterRelease() {
-        val connection = connectOrNull() ?: return // no bus in this environment -> skip
+        val connection = createBusConnection()
         try {
             val weak = setUpAndRelease(connection)
             if (!collected(weak)) {
@@ -97,12 +98,5 @@ class CleanerJvmLifecycleSoakTest {
             if (weak.get() == null) return true
         }
         return false
-    }
-
-    // The connection factory throws when no usable bus is reachable (issue #81); treat as skip.
-    private fun connectOrNull(): Connection? = try {
-        createBusConnection()
-    } catch (e: Error) {
-        null
     }
 }


### PR DESCRIPTION
Fixes #227.

`JvmRealBusIntegrationTest` reported 7 tests / 0 skipped / 0 failures with no D-Bus session bus present. The mechanism is `connectOrNull { … } ?: return@runBlocking` — the bus is unreachable, the connection is null, the body never runs, the function returns normally, and **JUnit records an early return as a pass, not a `<skipped/>`**. Two `cross_test` suites were worse for being more convincing: they `println("SKIP …")` and then return, so the log says skip and the XML says pass.

## The classification, applied per precondition rather than per suite

This follows the distinction c5f874c (#182, *"fail loudly when a required dbusmock peer cannot start, and skip honestly when it is absent"*) already established, with no new mechanism.

**FAIL — the precondition should always hold here.** Every job that runs these tasks wraps the build in `dbus-run-session`, and `arm-build-test.yaml` additionally exports `DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"`, so a missing bus is a broken environment, not a legitimate absence. The `connectOrNull` helpers are deleted and the factories' throw is left to fail the test, naming the cause:

```
com.monkopedia.sdbus.SdbusException: org.freedesktop.DBus.Error.AccessDenied:
Failed to open bus: DBUS_SESSION_BUS_ADDRESS is not set (Operation not permitted)
```

That is also how the neighbouring `JvmScaffoldTest.createBusConnection_hasUniqueName` already behaves — it never guarded at all.

| suite | was | now |
|---|---|---|
| `JvmRealBusIntegrationTest` | 7 phantom passes | fails, naming the missing bus |
| `JvmCredentialsTest` | 1 phantom pass | fails |
| `DBusWireConnectionTest` | up to 9 phantom passes | fails |
| `CleanerJvmLifecycleSoakTest` (`-PgcSoak`) | 1 phantom pass | fails |
| `WireServeExternalTest` / `WireSignalEmissionExternalTest` (bus half) | `println("SKIP")` + pass | fails |

**SKIP honestly — the precondition is genuinely optional.** `busctl` and `dbus-monitor` may legitimately be absent on a contributor's box, so those halves now record a real skip through `org.junit.Assume` — the same primitive `skipTest`'s JVM actual uses in c5f874c, and the same one `CrossRuntimeInteropSmokeTest` already uses in this source set. Same for junixsocket's native fd support (`supportsFdDuplicationSemantics`) in `JvmUnixFdTest` and `DBusWireConnectionTest`.

Splitting the two preconditions is the point: `WireServeExternalTest` had *one* early-return path covering both, and only one of them is a legitimate absence.

## Evidence — measured, both directions

**Vacuity, pre-fix, no bus** (same worktree, changes stashed):

```
$ env -u DBUS_SESSION_BUS_ADDRESS ./gradlew :jvmTest --tests "…JvmRealBusIntegrationTest"
BUILD SUCCESSFUL
<testsuite name="JvmRealBusIntegrationTest[jvm]" tests="7" skipped="0" failures="0" errors="0"
```

**Post-fix, no bus:**

```
BUILD FAILED
<testsuite name="JvmRealBusIntegrationTest[jvm]" tests="7" skipped="0" failures="5" errors="0"
  <testcase name="signalCallback_resolvesSenderCredentialsFromBus[jvm]" …>
    <failure message="…Failed to open bus: DBUS_SESSION_BUS_ADDRESS is not set…"
  <testcase name="connectionAddObjectManager_routesInterfacesAddedOnManagerPath[jvm]" …>  <failure …>
  <testcase name="methodCall_withEmptyArrayArg_overWire_doesNotDropConnection[jvm]" …>    <failure …>
  <testcase name="objectManagerGetManagedObjects_returnsManagedChildWithProperties[jvm]" …> <failure …>
  <testcase name="createSessionBusConnection_usesDistinctConnections[jvm]" …>             <failure …>
  <testcase name="systemBusObjectManagerGetManagedObjects_returnsManagedChildWithProperties[jvm]" time="0.204"/>
  <testcase name="createSystemBusConnection_usesDistinctConnections[jvm]" time="0.003"/>
```

5 of 7 fail. The 2 that still pass are the **system**-bus cases — this host runs a real system bus at `/run/dbus/system_bus_socket`, so those two genuinely connected and genuinely ran. That is the honest result, not a residual hole.

Whole-module, no bus: `:jvmTest` went from 135/331 failing (measured in #192) to **150/331** — the 15 newly-failing are exactly the cases that used to pass having connected to nothing. Other affected suites, same run:

```
<testsuite name="JvmCredentialsTest[jvm]"           tests="1" skipped="0" failures="1" errors="0"
<testsuite name="DBusWireConnectionTest[jvm]"       tests="9" skipped="0" failures="9" errors="0"
<testsuite name="WireServeExternalTest[jvm]"        tests="1" skipped="0" failures="1" errors="0"
<testsuite name="WireSignalEmissionExternalTest[jvm]" tests="1" skipped="0" failures="1" errors="0"
<testsuite name="CleanerJvmLifecycleSoakTest[jvm]"  tests="1" skipped="0" failures="1" errors="0"   (-PgcSoak)
```

**With `dbus-run-session` (CI's exact env), still green, no coverage lost.** `:jvmTest :cross_test:jvmTest` before vs after, all 50 `<testsuite …>` lines diffed with timestamps stripped: **zero differences**, 381 tests total in both.

```
<testsuite name="JvmRealBusIntegrationTest[jvm]"    tests="7" skipped="0" failures="0" errors="0"
<testsuite name="DBusWireConnectionTest[jvm]"       tests="9" skipped="0" failures="0" errors="0"
<testsuite name="CleanerJvmLifecycleSoakTest[jvm]"  tests="1" skipped="0" failures="0" errors="0"   (-PgcSoak)
```

**The skip direction actually skips.** With a bus, but `busctl`/`dbus-monitor` removed from `PATH`:

```
<testsuite name="WireServeExternalTest[jvm]" tests="1" skipped="1" failures="0" errors="0"
  <skipped message="org.junit.AssumptionViolatedException: busctl is not on PATH, so no external peer can call the served object."
<testsuite name="WireSignalEmissionExternalTest[jvm]" tests="1" skipped="1" failures="0" errors="0"
  <skipped message="org.junit.AssumptionViolatedException: dbus-monitor is not on PATH, so no external observer can see the signal."
```

`ktlintCheck apiCheck`: BUILD SUCCESSFUL.

## Left alone deliberately

`NativeInteropPeerTest`'s 13 `if (env("KDBUS_NATIVE_INTEROP_ROLE") != "…") return@runBlocking` gates. Those select which role a spawned peer process plays — the binary is launched once per role by the JVM side — and Kotlin/Native's test runner has no runtime-skip primitive (documented on `skipTest` in c5f874c), so there is no mechanism that would render them as anything but a return. Changing them would need a native-side skip primitive that does not exist.

Not touched either: the `println("SKIP <sub-case>")` lines in `DbusmockSecretServiceTest` / `DbusmockTypeMatrixTest` / `DbusmockBluezTest` / `DbusmockForeignErrorTest`. Those narrow individual assertions inside a test that still asserts plenty; they are a different shape from "asserted nothing at all" and out of scope here.

## Review round 2 (`4ab9ba5`)

Reviewer blocked on two documents this change falsifies — fixed:

- `AGENTS.md:57-59` — the bus-less `:jvmTest` figure goes 135 → **150 of 331** (independently measured by the reviewer and by me). `:linuxX64Test`'s 180 of 301 is untouched.
- `COVERAGE_TODO.md:22-23` — dropped the "with graceful skip when unavailable" clause from the two `JvmRealBusIntegrationTest` system-bus lines, which is exactly the behaviour this PR removes.

Reviewer's non-blocking point — `c5f874c` paired its honest skip with `DBUSMOCK_REQUIRED=1` in the job that installs the dependency, and `busctl`/`dbus-monitor` get no equivalent, so a vanished binary would turn #90's only out-of-process coverage into a green `skipped="1"` — is filed as **#229** rather than folded in. It needs a CI-workflow change plus a real run to confirm both binaries are on the `full-tests-x64` runner before their absence can be made fatal, which is the one thing that cannot be checked locally.
