### PR TITLE
test: pin sd-bus's PropertiesChanged flag contract and record the JVM divergence (Refs #193)

### DIFF
--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/PropertiesChangedFlagParityTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/PropertiesChangedFlagParityTest.kt
@@ -1,0 +1,255 @@
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.CONST_PROPERTY_VALUE
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_INVALIDATION_SIGNAL
+import com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags.EMITS_NO_SIGNAL
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertiesProxy
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.SdbusException
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.createBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.onSignal
+import com.monkopedia.sdbus.prop
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Pins what each backend puts in a `PropertiesChanged` signal for a property carrying a non-default
+ * [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags].
+ *
+ * `EmitsChangedSignal` is not introspection decoration -- it is an instruction to the emitter, and
+ * sd-bus acts on it in `emit_properties_changed_on_interface` (`bus-objects.c`) with two distinct
+ * rules, one per overload of [Object.emitPropertiesChangedSignal]:
+ *
+ * - **No explicit names** (`names == NULL`): a property flagged `EMITS_INVALIDATION` goes to the
+ *   name-only array, a property with neither `EMITS_CHANGE` nor `EMITS_INVALIDATION` is skipped,
+ *   and if that leaves nothing to say **no signal is sent at all**.
+ * - **An explicit name list**: a named property carrying neither flag is not skipped, it is
+ *   *rejected* -- `assert_return(..., -EDOM)` aborts the whole emission, so nothing is sent and
+ *   `ConnectionImpl` turns the errno into a thrown [SdbusException].
+ *
+ * Nothing in this repo verified either rule before, which is a gap #193 itself raises: its
+ * divergence table was derived from reading C rather than from a run. The JVM wire backend reads no
+ * flags at all, so it disagrees on every case here -- that divergence is recorded in
+ * [backendHonoursEmitsChangedSignalOnEmit] and pinned in both directions rather than asserted away.
+ *
+ * This test records reality and commits to nothing: closing the divergence is a breaking change
+ * that PR #231 priced and deliberately did not merge, and #193 remains open. Refs #193.
+ */
+class PropertiesChangedFlagParityTest {
+
+    private class Emission(
+        val changed: Map<PropertyName, Variant>,
+        val invalidated: List<PropertyName>
+    )
+
+    private class Fixture(
+        val obj: Object,
+        /** Carries [CHANGING], [INVALIDATING], [CONST] and [SILENT]. */
+        val mixedIface: InterfaceName,
+        /** Carries [CONST] and [SILENT] only, so nothing on it announces a change. */
+        val quietIface: InterfaceName,
+        val mixedEmission: CompletableDeferred<Emission>,
+        val quietEmission: CompletableDeferred<Emission>
+    )
+
+    /**
+     * Serves both interfaces on one object, with a proxy already subscribed to `PropertiesChanged`.
+     */
+    private suspend fun withFixture(body: suspend (Fixture) -> Unit) {
+        val id = Random.nextInt(100_000, 999_999)
+        val service = ServiceName("com.monkopedia.sdbus.pcflags$id")
+        val path = ObjectPath("/com/monkopedia/sdbus/pcflags$id")
+        val mixedIface = InterfaceName("com.monkopedia.sdbus.pcflags$id.Mixed")
+        val quietIface = InterfaceName("com.monkopedia.sdbus.pcflags$id.Quiet")
+
+        val server = createBusConnection(service)
+        val client = createBusConnection()
+        val obj = createObject(server, path)
+        val mixedReg = obj.addVTable(mixedIface) {
+            prop(CHANGING) { withGetter { 1 } }
+            prop(INVALIDATING) {
+                +EMITS_INVALIDATION_SIGNAL
+                withGetter { 2 }
+            }
+            prop(CONST) {
+                +CONST_PROPERTY_VALUE
+                withGetter { 3 }
+            }
+            prop(SILENT) {
+                +EMITS_NO_SIGNAL
+                withGetter { 4 }
+            }
+        }
+        val quietReg = obj.addVTable(quietIface) {
+            prop(CONST) {
+                +CONST_PROPERTY_VALUE
+                withGetter { 5 }
+            }
+            prop(SILENT) {
+                +EMITS_NO_SIGNAL
+                withGetter { 6 }
+            }
+        }
+        server.startEventLoop()
+        client.startEventLoop()
+        val proxy = createProxy(client, service, path)
+
+        val mixed = CompletableDeferred<Emission>()
+        val quiet = CompletableDeferred<Emission>()
+        val sigReg = proxy.onSignal(
+            PropertiesProxy.INTERFACE_NAME,
+            SignalName("PropertiesChanged")
+        ) {
+            call {
+                    changedInterface: InterfaceName,
+                    changed: Map<PropertyName, Variant>,
+                    invalidated: List<PropertyName>
+                ->
+                val emission = Emission(changed, invalidated)
+                if (changedInterface == mixedIface) mixed.complete(emission)
+                if (changedInterface == quietIface) quiet.complete(emission)
+            }
+        }
+
+        try {
+            body(Fixture(obj, mixedIface, quietIface, mixed, quiet))
+        } finally {
+            sigReg.release()
+            quietReg.release()
+            mixedReg.release()
+            proxy.release()
+            obj.release()
+            client.stopEventLoop()
+            server.stopEventLoop()
+            client.release()
+            server.release()
+        }
+    }
+
+    @Test
+    fun noArgEmissionSkipsSilentPropertiesOnlyWhereTheBackendHonoursTheFlags() = runBlocking {
+        withFixture { fixture ->
+            fixture.obj.emitPropertiesChangedSignal(fixture.mixedIface)
+
+            val emission = withTimeout(5_000) { fixture.mixedEmission.await() }
+            if (backendHonoursEmitsChangedSignalOnEmit) {
+                assertEquals(setOf(CHANGING), emission.changed.keys, "changed_properties")
+                assertEquals(1, emission.changed.getValue(CHANGING).get<Int>())
+                assertEquals(listOf(INVALIDATING), emission.invalidated, "invalidated_properties")
+            } else {
+                assertEquals(
+                    setOf(CHANGING, INVALIDATING, CONST, SILENT),
+                    emission.changed.keys,
+                    "changed_properties"
+                )
+                assertEquals(2, emission.changed.getValue(INVALIDATING).get<Int>())
+                assertEquals(emptyList(), emission.invalidated, "invalidated_properties")
+            }
+        }
+    }
+
+    @Test
+    fun noArgEmissionSendsNothingAtAllWhereTheBackendHonoursTheFlags() = runBlocking {
+        withFixture { fixture ->
+            // Nothing on quietIface announces a change, so sd-bus's names==NULL path leaves the
+            // message empty and returns without sending it. Emitting on mixedIface afterwards is
+            // the sentinel: both backends send that one, and the daemon preserves per-sender order,
+            // so its arrival proves the quiet emission is never coming rather than merely late.
+            fixture.obj.emitPropertiesChangedSignal(fixture.quietIface)
+            fixture.obj.emitPropertiesChangedSignal(fixture.mixedIface)
+
+            withTimeout(5_000) { fixture.mixedEmission.await() }
+            if (backendHonoursEmitsChangedSignalOnEmit) {
+                assertFalse(
+                    fixture.quietEmission.isCompleted,
+                    "PropertiesChanged for an interface with nothing to announce"
+                )
+            } else {
+                val emission = withTimeout(5_000) { fixture.quietEmission.await() }
+                assertEquals(setOf(CONST, SILENT), emission.changed.keys, "changed_properties")
+                assertEquals(emptyList(), emission.invalidated, "invalidated_properties")
+            }
+        }
+    }
+
+    @Test
+    fun namedEmissionOfAnInvalidatingPropertyIsNameOnlyWhereTheBackendHonoursTheFlags() =
+        runBlocking {
+            withFixture { fixture ->
+                fixture.obj.emitPropertiesChangedSignal(fixture.mixedIface, listOf(INVALIDATING))
+
+                val emission = withTimeout(5_000) { fixture.mixedEmission.await() }
+                if (backendHonoursEmitsChangedSignalOnEmit) {
+                    assertEquals(emptySet(), emission.changed.keys, "changed_properties")
+                    assertEquals(
+                        listOf(INVALIDATING),
+                        emission.invalidated,
+                        "invalidated_properties"
+                    )
+                } else {
+                    assertEquals(setOf(INVALIDATING), emission.changed.keys, "changed_properties")
+                    assertEquals(2, emission.changed.getValue(INVALIDATING).get<Int>())
+                    assertEquals(emptyList(), emission.invalidated, "invalidated_properties")
+                }
+            }
+        }
+
+    @Test
+    fun namedEmissionOfAConstPropertyIsRejectedOnlyWhereTheBackendHonoursTheFlags() = runBlocking {
+        withFixture { fixture ->
+            assertNamedEmissionIsRejected(fixture, CONST, valueIfEmitted = 3)
+        }
+    }
+
+    @Test
+    fun namedEmissionOfASilentPropertyIsRejectedOnlyWhereTheBackendHonoursTheFlags() = runBlocking {
+        withFixture { fixture ->
+            assertNamedEmissionIsRejected(fixture, SILENT, valueIfEmitted = 4)
+        }
+    }
+
+    /**
+     * The named path rejects rather than skips, so on a backend honouring the flags the call throws
+     * and nothing reaches the bus; elsewhere the property is emitted with its current value.
+     */
+    private suspend fun assertNamedEmissionIsRejected(
+        fixture: Fixture,
+        property: PropertyName,
+        valueIfEmitted: Int
+    ) {
+        if (backendHonoursEmitsChangedSignalOnEmit) {
+            assertFailsWith<SdbusException> {
+                fixture.obj.emitPropertiesChangedSignal(fixture.mixedIface, listOf(property))
+            }
+        } else {
+            fixture.obj.emitPropertiesChangedSignal(fixture.mixedIface, listOf(property))
+
+            val emission = withTimeout(5_000) { fixture.mixedEmission.await() }
+            assertEquals(setOf(property), emission.changed.keys, "changed_properties")
+            assertEquals(valueIfEmitted, emission.changed.getValue(property).get<Int>())
+            assertEquals(emptyList(), emission.invalidated, "invalidated_properties")
+        }
+    }
+
+    private companion object {
+        val CHANGING = PropertyName("Changing")
+        val INVALIDATING = PropertyName("Invalidating")
+        val CONST = PropertyName("Const")
+        val SILENT = PropertyName("Silent")
+    }
+}

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.kt
@@ -40,3 +40,23 @@ internal expect val backendServesEmitsChangedSignal: Boolean
  * `false` -- both did until #197. Measured by [VtableFlagIntrospectionTest].
  */
 internal expect val backendServesMethodNoReply: Boolean
+
+/**
+ * Whether the active backend applies a property's
+ * [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags] when it builds the `PropertiesChanged`
+ * payload -- skipping properties that announce no change, putting `invalidates` properties in the
+ * name-only array, and rejecting an explicitly named property that announces neither.
+ *
+ * **This flag records an OPEN DECISION on #193, not an accepted limitation.** Unlike the
+ * `backendServes*` flags above -- introspection metadata, where each backend's answer is simply
+ * what it is -- this is the signal payload a client consumes, and the two backends give different
+ * answers to the same question. Which one is right has not been decided: matching native would
+ * silently stop broadcasts for `const`/`false` properties and make an ordinary assignment through
+ * the `Object.notifying` delegate throw, on a released artifact, so PR #231 priced that change and
+ * did not merge it. #193 stays open until the owner rules.
+ *
+ * So do not read `false` as "fine on JVM" or `true` as "settled in native's favour". Whoever
+ * closes #193 flips an `actual` or deletes the flag; until then [PropertiesChangedFlagParityTest]
+ * pins both sides so neither can move unobserved.
+ */
+internal expect val backendHonoursEmitsChangedSignalOnEmit: Boolean

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/TestBackendCapabilities.jvm.kt
@@ -13,3 +13,8 @@ internal actual val backendServesEmitsChangedSignal: Boolean = false
 
 // Same reason: hasNoReply drives the reply-suppression path only, never the introspection XML.
 internal actual val backendServesMethodNoReply: Boolean = false
+
+// KNOWN JVM/NATIVE DIVERGENCE, #193 -- OPEN, not an accepted limitation (see the expect
+// declaration). WireDbusObject reads no PropertyUpdateBehaviorFlags, so every property is emitted
+// with its current value whichever flags it carries, and nothing is ever rejected.
+internal actual val backendHonoursEmitsChangedSignalOnEmit: Boolean = false

--- a/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
+++ b/src/nativeTest/kotlin/integration/TestBackendCapabilities.native.kt
@@ -13,3 +13,9 @@ internal actual val backendServesEmitsChangedSignal: Boolean = true
 // sd-bus writes org.freedesktop.DBus.Method.NoReply for SD_BUS_VTABLE_METHOD_NO_REPLY. Until #197
 // that bit never reached it: Flags.toSdBusMethodFlags OR-ed the branch with a literal 0u.
 internal actual val backendServesMethodNoReply: Boolean = true
+
+// sd-bus applies the emit bits in emit_properties_changed_on_interface (bus-objects.c): the
+// names==NULL path skips anything without EMITS_CHANGE and sends nothing when that empties the
+// message, and the explicit-name path assert_returns -EDOM instead of skipping. Refs #193 (OPEN --
+// see the expect declaration; this is sd-bus's contract, not a ruling on which backend is right).
+internal actual val backendHonoursEmitsChangedSignalOnEmit: Boolean = true


### PR DESCRIPTION
**Test-only. `Refs #193` — this records reality and commits to nothing.** No file under
`src/jvmMain/**` or `src/nativeMain/**` moves; #193 stays open; #231 stays a draft.

This is **option 4** from #231 §5e — the one that spike surfaced and recommended *over* merging its
own production change. #231 priced making the JVM `PropertiesChanged` emitter honour property flags
and concluded **do not merge**: the change is breaking twice over (it silently drops broadcasts for
`const`/`false` properties, and it makes `Object.notifying()` throw `SdbusException` from an ordinary
Kotlin assignment via the list overload's `-EDOM`). That decision is the owner's and is untouched
here.

What stands independently of it is #231's test: **native already implements sd-bus's real contract
and nothing in this repo verified that** — a gap #193's own closing section complains about. So the
test lands; the fix does not.

---

## 1. What sd-bus actually does — re-derived, not taken on #231's word

`emit_properties_changed_on_interface`, `src/libsystemd/sd-bus/bus-objects.c`, checked against
**systemd v257** (line numbers below are that file; #231 quoted v261, and the two agree):

**Path A — `names == NULL`** (the no-argument overload). *Skip:*

```c
if (v->flags & SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION) { has_invalidating = true; continue; }
if (!(v->flags & SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE))    continue;   /* :2179 */
```

…and if that leaves nothing to say, **no signal is sent at all**:

```c
if (!has_invalidating && !has_changing)   /* :2193 */
        return 0;
```

**Path B — an explicit name list.** ***Reject, not skip:***

```c
assert_return(v->vtable->flags & SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE ||
              v->vtable->flags & SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION, -EDOM);   /* :2141 */
```

`assert_return` *returns*; `-EDOM` propagates out of `sd_bus_emit_properties_changed_strv`, and
`ConnectionImpl.kt:631`'s `sdbusRequire(r < 0, …, -r)` turns it into a thrown `SdbusException`.
**Nothing is sent** — not even the named properties that would have been fine.

Our two overloads map onto those two paths: `emitPropertiesChangedSignal(iface)` → `emptyList()` →
`names = null` → Path A; `emitPropertiesChangedSignal(iface, listOf(…))` → Path B.

## 2. The test

One new file, `src/commonTest/…/integration/PropertiesChangedFlagParityTest.kt`, run on both
targets. It serves two interfaces on one object — a *mixed* one carrying a default, an
`invalidates`, a `const` and a `false` property, and a *quiet* one carrying only `const` + `false` —
and pins five cases:

| Test | Native (flag `true`) | JVM (flag `false`) |
| --- | --- | --- |
| `noArgEmissionSkipsSilentPropertiesOnlyWhereTheBackendHonoursTheFlags` | `changed = {Changing}`, `invalidated = [Invalidating]` | `changed = {Changing, Invalidating, Const, Silent}` with values, `invalidated = []` |
| `noArgEmissionSendsNothingAtAllWhereTheBackendHonoursTheFlags` | **no signal at all** for the quiet interface | a signal carrying `{Const, Silent}` |
| `namedEmissionOfAnInvalidatingPropertyIsNameOnlyWhereTheBackendHonoursTheFlags` | `changed = {}`, `invalidated = [Invalidating]` | `changed = {Invalidating}` with its value |
| `namedEmissionOfAConstPropertyIsRejectedOnlyWhereTheBackendHonoursTheFlags` | throws `SdbusException` | succeeds, emits `{Const}` |
| `namedEmissionOfASilentPropertyIsRejectedOnlyWhereTheBackendHonoursTheFlags` | throws `SdbusException` | succeeds, emits `{Silent}` |

Two notes on how it is written:

- **The "no signal at all" case needs a negative, so it uses an ordering sentinel** rather than a
  sleep: emit on the quiet interface, then on the mixed one, wait for the *mixed* signal, and assert
  the quiet deferred is still incomplete. The daemon preserves per-sender ordering, so the sentinel's
  arrival proves the quiet emission is never coming rather than merely late.
- **Both branches assert; neither is weakened.** The `false` branch is not a skip — it pins what the
  JVM backend does *today*, so the divergence cannot change unobserved in either direction.

## 3. The capability flag, and its provenance

The JVM divergence is recorded with the repo's existing mechanism (#141/#213), as one new
`expect val` in `TestBackendCapabilities`. Per #230 — flags that cite nothing are indistinguishable
from encoded bugs — it names the issue **and** says explicitly that the divergence is undecided:

```kotlin
/**
 * Whether the active backend applies a property's
 * [com.monkopedia.sdbus.Flags.PropertyUpdateBehaviorFlags] when it builds the `PropertiesChanged`
 * payload -- skipping properties that announce no change, putting `invalidates` properties in the
 * name-only array, and rejecting an explicitly named property that announces neither.
 *
 * **This flag records an OPEN DECISION on #193, not an accepted limitation.** Unlike the
 * `backendServes*` flags above -- introspection metadata, where each backend's answer is simply
 * what it is -- this is the signal payload a client consumes, and the two backends give different
 * answers to the same question. Which one is right has not been decided: matching native would
 * silently stop broadcasts for `const`/`false` properties and make an ordinary assignment through
 * the `Object.notifying` delegate throw, on a released artifact, so PR #231 priced that change and
 * did not merge it. #193 stays open until the owner rules.
 *
 * So do not read `false` as "fine on JVM" or `true` as "settled in native's favour". Whoever
 * closes #193 flips an `actual` or deletes the flag; until then [PropertiesChangedFlagParityTest]
 * pins both sides so neither can move unobserved.
 */
internal expect val backendHonoursEmitsChangedSignalOnEmit: Boolean
```

The two `actual`s carry the same provenance — native cites `bus-objects.c` and marks #193 OPEN; JVM
opens with `KNOWN JVM/NATIVE DIVERGENCE, #193 -- OPEN, not an accepted limitation`, matching the
house style of `peerErrorNameMappingSupported`'s `KNOWN JVM BACKEND BUG` (#72).

No second mechanism was invented, and no `backendServes*` flag was touched.

## 4. Evidence

All runs under `dbus-run-session`, `JAVA_HOME=/usr/lib/jvm/java-21-openjdk`, each preceded by
`find . -type d -name test-results -prune -exec rm -rf {} +`. `BUILD SUCCESSFUL` is not the evidence;
counts come from the fresh JUnit XML.

### GREEN — full suites, both targets, `9ca8c3a` + this commit

| Run | Result |
| --- | --- |
| `:jvmTest` | **38 XML files — 336 tests, 0 failures, 0 errors, 0 skipped** |
| `:linuxX64Test` | **30 XML files — 306 tests, 0 failures, 0 errors, 0 skipped** |
| `ktlintCheck` + `apiCheck` | exit 0; `git status api/` and `git diff --stat api/` both empty |

The new suite is 5 tests on each target:

```
<testsuite name="PropertiesChangedFlagParityTest[jvm]" tests="5" skipped="0" failures="0" errors="0"
<testsuite name="linuxX64Test.…PropertiesChangedFlagParityTest" tests="5" skipped="0" failures="0" errors="0"
```

Reproduced independently on a second host (adolin, fresh clone of this branch): `BUILD SUCCESSFUL`,
`jvmTest 38 XML / 336 tests / 0 failures`, `linuxX64Test 30 XML / 306 tests / 0 failures`.

### The native pin can fail — negative control (#216's precedent)

A pin that cannot go red is the defect #219/#227 spent this week removing, so it was made to fail:
**invert the native `actual` to `false`** (i.e. claim native does not honour the flags) and the whole
suite goes red — **5 tests, 5 failures, 0 errors, 0 skipped** — with each failure quoting sd-bus's
real behaviour:

| Test | `<failure message=…>` |
| --- | --- |
| `noArgEmissionSkipsSilentPropertiesOnlyWhereTheBackendHonoursTheFlags` | `kotlin.AssertionError: changed_properties. Expected <[Changing, Invalidating, Const, Silent]>, actual <[Changing]>.` |
| `noArgEmissionSendsNothingAtAllWhereTheBackendHonoursTheFlags` | `kotlinx.coroutines.TimeoutCancellationException: Timed out waiting for 5000 ms` — the quiet interface's signal never arrives, because sd-bus never sent one |
| `namedEmissionOfAnInvalidatingPropertyIsNameOnlyWhereTheBackendHonoursTheFlags` | `kotlin.AssertionError: changed_properties. Expected <[Invalidating]>, actual <[]>.` |
| `namedEmissionOfAConstPropertyIsRejectedOnlyWhereTheBackendHonoursTheFlags` | `com.monkopedia.sdbus.SdbusException: System.Error.EDOM: Failed to emit PropertiesChanged signal (Numerical argument out of domain)` |
| `namedEmissionOfASilentPropertyIsRejectedOnlyWhereTheBackendHonoursTheFlags` | `com.monkopedia.sdbus.SdbusException: System.Error.EDOM: Failed to emit PropertiesChanged signal (Numerical argument out of domain)` |

Those last two are the `-EDOM` of §1 arriving at a Kotlin caller, verbatim, from a live sd-bus. The
flag was restored afterwards and `git status --porcelain` came back empty.

### No production change

```
 .../integration/PropertiesChangedFlagParityTest.kt | 255 +++++++++++++++++++++
 .../sdbus/integration/TestBackendCapabilities.kt   |  20 ++
 .../integration/TestBackendCapabilities.jvm.kt     |   5 +
 .../integration/TestBackendCapabilities.native.kt  |   6 +
 4 files changed, 286 insertions(+)
```

`git diff --name-only 9ca8c3a | grep Main/` → empty. Nothing under `src/jvmMain/**` or
`src/nativeMain/**`, no deletions anywhere, and `api/*.api` unchanged.

## 5. What this deliberately does NOT do

- **No production change**, on either backend.
- **No `docs/BACKENDS.md` edit.** Line 35 currently marks `PropertiesChanged` emission ✅/✅, which
  is now demonstrably incomplete — but amending it is #193's *option 1* ("document and freeze"), and
  choosing option 1 is the owner's call, not a side effect of landing a test. Left for whoever
  settles #193.
- **No claim about which backend is right.** The test pins both; the flag says so in as many words.

Refs #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
