### PR TITLE
[SPIKE][DO NOT MERGE] Price both halves of #184: MethodCall.send(ZERO) and the missing JVM default reply timeout

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -92,12 +92,14 @@ timeout-shaped `com.monkopedia.sdbus.Error` — never a hang.
 
 The **connection-level default** (`Connection.methodCallTimeout`) is selected by a per-call
 timeout of `Duration.ZERO` — the sentinel the raw-message overloads (`Proxy.callMethod(message)`,
-`Proxy.callMethodAsync(message)`) send. On native it maps to
-`sd_bus_set/get_method_call_timeout` (sd_bus resolves a 0 per-call timeout through the
-connection default inside `sd_bus_call`); the JVM call paths consult the stored value the same
-way (issue #80). Any other explicit per-call timeout wins over the connection default; if the
-connection default is never set either, each backend's own default reply timeout applies
-(sd-bus's 25 s default / the JVM wire backend's own default reply timeout).
+`Proxy.callMethodAsync(message)`) send, and the one `MethodCall.send(Duration.ZERO)` carries. On
+native it maps to `sd_bus_set/get_method_call_timeout` (sd_bus resolves a 0 per-call timeout
+through the connection default inside `sd_bus_call`); the JVM call paths consult the stored value
+the same way (issue #80, and `MethodCall.send` since #184). Any other explicit per-call timeout
+wins over the connection default; if the connection default is never set either, both backends
+report and apply 25 s — sd-bus's `BUS_DEFAULT_TIMEOUT_USEC` on native (overridable by
+`$SYSTEMD_BUS_TIMEOUT`, which the JVM backend does **not** read), and the same value as the JVM
+connection's initial `methodCallTimeout` (issue #184).
 
 Note that the high-level invoker block defaults `timeout` to `Duration.INFINITE` — *no* per-call
 timeout, **not** the connection default — so `callMethod { call(…) }` with no `timeout =` line

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
@@ -85,10 +85,18 @@ interface Connection : Resource {
     val currentlyProcessedMessage: Message
 
     /**
-     * General method call timeout
+     * The connection's default method call timeout.
      *
-     * General method call timeout is used for all method calls upon this connection.
-     * Method call-specific timeout overrides this general setting.
+     * It applies to calls that ask for it, which is **not** every call on this connection: the
+     * raw-message overloads ([Proxy.callMethod]/[Proxy.callMethodAsync] taking a
+     * [MethodCall]) and any call whose per-call timeout is [Duration.ZERO], the
+     * "use the connection default" sentinel. The high-level invoker block defaults
+     * [MethodInvoker.timeout] to [Duration.INFINITE] — *no* per-call timeout, not this value — so
+     * `callMethod { … }` with no `timeout =` line is unaffected by this property. Any other
+     * explicit per-call timeout overrides it.
+     *
+     * Unset, it reads back as the backend's own default reply timeout (sd-bus's, 25 s unless
+     * `$SYSTEMD_BUS_TIMEOUT` says otherwise).
      *
      * @throws [com.monkopedia.sdbus.SdbusException] in case of failure
      */

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/FailurePathParityTest.kt
@@ -264,6 +264,84 @@ class FailurePathParityTest {
         }
     }
 
+    // Item 1 of #184. [com.monkopedia.sdbus.MethodCall.send] documents "[Duration.ZERO] uses the
+    // connection default". Native gets that for free -- 0 is sd-bus's own sentinel inside
+    // sd_bus_call -- but the JVM MethodCall never consulted a connection at all, so ZERO reached
+    // the dispatch as "no timeout". Same two-phase shape as
+    // explicitZeroPerCallTimeout_selectsConnectionDefault, one level lower: the raw-message
+    // send() path rather than the high-level invoker.
+    @Test
+    fun rawMessageSendWithZeroTimeout_selectsConnectionDefault() = runBlocking {
+        val ids = uniqueFixtureIds("zeroSend")
+        val serverConnection = createBusConnection(ids.service)
+        val proxyConnection = createBusConnection()
+        val obj = createObject(serverConnection, ids.path)
+        val serverDelayMs = 600L
+        val registration = obj.addVTable(ids.iface) {
+            method(MethodName("Slow")) {
+                asyncCall { value: Int ->
+                    delay(serverDelayMs)
+                    value
+                }
+            }
+        }
+        serverConnection.startEventLoop()
+        val proxy = createProxy(proxyConnection, ids.service, ids.path)
+
+        try {
+            // Phase 1: a generous connection default means the ZERO send must let the slow
+            // method run to completion. A ZERO taken literally would fail here immediately.
+            proxyConnection.methodCallTimeout = 5_000.milliseconds
+            val generous = proxy.createMethodCall(ids.iface, MethodName("Slow"))
+            generous.append(1)
+            val reply = generous.send(Duration.ZERO)
+            reply.rewind(false)
+            assertEquals(1, reply.readInt())
+
+            // Phase 2: a connection default shorter than the handler's delay must now expire the
+            // same ZERO send. A ZERO meaning "no timeout" returns 2 after ~600 ms instead.
+            proxyConnection.methodCallTimeout = 100.milliseconds
+            val stingy = proxy.createMethodCall(ids.iface, MethodName("Slow"))
+            stingy.append(2)
+            val thrown = assertFailsWith<SdbusException> { stingy.send(Duration.ZERO) }
+            assertIsTimeout(thrown)
+
+            delay(serverDelayMs + 400)
+        } finally {
+            withTimeout(5_000) {
+                proxyConnection.stopEventLoop()
+                serverConnection.stopEventLoop()
+            }
+            registration.release()
+            proxy.release()
+            obj.release()
+            proxyConnection.release()
+            serverConnection.release()
+        }
+    }
+
+    // Item 2 of #184. A connection whose methodCallTimeout was never set must still report a
+    // real default, because that value is what every "use the connection default" path resolves
+    // to: the raw-message callMethod(message)/callMethodAsync(message) overloads, and (item 1) a
+    // Duration.ZERO send. Native inherits sd-bus's BUS_DEFAULT_TIMEOUT_USEC (25 s); the JVM
+    // backend initialised its stored timeout to Duration.ZERO, which means "no timeout" one layer
+    // down, so the sentinel resolved to itself and nothing bounded the call.
+    @Test
+    fun freshConnection_reportsANonZeroDefaultMethodCallTimeout() {
+        val connection = createBusConnection()
+        try {
+            val default = connection.methodCallTimeout
+            assertTrue(
+                default > Duration.ZERO,
+                "a fresh connection must report a real default method-call timeout, " +
+                    "otherwise every Duration.ZERO 'use the connection default' path resolves " +
+                    "to no timeout at all; got $default"
+            )
+        } finally {
+            connection.release()
+        }
+    }
+
     // The backends differ on whether the daemon reports Timeout or NoReply, and on the exact
     // human-readable string, so assert membership rather than an exact value -- but require that
     // it is recognizably a timeout, never a generic/unrelated error.

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -394,9 +394,17 @@ actual class MethodCall internal constructor() : Message() {
     internal var sentReply: MethodReply? = null
     private val replySent = CountDownLatch(1)
 
+    // Duration.ZERO is the API's "use the connection default" sentinel (see MethodCall.send's
+    // KDoc), the same one Proxy.callMethod(message) already resolves. A call built by
+    // Proxy.createMethodCall reads the owning connection's current default through this hook; a
+    // standalone MethodCall has no connection to defer to, so its default stays 0 = no timeout.
+    internal var connectionDefaultTimeoutMicros: () -> ULong = { 0uL }
+
     actual fun send(timeout: Duration): MethodReply = send(timeout.inWholeMicroseconds.toULong())
 
     internal fun send(timeout: ULong): MethodReply {
+        val effectiveTimeout =
+            if (timeout == 0uL) connectionDefaultTimeoutMicros() else timeout
         val interfaceName = metadata.interfaceName
             ?: throw createError(-1, "MethodCall.send failed: missing interface name")
         val methodName = metadata.memberName
@@ -416,7 +424,7 @@ actual class MethodCall internal constructor() : Message() {
                     "MethodCall.send failed: no static binding for $path:$interfaceName.$methodName/${payload.size}"
                 )
         }
-        val result = if (timeout == 0uL) {
+        val result = if (effectiveTimeout == 0uL) {
             invoke()
         } else {
             val value = AtomicReference<Any?>()
@@ -432,7 +440,7 @@ actual class MethodCall internal constructor() : Message() {
                     .onFailure { failure.set(it) }
                 done.countDown()
             }
-            val timeoutMillis = ((timeout + 999uL) / 1000uL).toLong().coerceAtLeast(1L)
+            val timeoutMillis = ((effectiveTimeout + 999uL) / 1000uL).toLong().coerceAtLeast(1L)
             if (!done.await(timeoutMillis, TimeUnit.MILLISECONDS)) {
                 throw createError(-1, "Method call timed out")
             }

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.thread
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * The JVM D-Bus backend (epic #93): the one and only backend, routing everything through the
@@ -167,11 +168,18 @@ private fun emitWireSignal(
 // instead. #141.
 private val directConnectionCounter = AtomicLong()
 
+// sd-bus's BUS_DEFAULT_TIMEOUT_USEC, the value a native connection reports when nothing called
+// sd_bus_set_method_call_timeout. Every "use the connection default" path -- the raw-message
+// callMethod(message) overloads and MethodCall.send(Duration.ZERO) -- resolves to this, so a
+// connection that reported Duration.ZERO here was reporting "no timeout" and left those calls
+// unbounded. #184.
+private val DEFAULT_METHOD_CALL_TIMEOUT: Duration = 25.seconds
+
 internal class WireDbusConnection(private val wire: DBusWireConnection) : JvmDbusConnection {
     private val localUniqueName: String =
         wire.uniqueName ?: ":jvm-wire-${directConnectionCounter.incrementAndGet()}"
     private val released = AtomicBoolean(false)
-    private var timeout: Duration = Duration.ZERO
+    private var timeout: Duration = DEFAULT_METHOD_CALL_TIMEOUT
 
     val wireConnection: DBusWireConnection get() = wire
     fun isReleased(): Boolean = released.get()

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -279,15 +279,25 @@ internal class WireDbusProxy(
     override fun createMethodCall(
         interfaceName: InterfaceName,
         methodName: MethodName
-    ): MethodCall = MethodCall().also {
-        it.metadata = Message.Metadata(
-            interfaceName = interfaceName.value,
-            memberName = methodName.value,
-            destination = destination.value,
-            path = objectPath.value,
-            valid = true,
-            empty = true
-        )
+    ): MethodCall {
+        // Local capture so the timeout hook below holds the connection alone, not this proxy.
+        val owningConnection = connection
+        return MethodCall().also {
+            it.metadata = Message.Metadata(
+                interfaceName = interfaceName.value,
+                memberName = methodName.value,
+                destination = destination.value,
+                path = objectPath.value,
+                valid = true,
+                empty = true
+            )
+            // MethodCall.send(Duration.ZERO) documents "uses the connection default"; read it at
+            // send time rather than here, so a methodCallTimeout set after the call was created
+            // still applies -- the same order Proxy.callMethod(message) resolves it in. #184.
+            it.connectionDefaultTimeoutMicros = {
+                owningConnection?.defaultTimeoutMicros() ?: 0uL
+            }
+        }
     }
 
     override fun callMethod(message: MethodCall): MethodReply = callMethod(message, 0uL)


### PR DESCRIPTION
**SPIKE — DO NOT MERGE.** Refs #184. This is not a decision and not a proposal to merge; it exists so that
"make JVM match the documented contract" can be compared against "correct the doc" with a real diff and real
numbers instead of a guess. Draft, no reviewer, no labels. **If the verdict is "document instead", close this
unmerged — that is a success for this branch, not a failure.**

#184 asks one question twice. **This spike's finding is that the two halves want different answers**, so the
diff is split into commits that can be taken separately or dropped separately.

---

## What I measured before writing anything

The issue is right about the divergences and imprecise about their size in three places. Correcting them
changes what the options cost, so they go first. (The issue is the authority on the decision; these are
measurements against the code at `9ca8c3a`.)

**(a) On JVM, `MethodCall.send` never reaches the wire at all.** `Message.jvm.kt:399-467` dispatches only
through `JvmStaticDispatch`, and a miss throws
`MethodCall.send failed: no static binding for <path>:<iface>.<member>/<n>`. There is no `callRemote`
fallback — verified by reading the whole method, since `WireDbusBackend.kt` is `file`-detected as `data` and
plain `grep` silently skips it (`/usr/bin/grep -a` used throughout). Native's `MethodCall.send` is a straight
`sd_bus_call`, so it talks to any peer on the bus. The timeout divergence in item 1 is therefore a *symptom*
of a send path that had no connection behind it — which is why the fix is plumbing rather than a
substitution, and why the affected population is "raw-message callers against a same-process object", not
everyone.

**(b) "A JVM caller who never touches timeouts can wait indefinitely" is true on only one of the two paths.**
`DBusWireConnection.kt:574` — `private const val DEFAULT_TIMEOUT_MILLIS = 30_000L` — is the default parameter
of `callBlocking`, so the **cross-process** path (`WireDbusBackend.kt:558-562`:
`if (timeoutMicros == 0uL) realWire.callBlocking(request)`) is bounded at 30 s today. The unbounded case is
the **same-process** path (`WireDbusBackend.kt:353-354`: a zero effective timeout calls `callLocalDispatch`
with no wrapper at all) and the raw `MethodCall.send` static dispatch. So the real state of the world is
*three* values behind one documented one:

| | native | JVM |
| --- | --- | --- |
| `connection.methodCallTimeout` on a fresh connection | 25 s | **`0s`** |
| call with no timeout, **cross-process** | 25 s | 30 s |
| call with no timeout, **same-process** | 25 s (goes over the bus) | **unbounded** |
| `MethodCall.send(Duration.ZERO)` | connection default | **no timeout** |

`docs/BACKENDS.md:99-100` already hedges this as "each backend's own default reply timeout applies (sd-bus's
25 s default / the JVM wire backend's own default reply timeout)" — true of the 30 s wire path, false of the
same-process one.

**(c) sd-bus's 25 s is not a constant.** From `sd_bus_set_method_call_timeout(3)` on this host (systemd 261),
not folklore: the timeout is read from `$SYSTEMD_BUS_TIMEOUT`, cached at first read, and only *falls back* to
"a predefined method call timeout of 25 seconds". A hard-coded 25 s on JVM therefore matches native in the
default environment and diverges in one that sets that variable. That is why the new test asserts
`> Duration.ZERO` rather than `== 25.seconds`.

**`Duration.ZERO` and `Duration.INFINITE` are distinct in the JVM path**, and were before this diff.
`ZERO.inWholeMicroseconds` is `0`, taking the sentinel branch; `INFINITE.inWholeMicroseconds` is
`Long.MAX_VALUE`, taking the timed branch with an await of ~2.9 × 10^14 ms. Behaviourally both meant "no
timeout" on the raw path before this diff, by two different routes. `INFINITE` keeps its #181 meaning here —
*no per-call timeout is applied* — and this PR does not touch it or reintroduce the claim #181 removed.

### History, and whether anything already pinned this

Both lines are wrong-since-written, the same shape as #179:

- `WireDbusBackend.kt:174` `private var timeout: Duration = Duration.ZERO` — `git log -L 174,174` returns a
  single commit, `faad79f` *"Phase 3 (#93): JVM client path through the owned connection (toggle) (#96)"*. It
  is the line's introduction, not a later deliberate change.
- `Message.jvm.kt:419` `if (timeout == 0uL)` — `git log -L 419,419` likewise returns one commit, `dab35d1`
  *"feat(jvm): implement JVM backend and common parity coverage"*.

**No existing test pins either behaviour**, so changing it overrides no prior decision — there wasn't one.
The closest candidates, checked: `JvmMessageSupportTest.methodCallSend_dispatchesViaStaticRegistry` calls
`send(Duration.ZERO)` on a standalone `MethodCall()` that has no connection, and passes unchanged here
because a connection-less call keeps `0 = no timeout`; `JvmConnectionMockkTest` only round-trips a value it
set itself; `CommonApiIntegrationTest:1120` asserts `methodCallTimeout >= Duration.ZERO`, which `0s` and
`25s` both satisfy.

---

## Half 1 — `MethodCall.send(Duration.ZERO)`

**Price: `+29 / −11` of production code across two files (8 of the added lines are comment), and no
behaviour change for any code that does not already set `Connection.methodCallTimeout`.**

`MethodCall` gets an internal `connectionDefaultTimeoutMicros: () -> ULong`, defaulted to `{ 0uL }`;
`WireDbusProxy.createMethodCall` points it at the owning connection — captured into a local so the hook holds
the connection, not the proxy — read at *send* time so a `methodCallTimeout` set after the call was created
still applies (the order `Proxy.callMethod(message)` already resolves it in).

The reason this is cheap: **today the JVM connection default is `Duration.ZERO`**, so for anyone who never
touches `methodCallTimeout`, `0uL → 0uL` — bit-for-bit the behaviour shipped in 1.0.1. It only starts doing
anything for a caller who *did* set a connection default, which is exactly the caller the KDoc addresses.

### Red → green

New cross-backend test `FailurePathParityTest.rawMessageSendWithZeroTimeout_selectsConnectionDefault`
(commonTest, so it runs on `jvmTest` *and* `linuxX64Test`), two phases modelled on #181's
`explicitZeroPerCallTimeout_selectsConnectionDefault`: generous default → the ZERO send must succeed (so ZERO
is not literally zero), short default → the same send must expire (so ZERO is not "no timeout"). There is no
wall-clock assertion — the contract asserted is *which error*, through the suite's existing `assertIsTimeout`
helper (`name` contains `Timeout`/`NoReply`, or the message says "timed out").

RED on `jvmTest` before the fix, verbatim from freshly regenerated JUnit XML:

> `rawMessageSendWithZeroTimeout_selectsConnectionDefault[jvm]`
> `java.lang.AssertionError: Expected an exception of class com.monkopedia.sdbus.SdbusException to be thrown,`
> `but was completed successfully with the result: <com.monkopedia.sdbus.MethodReply@66746f57>.`

— the 100 ms connection default did not bound the call; the 600 ms handler ran to completion and returned a
reply. **Native was green on the unmodified tree** (`FailurePathParityTest[linuxX64]`: 14 tests, 0 failures;
`rawMessageSendWithZeroTimeout_selectsConnectionDefault[linuxX64]` 2.001 s), which is what makes this a JVM
defect rather than a shared design question.

The intermediate run is the useful one for separability: with **only** the half-1 commit applied, `jvmTest`
reports `14 tests completed, 1 failed` — `rawMessageSendWithZeroTimeout…` green, and only the half-2 test
still red. The halves are independently landable, in that order.

### The case FOR fixing

- The doc has said this since it was written, two other places in the API say the same (`Proxy.kt:135`,
  `Proxy.kt:178`), and #181 *actively started pointing people at `Duration.ZERO`* as the way to get the
  connection default. That makes the sentinel an advertised entry point that one backend does not implement.
- It is genuinely non-breaking today, so it does not carry half 2's compatibility problem at all.
- Without it, fixing half 2 alone produces an *internal* inconsistency inside the JVM backend:
  `proxy.callMethod(message)` would honour the connection default while `call.send(Duration.ZERO)` — the
  documented spelling of the same thing — would not.

### The case AGAINST fixing (i.e. for doc-only on this half)

- **The affected population may be empty.** On JVM this API only reaches same-process objects at all (finding
  (a)), so a caller must be using the raw message API, against an in-process object, *and* passing
  `Duration.ZERO`, *and* have set a connection default. `blue-falcon-sdbus` — the one known downstream —
  contains no reference to `methodCallTimeout`, `createMethodCall`, `.send(` or `timeout =` anywhere outside
  `build/`. A one-line doc edit serves that population identically at zero risk.
- **It adds a field and a lambda to a message class** to serve a sentinel, where the honest doc would be
  `@param timeout Call timeout; [Duration.ZERO] means no timeout on JVM and the connection default on native`
  — ugly, but ugly *and true*, and #179 was settled in exactly that direction.
- **It is a no-op unless half 2 also lands.** Shipping it alone pays a small permanent maintenance cost for a
  contract nobody can currently observe. "Correct by construction for a future that may never arrive" is a
  fair thing to be sceptical of.
- **The deeper divergence on this API is (a), not the timeout.** Making the timeout right leaves
  `MethodCall.send` still unable to reach another process on JVM. Fixing the smaller half of a two-part
  divergence can make the docs *more* misleading, not less — a reader who sees "the timeout contract was
  fixed" reasonably infers the rest of the method matches too.

---

## Half 2 — no default reply timeout on JVM

**Price: `+9 / −1` in one file — six of those lines are the comment explaining it — and it changes the
behaviour of code that touches no timeout API at all.** The ratio is the point: the smallest diff in this PR
carries all of its risk.

`WireDbusConnection.timeout` initialises to `DEFAULT_METHOD_CALL_TIMEOUT = 25.seconds` (sd-bus's
`BUS_DEFAULT_TIMEOUT_USEC`) instead of `Duration.ZERO`.

### Red → green

New cross-backend test `FailurePathParityTest.freshConnection_reportsANonZeroDefaultMethodCallTimeout`. It
asserts the *observable* contract — that a fresh connection reports a real default — rather than waiting 25 s
for one to expire, which would be a 25-second test in a suite whose other fixtures are 600 ms.

RED on `jvmTest` before the fix, verbatim:

> `freshConnection_reportsANonZeroDefaultMethodCallTimeout[jvm]`
> `java.lang.AssertionError: a fresh connection must report a real default method-call timeout, otherwise`
> `every Duration.ZERO 'use the connection default' path resolves to no timeout at all; got 0s`

Green after the fix. Native green unmodified (`[linuxX64]`, 0.0 s).

**What this test does NOT prove, stated plainly:** it pins the *value*, not an expiry. That a non-zero stored
default actually bounds a call is already pinned by the pre-existing
`connectionMethodCallTimeout_appliesToCallsWithoutExplicitTimeout` (which sets 100 ms explicitly and asserts
the call expires), so between them the chain is covered — but **no test in this diff waits out a real 25 s
default**, and I am not claiming one does. I chose that over adding a 25-second test to CI. If the owner
wants that proof it is a separate, slow test, and its cost belongs to this option's price.

### The case FOR fixing

- This is the one with a defect shape rather than a documentation shape. An unbounded wait the caller cannot
  know they opted into has no good failure mode: it presents as a hang, not an error, and the natural
  debugging path — look at the timeout you set — leads nowhere, because they set none.
- The same-process/cross-process split (unbounded vs 30 s) means the *same* JVM code changes its failure
  behaviour depending on whether the callee happens to live in this process — a distinction the public API
  deliberately hides everywhere else.
- It makes `Connection.methodCallTimeout`'s getter meaningful on JVM, which every "connection default"
  sentence in the docs, and half 1, is written against.

### The case AGAINST fixing

- **It is a behaviour change on a released 1.0.1 artifact, for code that uses no timeout API.** That is the
  widest blast radius a change here can have, and the issue says so itself. Concretely: a same-process JVM
  call whose handler legitimately takes more than 25 s **returns a value today and would start throwing
  `org.freedesktop.DBus.Error.Timeout` after this change.** #179 declined exactly that trade one layer up,
  with BlueZ's ~48 s `Device1.Connect` as the stated reason; a long-running same-process handler is the same
  animal. This spike should not pretend that reasoning stopped applying just because the layer changed.
- **It also moves the cross-process default down, 30 s → 25 s.** There is a five-second band in which a call
  that succeeds on 1.0.1 throws afterwards. Nobody asked for that; it is collateral from picking native's
  number.
- **It changes what `connection.methodCallTimeout` returns**, `0s` → `25s`. Save/restore code
  (`val old = c.methodCallTimeout; …; c.methodCallTimeout = old`) silently changes meaning, and so does any
  `if (c.methodCallTimeout == Duration.ZERO)` check.
- **It adds thread churn on the same-process raw-message path.** With a zero effective timeout, `callMethod`
  dispatches inline on the caller thread (`WireDbusBackend.kt:353`); with a non-zero one it goes through
  `callLocalDispatchWithTimeout`, which spawns a daemon thread and a `CountDownLatch` **per call**. After
  this commit `proxy.callMethod(message)` and `MethodCall.send(Duration.ZERO)` against an in-process object
  each become a thread creation. #178 in this same cluster was a *performance* defect on the timeout path, so
  a change that adds thread churn while tidying the timeout docs deserves a look before it ships.

  *Correcting myself, because I wrote the stronger version of this claim first and re-measurement killed it:*
  the **high-level** invoker path already spawns that thread today and this commit does not change it —
  `MethodInvoker.timeout` defaults to `Duration.INFINITE`, whose `inWholeMicroseconds` is `Long.MAX_VALUE`,
  so `callMethod { … }` has always reached `callLocalDispatchWithTimeout` with an effectively unbounded
  await. The new cost is confined to the raw-message overloads, not "every in-process call". (Incidental,
  unrelated to #184 and deliberately not touched here: every same-process high-level JVM call therefore
  already burns a daemon thread + latch waiting `Long.MAX_VALUE` ms. That looks worth its own issue.)
- **25 s is not reliably native's value either** (finding (c)): real parity would mean reading and parsing
  `$SYSTEMD_BUS_TIMEOUT` (systemd's `parse_sec` grammar) on the JVM side. This commit does not, so it buys
  "a default", not "the same default".
- **The honest doc alternative is cheap and available**: state the three values from the table above in
  `docs/BACKENDS.md` and on `Connection.methodCallTimeout`, and tell JVM users to set a connection default if
  they want one. That is #179's resolution applied consistently, and it breaks nobody.

---

## The third item, from the issue's comment thread

The comment on #184 adds `Connection.methodCallTimeout`'s own KDoc — *"used for all method calls upon this
connection"* — which is false on **both** backends, since `MethodInvoker.timeout` defaults to
`Duration.INFINITE` (#181) and so no `callMethod { … }` block reaches it. The last commit corrects that
sentence and the matching paragraph in `docs/BACKENDS.md`.

Caveat, since it changes what can be cherry-picked: **as written, that text describes the world after the two
fixes.** Under a doc-only verdict the same two locations need different text — the three-value table above
instead of "both backends report and apply 25 s". The *first* sentence of the correction (that this property
does not apply to all calls) is right under every verdict.

---

## Gates

- `ktlintCheck` — green.
- `apiCheck` — green, and **`api/*.api` does not move**: every changed declaration is `internal` or a KDoc.
  `api/sdbus-kotlin.klib.api`, consumed downstream by `blue-falcon-sdbus`, is untouched. Which is also the
  trap worth naming: the compatibility risk in half 2 is entirely *behavioural*, so the ABI gate cannot see
  it and its green tells the owner nothing about whether this is safe to ship.
- `dbus-run-session -- ./gradlew :jvmTest :linuxX64Test` — green on the final tree, counted from freshly
  deleted-and-regenerated JUnit XML: **`jvmTest` 333 tests / 0 skipped / 0 failures / 0 errors**,
  **`linuxX64Test` 303 / 0 / 0 / 0**. JDK 21, `dbus-run-session`.

The four commits are byte-identical in final tree to the one those numbers were measured on (`git diff`
against the tagged verified tree is empty); they were re-split afterwards so that each half can be dropped
on its own. Commit order is: tests (red on JVM) → half 1 → half 2 → docs.

## What I could not settle

- **Whether anything depends on the unbounded same-process wait.** Not answerable from this repo. The only
  downstream I can inspect (`blue-falcon-sdbus`) does not touch the timeout API — but it is also native-first,
  so its silence is weak evidence about JVM consumers.
- **The right number**, if half 2 is fixed: 25 s (native parity, breaks a 5 s band on the wire path), 30 s
  (JVM's existing wire default, no wire-path change, diverges from native), or reading `$SYSTEMD_BUS_TIMEOUT`
  (real parity, most code). This spike implements 25 s because that is the value the issue's premise names;
  that is not an argument that 25 s is right.
- **Whether the thread-churn cost is acceptable.** I flagged it from the branch it forces, not from a
  benchmark. No measurement was taken.
