### PR TITLE
SPIKE / DO NOT MERGE: price the EMITTER half of JVM EmitsChangedSignal parity — introspection + PropertiesChanged (Refs #193)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/PropertiesChangedFlagParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/PropertiesChangedFlagParityTest.kt
@@ -1,0 +1,158 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.CONST_PROPERTY_VALUE
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertiesProxy
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SdbusException
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.onSignal
+import com.monkopedia.sdbus.prop
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Cross-backend parity for the `PropertiesChanged` PAYLOAD against each property's
+ * [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags].
+ *
+ * `EmitsChangedSignal` is not introspection decoration -- it is an instruction to the emitter, and
+ * sd-bus acts on it in `emit_properties_changed_on_interface` (`bus-objects.c`). The assertions
+ * here are UNCONDITIONAL on both backends on purpose: unlike the introspection rows in
+ * [TestBackendCapabilities], this is a payload contract a client can observe, so a backend that
+ * disagrees is wrong rather than merely different. Refs #193.
+ */
+class PropertiesChangedFlagParityTest {
+
+    private class Fixture(
+        val obj: Object,
+        val changed: CompletableDeferred<Pair<Map<PropertyName, Variant>, List<PropertyName>>>
+    )
+
+    /**
+     * Serves one interface carrying a default property, an invalidating one, a const one and a
+     * silent one, with a proxy already subscribed to `PropertiesChanged` for it.
+     */
+    private suspend fun withFixture(body: suspend (Fixture, InterfaceName) -> Unit) {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.pcflags$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/pcflags$id")
+        val iface = InterfaceName("com.monkopedia.sdbus.pcflags$id.Iface")
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val reg = obj.addVTable(iface) {
+            prop(CHANGING) { withGetter { 1 } }
+            prop(INVALIDATING) {
+                +EMITS_INVALIDATION_SIGNAL
+                withGetter { 2 }
+            }
+            prop(CONST) {
+                +CONST_PROPERTY_VALUE
+                withGetter { 3 }
+            }
+            prop(SILENT) {
+                +EMITS_NO_SIGNAL
+                withGetter { 4 }
+            }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, path)
+
+        val seen =
+            CompletableDeferred<Pair<Map<PropertyName, Variant>, List<PropertyName>>>()
+        val sigReg = proxy.onSignal(
+            PropertiesProxy.INTERFACE_NAME,
+            SignalName("PropertiesChanged")
+        ) {
+            call {
+                    changedInterface: InterfaceName,
+                    changed: Map<PropertyName, Variant>,
+                    invalidated: List<PropertyName>
+                ->
+                if (changedInterface == iface) seen.complete(changed to invalidated)
+            }
+        }
+
+        try {
+            body(Fixture(obj, seen), iface)
+        } finally {
+            sigReg.release()
+            reg.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+
+    @Test
+    fun noArgEmissionSkipsPropertiesThatDoNotEmitChange() = runBlocking {
+        withFixture { fixture, iface ->
+            fixture.obj.emitPropertiesChangedSignal(iface)
+
+            val (changed, invalidated) = withTimeout(5_000) { fixture.changed.await() }
+            // sd-bus's names==NULL path: EMITS_INVALIDATION goes to the name-only array, anything
+            // without EMITS_CHANGE is skipped entirely, everything else carries its value.
+            assertEquals(setOf(CHANGING), changed.keys, "changed_properties")
+            assertEquals(1, changed.getValue(CHANGING).get<Int>())
+            assertEquals(listOf(INVALIDATING), invalidated, "invalidated_properties")
+        }
+    }
+
+    @Test
+    fun namedEmissionPutsAnInvalidatingPropertyInTheNameOnlyArray() = runBlocking {
+        withFixture { fixture, iface ->
+            fixture.obj.emitPropertiesChangedSignal(iface, listOf(INVALIDATING))
+
+            val (changed, invalidated) = withTimeout(5_000) { fixture.changed.await() }
+            assertEquals(emptySet<PropertyName>(), changed.keys, "changed_properties")
+            assertEquals(listOf(INVALIDATING), invalidated, "invalidated_properties")
+        }
+    }
+
+    @Test
+    fun namedEmissionOfAConstPropertyIsRejected() = runBlocking {
+        withFixture { fixture, iface ->
+            // sd-bus's named path does NOT silently skip: it assert_returns -EDOM for a property
+            // carrying neither EMITS_CHANGE nor EMITS_INVALIDATION, aborting the whole signal.
+            assertFailsWith<SdbusException> {
+                fixture.obj.emitPropertiesChangedSignal(iface, listOf(CONST))
+            }
+        }
+    }
+
+    @Test
+    fun namedEmissionOfASilentPropertyIsRejected() = runBlocking {
+        withFixture { fixture, iface ->
+            assertFailsWith<SdbusException> {
+                fixture.obj.emitPropertiesChangedSignal(iface, listOf(SILENT))
+            }
+        }
+    }
+
+    private companion object {
+        val CHANGING = PropertyName("Changing")
+        val INVALIDATING = PropertyName("Invalidating")
+        val CONST = PropertyName("Const")
+        val SILENT = PropertyName("Silent")
+    }
+}

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusObject.kt
@@ -1,6 +1,8 @@
 package com.monkopedia.sdbus.internal.jvmdbus
 
 import com.monkopedia.sdbus.ActionResource
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_CHANGE_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
 import com.monkopedia.sdbus.InterfaceName
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodCall
@@ -23,6 +25,10 @@ import java.util.concurrent.atomic.AtomicLong
 
 private const val OBJECT_MANAGER_INTERFACE_NAME = "org.freedesktop.DBus.ObjectManager"
 private const val OBJECT_MANAGER_GET_MANAGED_OBJECTS = "GetManagedObjects"
+
+// EDOM, the errno sd-bus assert_returns when PropertiesChanged is asked to announce a property
+// whose vtable flags say it announces nothing (bus-objects.c, emit_properties_changed_on_interface).
+private const val EDOM = 33
 
 /**
  * Sends a signal OVER THE WIRE on the self-owned connection (epic #93). Supplied to
@@ -226,9 +232,12 @@ internal class WireDbusObject(
         return propertyToVariant(value)
     }
 
-    // Mirrors native's sd_bus_emit_properties_changed_strv: each named property whose vtable
-    // getter can be read goes into changed_properties with its current value; names without a
-    // readable getter (write-only / value unavailable) fall back to invalidated_properties.
+    // Mirrors the explicit-names branch of sd-bus's emit_properties_changed_on_interface
+    // (bus-objects.c): a named property carrying EMITS_INVALIDATION contributes its NAME ONLY to
+    // invalidated_properties, one carrying EMITS_CHANGE contributes its current value to
+    // changed_properties, and one carrying NEITHER (const / no-signal) is a caller error that
+    // sd-bus rejects with -EDOM before sending anything at all. Names with no readable getter
+    // (write-only / value unavailable) still fall back to invalidated_properties.
     private fun resolveChangedProperties(
         interfaceName: String,
         propNames: List<PropertyName>
@@ -238,8 +247,15 @@ internal class WireDbusObject(
         val invalidated = mutableListOf<PropertyName>()
         propNames.forEach { propName ->
             val property = properties[propName.value]
+            if (property != null && !property.emitsAnyChange) {
+                throw createError(
+                    EDOM,
+                    "PropertiesChanged failed: $interfaceName.${propName.value} is registered " +
+                        "as not emitting a change signal"
+                )
+            }
             val value = property
-                ?.takeIf { it.getter != null }
+                ?.takeIf { !it.emitsInvalidationOnly && it.getter != null }
                 ?.let { runCatching { readPropertyValue(it) }.getOrNull() }
             if (value != null) {
                 changed[propName] = value
@@ -249,6 +265,14 @@ internal class WireDbusObject(
         }
         return changed to invalidated
     }
+
+    /** Whether this property announces its changes at all, in either form. */
+    private val PropertyVTableItem.emitsAnyChange: Boolean
+        get() = flags.has(EMITS_CHANGE_SIGNAL) || flags.has(EMITS_INVALIDATION_SIGNAL)
+
+    /** Whether this property announces changes by name only, withholding the value. */
+    private val PropertyVTableItem.emitsInvalidationOnly: Boolean
+        get() = flags.has(EMITS_INVALIDATION_SIGNAL)
 
     override fun emitPropertiesChangedSignal(
         interfaceName: InterfaceName,
@@ -269,11 +293,15 @@ internal class WireDbusObject(
     }
 
     override fun emitPropertiesChangedSignal(interfaceName: InterfaceName) {
-        // No-argument form mirrors sd_bus_emit_properties_changed_strv(..., names=null): emit ALL
-        // of the interface's properties (readable ones into changed_properties with their current
-        // value, write-only ones into invalidated_properties), not an empty payload.
-        val allProps = propertiesByInterface[interfaceName.value].orEmpty().keys.map(::PropertyName)
-        emitPropertiesChangedSignal(interfaceName, allProps)
+        // No-argument form mirrors sd_bus_emit_properties_changed_strv(..., names=null), whose
+        // rule differs from the explicit-names one above: properties that announce nothing are
+        // SKIPPED here rather than rejected, and when that leaves nothing to say sd-bus sends no
+        // signal at all ("if (!has_invalidating && !has_changing) return 0").
+        val announcing = propertiesByInterface[interfaceName.value].orEmpty()
+            .filterValues { it.emitsAnyChange }
+            .keys.map(::PropertyName)
+        if (announcing.isEmpty()) return
+        emitPropertiesChangedSignal(interfaceName, announcing)
     }
 
     // The no-argument overloads map onto sd_bus_emit_object_added/_removed, which advertise the

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireServe.kt
@@ -21,6 +21,11 @@
 package com.monkopedia.sdbus.internal.jvmdbus
 
 import com.monkopedia.sdbus.ActionResource
+import com.monkopedia.sdbus.Flags
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.CONST_PROPERTY_VALUE
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_CHANGE_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
+import com.monkopedia.sdbus.InterfaceFlagsVTableItem
 import com.monkopedia.sdbus.Message
 import com.monkopedia.sdbus.MethodCall
 import com.monkopedia.sdbus.MethodVTableItem
@@ -278,6 +283,7 @@ internal object WireServe {
 
     private fun StringBuilder.appendInterface(name: String, meta: WireServeRegistry.InterfaceMeta) {
         append("  <interface name=\"").append(name).append("\">\n")
+        if (meta.deprecated) appendAnnotation("    ", DEPRECATED_ANNOTATION, "true")
         meta.methods.values.sortedBy { it.name }.forEach { method ->
             append("    <method name=\"").append(method.name).append("\">\n")
             splitTypes(method.inputSignature).forEachIndexed { i, type ->
@@ -286,7 +292,7 @@ internal object WireServe {
             splitTypes(method.outputSignature).forEachIndexed { i, type ->
                 appendArg(type, method.outputNames.getOrNull(i), "out")
             }
-            if (method.deprecated) append(DEPRECATED_ANNOTATION)
+            if (method.deprecated) appendAnnotation("      ", DEPRECATED_ANNOTATION, "true")
             append("    </method>\n")
         }
         meta.signals.values.sortedBy { it.name }.forEach { signal ->
@@ -294,7 +300,7 @@ internal object WireServe {
             splitTypes(signal.signature).forEachIndexed { i, type ->
                 appendArg(type, signal.paramNames.getOrNull(i), null)
             }
-            if (signal.deprecated) append(DEPRECATED_ANNOTATION)
+            if (signal.deprecated) appendAnnotation("      ", DEPRECATED_ANNOTATION, "true")
             append("    </signal>\n")
         }
         meta.properties.values.sortedBy { it.name }.forEach { property ->
@@ -306,14 +312,24 @@ internal object WireServe {
             append("    <property name=\"").append(property.name)
                 .append("\" type=\"").append(property.signature)
                 .append("\" access=\"").append(access).append("\"")
-            if (property.deprecated) {
-                append(">\n").append("      ").append(DEPRECATED_ANNOTATION.trim()).append("\n")
-                    .append("    </property>\n")
-            } else {
+            val annotations = buildString {
+                if (property.deprecated) appendAnnotation("      ", DEPRECATED_ANNOTATION, "true")
+                property.emitsChangedSignal?.let {
+                    appendAnnotation("      ", EMITS_CHANGED_SIGNAL_ANNOTATION, it)
+                }
+            }
+            if (annotations.isEmpty()) {
                 append("/>\n")
+            } else {
+                append(">\n").append(annotations).append("    </property>\n")
             }
         }
         append("  </interface>\n")
+    }
+
+    private fun StringBuilder.appendAnnotation(indent: String, name: String, value: String) {
+        append(indent).append("<annotation name=\"").append(name)
+            .append("\" value=\"").append(value).append("\"/>\n")
     }
 
     // Splits a signature into its top-level complete types (e.g. "ia{sv}" -> [i, a{sv}]); empty
@@ -355,8 +371,10 @@ internal object WireServe {
         append("/>\n")
     }
 
-    private val DEPRECATED_ANNOTATION =
-        "      <annotation name=\"org.freedesktop.DBus.Deprecated\" value=\"true\"/>\n"
+    private const val DEPRECATED_ANNOTATION = "org.freedesktop.DBus.Deprecated"
+
+    private const val EMITS_CHANGED_SIGNAL_ANNOTATION =
+        "org.freedesktop.DBus.Property.EmitsChangedSignal"
 
     private val STANDARD_INTROSPECTION =
         "  <interface name=\"org.freedesktop.DBus.Peer\">\n" +
@@ -429,7 +447,12 @@ internal object WireServeRegistry {
         val signature: String,
         val readable: Boolean,
         val writable: Boolean,
-        val deprecated: Boolean
+        val deprecated: Boolean,
+        /**
+         * The `org.freedesktop.DBus.Property.EmitsChangedSignal` value to advertise, or `null` for
+         * the D-Bus default (`"true"`), which sd-bus leaves implicit and so is omitted here too.
+         */
+        val emitsChangedSignal: String? = null
     )
 
     data class SignalMeta(
@@ -443,7 +466,9 @@ internal object WireServeRegistry {
         val methods: Map<String, MethodMeta>,
         val properties: Map<String, PropertyMeta>,
         val signals: Map<String, SignalMeta>,
-        val objectManager: Boolean = false
+        val objectManager: Boolean = false,
+        /** Whether the interface itself was flagged deprecated via `interfaceFlags`. */
+        val deprecated: Boolean = false
     )
 
     private data class ObjectKey(val destination: String, val path: String)
@@ -535,6 +560,7 @@ internal object WireServeRegistry {
         val methods = mutableMapOf<String, MethodMeta>()
         val properties = mutableMapOf<String, PropertyMeta>()
         val signals = mutableMapOf<String, SignalMeta>()
+        var interfaceDeprecated = false
         vtable.forEach { item ->
             when (item) {
                 is MethodVTableItem -> methods[item.name.value] = MethodMeta(
@@ -551,7 +577,8 @@ internal object WireServeRegistry {
                     signature = item.signature?.value.orEmpty(),
                     readable = item.getter != null,
                     writable = item.setter != null,
-                    deprecated = item.isDeprecated
+                    deprecated = item.isDeprecated,
+                    emitsChangedSignal = item.flags.emitsChangedSignalValue()
                 )
 
                 is SignalVTableItem -> signals[item.name.value] = SignalMeta(
@@ -561,9 +588,26 @@ internal object WireServeRegistry {
                     deprecated = item.isDeprecated
                 )
 
-                else -> Unit
+                is InterfaceFlagsVTableItem ->
+                    interfaceDeprecated = interfaceDeprecated || item.isDeprecated
             }
         }
-        return InterfaceMeta(methods, properties, signals)
+        return InterfaceMeta(methods, properties, signals, deprecated = interfaceDeprecated)
+    }
+
+    /**
+     * The `org.freedesktop.DBus.Property.EmitsChangedSignal` value these flags advertise, or `null`
+     * for the D-Bus default (`"true"`), which sd-bus leaves implicit.
+     *
+     * The cascade mirrors sd-bus's `introspect_write_flags` exactly, including its final `else`:
+     * anything that is neither const, nor invalidating, nor explicitly emitting is advertised as
+     * `"false"`. [Flags.set] makes the four behaviors mutually exclusive, so only clearing the
+     * default without selecting a replacement reaches that branch.
+     */
+    private fun Flags.emitsChangedSignalValue(): String? = when {
+        has(CONST_PROPERTY_VALUE) -> "const"
+        has(EMITS_INVALIDATION_SIGNAL) -> "invalidates"
+        has(EMITS_CHANGE_SIGNAL) -> null
+        else -> "false"
     }
 }

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
@@ -4,12 +4,16 @@ package com.monkopedia.sdbus.integration
 // daemon unicast-routes the directed signal and the recipient sees the destination header (#137).
 internal actual val backendDeliversDirectedSignalsUnicast: Boolean = true
 
-// WireServe builds the introspection XML from WireServeRegistry, which captures the per-member
-// deprecated bit and no other vtable flag -- so nothing interface-level reaches the XML.
-internal actual val backendServesInterfaceLevelDeprecated: Boolean = false
+// WireServeRegistry captures the interface-level deprecated bit off InterfaceFlagsVTableItem and
+// WireServe writes it as a child of <interface>, matching what sd-bus emits for
+// SD_BUS_VTABLE_DEPRECATED on the vtable start item (#193 spike).
+internal actual val backendServesInterfaceLevelDeprecated: Boolean = true
 
-// Same reason: the wire backend records no property update behavior to advertise.
-internal actual val backendServesEmitsChangedSignal: Boolean = false
+// WireServeRegistry captures each property's PropertyUpdateBehaviorFlags and WireServe writes
+// const / invalidates / false; the D-Bus default ("true") is left implicit, as sd-bus does
+// (#193 spike).
+internal actual val backendServesEmitsChangedSignal: Boolean = true
 
-// Same reason: hasNoReply drives the reply-suppression path only, never the introspection XML.
+// Still false: hasNoReply drives the reply-suppression path only, never the introspection XML.
+// Out of scope for #193 -- the native half of this row was fixed separately in #216/#197.
 internal actual val backendServesMethodNoReply: Boolean = false


### PR DESCRIPTION
**⚠️ SPIKE — DO NOT MERGE. Refs #193.**

This is the **second** spike on #193, and it exists because the **first one (#220) argued against
itself**. #220 priced serving interface-level `Deprecated` + `EmitsChangedSignal` in the JVM
backend's introspection XML, then concluded *do not merge as scoped*: advertising
`EmitsChangedSignal` while the JVM emitter ignores it "converts a truthful silence into an unbacked
promise". Its §4 listed **the emitter half as explicitly unpriced.**

This branch prices it. It **carries #220's introspection change unmodified (cherry-picked) plus the
emitter change**, so the owner can see the complete "implement" option — and it prices the two
halves separately, because the marginal cost of the emitter is the number that was actually missing.

No reviewer requested. No labels. The decision on #193 remains entirely open, and **the strongest
argument in this document is the one against merging** (§5).

---

## 1. Which part is whose

| | #220's half (cherry-picked, `9095b1d`+`4a2501c`) | **This spike's half** (`99934f8`+`f4568c5`) |
| --- | --- | --- |
| What it does | JVM *advertises* interface-level `Deprecated` and `EmitsChangedSignal` in served introspection XML | JVM *honours* `PropertyUpdateBehaviorFlags` when emitting `PropertiesChanged` |
| Production file | `src/jvmMain/.../jvmdbus/WireServe.kt` | `src/jvmMain/.../jvmdbus/WireDbusObject.kt` |
| Production diff | **+57 / −13** | **+37 / −9** (net +28; **17 of the 37 added lines are comments**, so ~20 lines of real code) |
| Test diff | `TestBackendCapabilities.jvm.kt` +10/−6, two `actual`s flipped. **0 new tests** | **1 new file, 158 lines, 4 tests** — `src/commonTest/.../PropertiesChangedFlagParityTest.kt`, run on both targets |
| New capability flags | 0 (reuses #213's) | **0** — the assertions are unconditional on both backends; see §3 |
| Public API change | none (`internal object`) | none (`internal class`) |
| `apiCheck` | green, no `api/*.api` diff | **green, no `api/*.api` diff** — including `api/sdbus-kotlin.klib.api`, consumed by `blue-falcon-sdbus` |

**Marginal price of the emitter half: one production file, ~20 lines of real code, one new 158-line
cross-backend test, no new capability flag, no API movement.** In raw diff terms the emitter is
*cheaper* than #220's introspection half.

That is also the least interesting number here. The emitter half is small to write and large to
ship; §2 and §5 are why.

---

## 2. The finding: sd-bus has TWO rules, and both #220 and my own brief had one of them wrong

#220's body — and the #193 comment derived from it — say
`sd_bus_emit_properties_changed_strv` "skips properties lacking `EMITS_CHANGE`". **That is true of
exactly one of its two code paths.** Read from systemd v261,
`src/libsystemd/sd-bus/bus-objects.c`, `emit_properties_changed_on_interface`:

**Path A — `names == NULL`** (lines 2277-2307). *Skip:*

```c
if (v->flags & SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION) { has_invalidating = true; continue; }
if (!(v->flags & SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE))    continue;
```

…and if that leaves nothing to say, **no signal is sent at all** —
`if (!has_invalidating && !has_changing) return 0;` (line 2311).

**Path B — an explicit name list** (lines 2238-2276). ***Reject:***

```c
assert_return(v->vtable->flags & SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE ||
              v->vtable->flags & SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION, -EDOM);
```

`assert_return` *returns* — it does not abort — so `-EDOM` propagates out of
`sd_bus_emit_properties_changed_strv`, and `ConnectionImpl.kt:631`'s
`sdbusRequire(r < 0, "Failed to emit PropertiesChanged signal", -r)` turns it into a thrown
`SdbusException`. **Nothing is sent — not even the other named properties that would have been fine.**

Our two overloads map onto those two paths: `emitPropertiesChangedSignal(iface)` → `ObjectImpl.kt:148`
→ `emptyList()` → `ConnectionImpl.kt:622` `names = null` → **Path A**;
`emitPropertiesChangedSignal(iface, listOf(...))` → **Path B**.

### Measured, not inferred

`PropertiesChangedFlagParityTest` was written first and run against **`:linuxX64Test` with zero
production changes**. All four passed:

```
<testsuite name="linuxX64Test...PropertiesChangedFlagParityTest" tests="4" skipped="0" failures="0" errors="0">
  <testcase name="noArgEmissionSkipsPropertiesThatDoNotEmitChange[linuxX64]"/>
  <testcase name="namedEmissionPutsAnInvalidatingPropertyInTheNameOnlyArray[linuxX64]"/>
  <testcase name="namedEmissionOfAConstPropertyIsRejected[linuxX64]"/>
  <testcase name="namedEmissionOfASilentPropertyIsRejected[linuxX64]"/>
</testsuite>
```

So **on native today, `obj.emitPropertiesChangedSignal(iface, listOf(constProp))` throws.** That is
surprising, it is sd-bus's behaviour, and per the brief this branch matches it rather than
substituting a nicer rule. It matters because it changes what "parity" costs: the honest JVM
implementation is not just "emit less", it is **"emit less, and start throwing"**.

Native's existing suite already pinned Path A without anyone noticing:
`DBusStandardInterfacesTests.emitsPropertyChangedSignalForAllProperties` asserts `changed.size == 1`
and `invalidated == ["action"]` on a fixture whose third property, `state`, is
`+CONST_PROPERTY_VALUE` (`IntegrationTestsAdaptor.kt:154-158`) — and `state` appears in neither array.

---

## 3. Why there is no new capability flag

#213's `backendServes*` flags exist because *served introspection* genuinely differs per backend and
the divergence had to be recorded rather than asserted away. This is a different surface: the
`PropertiesChanged` **payload** is what a client actually consumes, and native's behaviour is the
D-Bus specification's. So all four assertions are **unconditional on both targets** — a backend that
disagrees is wrong, not different. That is also what makes the test a real acceptance test for the
emitter rather than a restatement of it.

The two flags this branch *does* touch are #220's, and **both directions were re-verified on this
tree** per #216's precedent — numbers in §4.

---

## 4. Red-then-green — counted from fresh JUnit XML

Every run was preceded by `find . -type d -name test-results -prune -exec rm -rf {} +`, under
`dbus-run-session`, `JAVA_HOME=/usr/lib/jvm/java-21-openjdk`. `BUILD SUCCESSFUL` was not trusted;
counts come from the XML.

### RED — test in, `WireDbusObject.kt` reverted to #220's tip

`:jvmTest --tests "*PropertiesChangedFlagParityTest*"` → **4 tests, 4 failures, 0 errors, 0 skipped.**
Verbatim `<failure message=…>`:

| Test | Assertion text |
| --- | --- |
| `noArgEmissionSkipsPropertiesThatDoNotEmitChange[jvm]` | `java.lang.AssertionError: changed_properties expected:<[Changing]> but was:<[Changing, Invalidating, Const, Silent]>` |
| `namedEmissionPutsAnInvalidatingPropertyInTheNameOnlyArray[jvm]` | `java.lang.AssertionError: changed_properties expected:<[]> but was:<[Invalidating]>` |
| `namedEmissionOfAConstPropertyIsRejected[jvm]` | `java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.SdbusException to be thrown, but was completed successfully.` |
| `namedEmissionOfASilentPropertyIsRejected[jvm]` | `java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.SdbusException to be thrown, but was completed successfully.` |

The first line is the whole issue in one string: **today a JVM adaptor broadcasts the current value
of a `const` property and of an `EmitsChangedSignal="false"` property** on every no-argument
`PropertiesChanged`, and broadcasts the *value* of an `invalidates` property instead of its bare
name. This is red **with #220's introspection change already applied** — i.e. #220's own §3a,
demonstrated rather than argued.

### GREEN — full suites, both targets

| Run | Result |
| --- | --- |
| `:jvmTest` | **38 XML files — 335 tests, 0 failures, 0 errors, 0 skipped** |
| `:linuxX64Test` | **30 XML files — 305 tests, 0 failures, 0 errors, 0 skipped** |
| `ktlintCheck` + `apiCheck` | exit 0; `git status api/` and `git diff --stat api/` both empty |

### Capability-flag negative control (#216's precedent)

With the implementation in but `TestBackendCapabilities.jvm.kt` reverted to `main`'s (both `actual`s
still `false`), `:jvmTest --tests "*VtableFlagIntrospectionTest*"` → **4 tests, 2 failures, 0 errors,
0 skipped** — so leaving a flag unflipped after the behaviour change does make the harness fail:

> `java.lang.AssertionError: org.freedesktop.DBus.Deprecated="true" on <interface name="com.monkopedia.sdbus.flags.DeprecatedInterface"> should be absent by this backend … expected:<false> but was:<true>`
>
> `java.lang.AssertionError: org.freedesktop.DBus.Property.EmitsChangedSignal="const" on <property name="ConstProperty"> should be absent by this backend … expected:<false> but was:<true>`

The failure messages embed the full served XML, which is worth quoting for the record — this is what
a JVM adaptor advertises with #220's half applied:

```xml
<interface name="com.monkopedia.sdbus.flags.Properties">
  <property name="ConstProperty" type="i" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
  </property>
  <property name="InvalidatingProperty" type="i" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates"/>
  </property>
  <property name="SilentProperty" type="i" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
  </property>
</interface>
```

Put that next to the RED table above and the problem #220 identified is legible in two artifacts from
the same tree: the XML promises `const`/`invalidates`/`false`, and the emitter sends
`[Changing, Invalidating, Const, Silent]` with values. **The emitter half is not optional if the
introspection half ships.**

The emitter half itself introduced **no** capability flag, so there is no third direction to check;
its four assertions hold on both backends unconditionally (§3).

---

## 5. The case AGAINST this change

Taking the case against first, deliberately: it is the longer and better-evidenced one.

### 5a. It IS a breaking change for existing JVM consumers, in two independent ways

**Answering the question the brief asked, directly: yes.** Not "technically", and not only in the
abstract:

1. **Signals silently stop arriving.** A JVM service that registers a property with
   `+CONST_PROPERTY_VALUE` or `+EMITS_NO_SIGNAL` and then calls `emitPropertiesChangedSignal(iface)`
   currently broadcasts that property's value. After this change it broadcasts nothing for it — and
   if *no* property on the interface announces changes, **no signal at all is sent**. A client that
   was receiving updates stops receiving them. No error, no log, no deprecation window; the update
   simply never comes. That is the worst failure shape available: silent, remote, and visible only
   as staleness.
2. **A call that used to succeed now throws.** `emitPropertiesChangedSignal(iface, listOf(p))` for a
   `const`/`false` property raises `SdbusException`. This reaches **public API by an indirect route**:
   `Object.notifying()` (`Object.kt:257`, backed by `NotifyingProperty` at `Object.kt:263-288`) is a
   `ReadWriteProperty` delegate whose `setValue` calls exactly that overload. So an application that
   writes `var x by obj.notifying(iface, prop, 0)` for a property flagged `+CONST_PROPERTY_VALUE`
   gets an exception **from an ordinary Kotlin assignment**, inside a `synchronized` block,
   potentially on a serve/event-loop thread. The user's code never mentions
   `emitPropertiesChangedSignal`.

Both land on **1.0.1, live on Maven Central**, for consumers whose only change is a version bump.
Neither is caught by any compiler check, and **`apiCheck` is green precisely because no signature
moves** — which is the point: binary-compatibility validation cannot see this class of break at all.

Honestly mitigating: the blast radius is bounded to services that *set a non-default
`PropertyUpdateBehaviorFlags`* **and** *emit for that property anyway*. That combination is arguably
a bug in the consumer — they asked for silence and got noise. But "your code was wrong, so we fixed
it by breaking it" is a maintainer's argument, not a user's, and it is not a thing a patch or minor
release gets to do.

### 5b. Matching native here imports a bad API, not just a behaviour

The `-EDOM` rejection (§2) is defensible in C, where the caller checks a return code. In Kotlin it
becomes a thrown exception from a `Unit`-returning notification method, for a condition that is
statically knowable at registration time. The design one would actually choose is to reject
`+CONST_PROPERTY_VALUE` + `notifying()` at `addVTable` time, or to skip in both paths. This branch
does neither, because the brief was parity and parity is what it measures — but that means the
"implement" option ships an ergonomic wart on the JVM backend **on purpose**, justified entirely by
"native does it", which only persuades you if you already believe parity dominates.

An owner could reasonably conclude the reverse: that JVM's current lenient behaviour is *better*,
and the divergence should be closed by making **native** skip — which we cannot do, because native's
behaviour is sd-bus's.

### 5c. It settles "which backend is the reference" on a case where native is awkward

Every parity fix so far (#137, #141, #142-145) moved JVM toward native on a surface where native was
uncontroversially right. Here native is right *by definition* (it is sd-bus) but not obviously right
*on the merits* (§5b). Shipping this sets the precedent that "sd-bus does it" settles behaviour
questions even when sd-bus's choice is awkward, and the next such question gets argued from this one.

### 5d. Nobody has reported it, and the alternative is nearly free

Like #193 itself, this was found by an audit pass, not a consumer. Meanwhile "document and freeze"
costs an edit to a `docs/BACKENDS.md` row that already exists and is already accurate
(`docs/BACKENDS.md:45`) — it would gain one clause about the emitter. Deferring costs a sentence;
shipping costs the two breaks in §5a.

*(Correcting a predecessor claim at the source, per re-measure-don't-adjudicate: #220's §3d and its
#193 comment both report that row as **stale**. It was, when written. It is not now — #221
(`8ea0423`) corrected the `Method.NoReply` clause after #216, and that landed before this branch's
base `9ca8c3a`. No doc debt is outstanding on that row.)*

### 5e. The best thing on this branch does not need the production change at all

`PropertiesChangedFlagParityTest` passes on native **unmodified, today**. Its value is that it pins
sd-bus's actual contract — including the surprising half — inside our own suite, where the next
person arguing about `EmitsChangedSignal` can read a test instead of re-deriving it from C. That
value is entirely independent of whether JVM changes to match. **If the owner declines the implement
option, the test still wants to land**, as a native pin plus an explicitly recorded JVM divergence.
That is a genuinely cheaper outcome than either branch #193 currently lists, and building the
emitter is what surfaced it.

---

## 6. The case FOR this change

- **It is the only honest version of "implement".** #220 established that shipping the introspection
  alone makes the adaptor state a contract its own emitter breaks. If the owner wants option 2 at
  all, this is what option 2 costs; making that comparable is this branch's entire purpose.
- **The current JVM behaviour is wrong by the D-Bus specification, not merely different.**
  `org.freedesktop.DBus.Property.EmitsChangedSignal` is a spec annotation with defined semantics;
  `invalidates` means *name only, re-`Get` it*. A JVM adaptor sending the value where the spec says
  name-only is a spec violation — one that is currently invisible only because the adaptor also
  declines to advertise the annotation.
- **It removes a real, observable cross-process divergence.** The same generated adaptor, from the
  same XML, emits different `PropertiesChanged` payloads depending on which artifact it links.
  `codegen` maps `invalidates`/`const`/`false` straight from introspection XML
  (`AdaptorGenerator.kt:276-281`) and real MPRIS interfaces use them
  (`codegen/src/test/resources/MediaPlayer2/adaptor.1.kt` carries three `+EMITS_NO_SIGNAL`), so the
  gap is not synthetic.
- **`const` properties are a bandwidth and correctness win.** A JVM BlueZ-shaped service with many
  const properties currently rebroadcasts all of them on every no-arg emission. Clients that trusted
  `const` and cached would see contradictory traffic; clients that did not, pay for it.
- **It is small and it is testable.** ~20 lines of real code, one test file, no API movement, and the
  acceptance test is cross-backend, so it would catch a regression on either side.

---

## 7. What I could not settle

- **Whether any real downstream is affected.** I did not survey `blue-falcon-sdbus` or any other
  consumer for JVM-hosted adaptors that set a non-default `PropertyUpdateBehaviorFlags`. §5a's blast
  radius is reasoned, not measured. This is the most decision-relevant unknown and it is cheap to
  close.
- **Three adjacent JVM/native divergences I found and deliberately did NOT fix**, because each is
  outside "honour the flags" and is its own decision:
  1. **Unknown property name.** Native returns `-ENOENT` (throws); JVM puts the unknown name into
     `invalidated_properties` and emits. `JvmSignalPropertyUnsupportedTest` (jvmTest-only)
     *depends* on the lenient behaviour — it emits for `PropertyName("state")` on an object with no
     vtable at all and asserts a signal arrives. Under full parity that test would have to change.
  2. **Empty explicit list.** `emitPropertiesChangedSignal(iface, emptyList())` means "emit
     everything" on native (`ConnectionImpl.kt:622` converts empty → `NULL`) and "emit an empty
     signal" on JVM. Untouched.
  3. **A getter that throws.** Native aborts the whole signal; JVM falls back to
     `invalidated_properties`. Untouched.
- **The exception's identity is only approximately matched.** Errno 33 is unmapped in both
  `Error.jvm.kt`'s table and sd-bus's, so both backends land on
  `org.freedesktop.DBus.Error.Failed` and the `SdbusException` *name* matches — but the detail text
  differs (`Unknown error 33` vs strerror's `Numerical argument out of domain`). The test asserts the
  type, not the message.
- **`cross_test` / `stress_test` were not run.** Only `:jvmTest`, `:linuxX64Test`, `ktlintCheck`,
  `apiCheck`. `cross_test`'s two `PropertiesChanged` interop tests use default-flag properties
  (`NativeInteropPeerTest.kt:263-265`) so they *should* be unaffected — inference, not a run.
- **`linuxArm64` tests were not run** (no runner here). The emitter change is `jvmMain`-only, and
  `linuxArm64` did compile as part of `apiCheck`'s `klibApiMerge`.

---

## 8. Status

**Do not merge. The #193 decision is the owner's and is untouched by this branch.**

What the two spikes together now establish:

- **Option 1 (document + freeze)** — cheapest; the `docs/BACKENDS.md` row exists and is accurate, and
  would gain one clause.
- **Option 2 (implement)** — the *complete* version is this branch. Introspection half +57/−13;
  emitter half ~20 lines of real code plus a 158-line test. **Total cost is small. Total risk is
  not**: a silent behavioural break plus a new runtime exception reachable from the `notifying()`
  delegate, on a released 1.0.1 artifact (§5a).
- **Option 3 (interface-level `Deprecated` only)** — surfaced by #220, unaffected by any of this,
  still the safest partial.
- **Option 4, which only appeared once the emitter was actually built** — land
  `PropertiesChangedFlagParityTest` **alone**, as a native pin plus a recorded JVM divergence, with
  no production change. It passes on native today. It converts "we think sd-bus does X" into a test,
  which is exactly the gap #193's own last section complained about, and it commits us to nothing.

I am **not** recommending merging this. Having built it, my read is that §5a is disqualifying for a
1.x line and option 4 is the best value on the board — but that is a judgement about compatibility
appetite, which is the owner's to make, and it is why this is a branch rather than a paragraph of
speculation.

The branch is disposable. It cost one worktree. That is not an argument for keeping it.
