### PR TITLE
SPIKE / DO NOT MERGE: price the direct-connection sender-credential fix (Refs #199)

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
@@ -284,6 +284,12 @@ expect fun createSessionBusConnection(address: String): Connection
 /**
  * Opens direct D-Bus connection at a custom address
  *
+ * A direct connection is **brokerless**: there is no `dbus-daemon` behind it, so nothing stamps
+ * the `sender` field of an incoming message — the single peer on the other end writes whatever it
+ * likes there. Treat the sender of anything received over a direct connection as unverified, and
+ * do not base an authorization decision on it or on [Message]'s `creds*` accessors, which report
+ * no credentials on this transport.
+ *
  * @param address ";"-separated list of addresses of bus brokers to try to connect to
  * @return [Connection] instance
  *

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -182,25 +182,34 @@ expect sealed class Message {
      */
     fun rewind(complete: Boolean)
 
-    /** The PID of the sending process, if credentials are available. */
+    /**
+     * The PID of the sending process.
+     *
+     * Sender credentials are only meaningful when something authoritative attached them. On a
+     * brokered bus the daemon stamps the sender and the credentials describe it; on a **brokerless
+     * direct connection there is no daemon**, the `sender` field is chosen by the peer, and no
+     * credentials are reported at all. Reading this — or any other `creds*` accessor — throws when
+     * credentials are unavailable, so an authorization check must be prepared for that rather than
+     * assume a value is always there.
+     */
     val credsPid: Int
 
-    /** The real UID of the sender, if credentials are available. */
+    /** The real UID of the sender. Unavailable in the same cases as [credsPid]. */
     val credsUid: UInt
 
-    /** The effective UID of the sender, if credentials are available. */
+    /** The effective UID of the sender. Unavailable in the same cases as [credsPid]. */
     val credsEuid: UInt
 
-    /** The real GID of the sender, if credentials are available. */
+    /** The real GID of the sender. Unavailable in the same cases as [credsPid]. */
     val credsGid: UInt
 
-    /** The effective GID of the sender, if credentials are available. */
+    /** The effective GID of the sender. Unavailable in the same cases as [credsPid]. */
     val credsEgid: UInt
 
-    /** The supplementary GIDs of the sender, if credentials are available. */
+    /** The supplementary GIDs of the sender. Unavailable in the same cases as [credsPid]. */
     val credsSupplementaryGids: List<UInt>
 
-    /** The SELinux security context of the sender. */
+    /** The SELinux security context of the sender. Unavailable in the same cases as [credsPid]. */
     val seLinuxContext: String
 }
 

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -98,8 +98,12 @@ internal class DBusWireConnection private constructor(
      * unique name), no `RequestName`/`ReleaseName`, no `AddMatch`/`RemoveMatch`/`GetNameOwner`.
      * Method calls, replies and signals flow straight to/from the single peer on the other end of
      * the socket. Mirrors sd-bus direct mode and dbus-java's DirectConnection (epic #93 phase 6).
+     *
+     * Consequence for identity: with no daemon, NOTHING stamps the `sender` field of an incoming
+     * frame — the peer writes whatever it likes there. Anything that derives an identity from
+     * `sender` must therefore treat it as unverified on a direct connection (#199).
      */
-    private val direct: Boolean = false
+    internal val direct: Boolean = false
 ) : Closeable {
 
     private val input: InputStream = BufferedInputStream(socket.inputStream)

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -50,7 +50,8 @@ import kotlin.time.Duration
  *   [installSignalMatch] over its own socket, so each signal is delivered exactly once. The
  *   in-process [LocalJvmSignalBus]/[LocalJvmMatchBus] is NOT used on this backend -- it stays the
  *   dbus-java backend's same-process mechanism. Sender credentials of a signal from one of our own
- *   connections are filled from the local process ([withLocalSenderCredentials]);
+ *   connections are filled from the local process ([withLocalSenderCredentials]) -- on BROKERED
+ *   connections only, since a brokerless peer picks its own `sender` (#199);
  * - what stays DEFERRED is incoming method-call SERVING over the wire (phase 4).
  */
 internal class WireDbusBackend : JvmDbusBackend {
@@ -765,7 +766,7 @@ private fun installSignalMatch(
                 destination = wireMessage.destination,
                 valid = true,
                 empty = wireMessage.body.isEmpty()
-            ).withLocalSenderCredentials(wireMessage.sender)
+            ).withLocalSenderCredentials(wire, wireMessage.sender)
         )
         signal.payload.addAll(fromWireReplyValues(wireMessage.body, wireMessage.signature))
         JvmCurrentMessageContext.withMessage(signal) { callback(signal) }
@@ -789,9 +790,10 @@ private data class WireSenderCredentials(
 )
 
 // Credentials of THIS process, used for senders that are one of our own connections (resolved via
-// LocalJvmServiceRegistry). A signal that traversed the bus carries the authoritative sender (the
-// bus stamps it), and for a same-process sender that is this very process -- so reporting the local
-// process credentials is correct and matches the dbus-java backend's local short-circuit
+// LocalJvmServiceRegistry) on a BROKERED connection. A signal that traversed the bus carries the
+// authoritative sender (the bus stamps it), and for a same-process sender that is this very
+// process -- so reporting the local process credentials is correct and matches the dbus-java
+// backend's local short-circuit
 // (resolveSenderCredentials -> localProcessCredentialsOrNull). Credentials of an EXTERNAL sender
 // would require a GetConnectionCredentials bus call, which cannot run on the reader thread that
 // delivers signals without deadlocking; no test needs it, so it is intentionally left out here.
@@ -812,7 +814,15 @@ private val localProcessWireCredentials: WireSenderCredentials by lazy {
     )
 }
 
-private fun Message.Metadata.withLocalSenderCredentials(sender: String?): Message.Metadata {
+private fun Message.Metadata.withLocalSenderCredentials(
+    wire: DBusWireConnection,
+    sender: String?
+): Message.Metadata {
+    // On a brokerless DIRECT connection no daemon stamps `sender`: it is an attribute the peer
+    // chooses, so "this name resolves to one of our connections" says nothing about who sent the
+    // frame. Report no credentials rather than this process's. Absent is honest; wrong is not
+    // (#199).
+    if (wire.direct) return this
     val senderName = sender?.takeIf { it.isNotBlank() } ?: return this
     if (LocalJvmServiceRegistry.resolveLocalUniqueName(senderName) == null) return this
     val creds = localProcessWireCredentials

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDirectSenderCredentialsTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/internal/jvmdbus/JvmDirectSenderCredentialsTest.kt
@@ -1,0 +1,174 @@
+package com.monkopedia.sdbus.internal.jvmdbus
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.Message
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.createDirectBusConnection
+import java.io.Closeable
+import java.io.IOException
+import java.io.OutputStream
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * On a brokerless DIRECT connection nothing stamps the `sender` field: there is no daemon, so the
+ * value is whatever the peer put in the frame. The credential accessors must therefore report
+ * *no* credentials for such a message rather than the credentials of some locally-known name the
+ * sender string happens to equal. Correctness contract for #199.
+ */
+class JvmDirectSenderCredentialsTest {
+
+    @Test
+    fun credentialsAreAbsentForAPeerSuppliedSenderOnADirectConnection() {
+        val iface = InterfaceName("com.monkopedia.sdbus.spike.Iface")
+        val member = "Ping"
+        val path = "/com/monkopedia/sdbus/spike"
+        val wellKnown = ServiceName("com.monkopedia.sdbus.spike.Service")
+
+        val localUid = com.sun.security.auth.module.UnixSystem().uid.toUInt()
+
+        DirectSignalPeer().use { peer ->
+            val connection = createDirectBusConnection(peer.address)
+            // In direct mode RequestName is synthesized as PRIMARY_OWNER, which is what publishes
+            // the well-known name into the process-wide local-name registry.
+            connection.requestName(wellKnown)
+
+            val delivered = CountDownLatch(1)
+            val reportedUid = AtomicReference<UInt?>(null)
+            val reportedPid = AtomicReference<Int?>(null)
+
+            val match = connection.addMatch(
+                "type='signal',interface='${iface.value}',member='$member'"
+            ) { message: Message ->
+                reportedUid.set(runCatching { message.credsUid }.getOrNull())
+                reportedPid.set(runCatching { message.credsPid }.getOrNull())
+                delivered.countDown()
+            }
+
+            try {
+                peer.awaitConnected()
+                peer.emit(
+                    WireMessage(
+                        type = WireMessageType.SIGNAL,
+                        serial = 1,
+                        path = path,
+                        interfaceName = iface.value,
+                        member = member,
+                        // The peer picks this freely — no daemon rewrites it on a direct socket.
+                        sender = wellKnown.value,
+                        signature = "",
+                        body = emptyList()
+                    )
+                )
+                assertTrue(
+                    delivered.await(10, TimeUnit.SECONDS),
+                    "the signal was never delivered to the match handler"
+                )
+
+                assertNull(
+                    reportedUid.get(),
+                    "Message.credsUid reported ${reportedUid.get()} for a signal on a DIRECT " +
+                        "connection whose sender field was supplied by the peer; this JVM " +
+                        "process runs as uid $localUid. A direct connection has no authoritative " +
+                        "sender, so no uid should be reported at all."
+                )
+                assertNull(
+                    reportedPid.get(),
+                    "Message.credsPid reported ${reportedPid.get()} for a peer-supplied sender " +
+                        "on a DIRECT connection; this JVM process is pid " +
+                        "${ProcessHandle.current().pid()}."
+                )
+            } finally {
+                match.release()
+                connection.release()
+            }
+        }
+    }
+}
+
+/**
+ * A minimal brokerless D-Bus peer: an AF_UNIX listener that completes the SASL EXTERNAL handshake
+ * and can then push arbitrary frames down the socket. Same shape as the peer in
+ * `JvmDirectConnectionIdentityTest`, plus [emit].
+ */
+private class DirectSignalPeer : Closeable {
+    private val directory: Path = Files.createTempDirectory("sdbus-direct-creds")
+    private val socketPath: Path = directory.resolve("peer")
+    private val listener: ServerSocketChannel =
+        ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            .apply { bind(UnixDomainSocketAddress.of(socketPath)) }
+    private val connected = CountDownLatch(1)
+    private val stream = AtomicReference<OutputStream?>(null)
+
+    val address: String = "unix:path=$socketPath"
+
+    private val acceptor = thread(start = true, isDaemon = true, name = "sdbus-spike-direct-peer") {
+        while (true) {
+            val channel = try {
+                listener.accept()
+            } catch (_: IOException) {
+                return@thread
+            }
+            thread(start = true, isDaemon = true, name = "sdbus-spike-direct-peer-sasl") {
+                runCatching { handshake(channel) }
+            }
+        }
+    }
+
+    fun awaitConnected() {
+        check(connected.await(10, TimeUnit.SECONDS)) { "peer handshake did not complete" }
+    }
+
+    fun emit(message: WireMessage) {
+        val output = checkNotNull(stream.get()) { "peer is not connected" }
+        synchronized(this) {
+            output.write(WireMessageCodec.encode(message))
+            output.flush()
+        }
+    }
+
+    private fun handshake(channel: SocketChannel) {
+        val input = Channels.newInputStream(channel)
+        val output = Channels.newOutputStream(channel)
+        fun readLine(): String = buildString {
+            while (!endsWith("\r\n")) {
+                val c = input.read()
+                if (c < 0) return@buildString
+                append(c.toChar())
+            }
+        }.removeSuffix("\r\n")
+        fun writeLine(line: String) {
+            output.write("$line\r\n".toByteArray(StandardCharsets.US_ASCII))
+            output.flush()
+        }
+
+        input.read() // the mandatory leading NUL
+        readLine() // AUTH EXTERNAL <uid>
+        writeLine("OK 0123456789abcdef0123456789abcdef")
+        readLine() // NEGOTIATE_UNIX_FD
+        writeLine("AGREE_UNIX_FD")
+        readLine() // BEGIN
+        stream.set(output)
+        connected.countDown()
+    }
+
+    override fun close() {
+        runCatching { listener.close() }
+        acceptor.join(1_000)
+        runCatching { Files.deleteIfExists(socketPath) }
+        runCatching { Files.deleteIfExists(directory) }
+    }
+}

--- a/src/nativeTest/kotlin/integration/NativeDirectSenderCredentialsProbe.kt
+++ b/src/nativeTest/kotlin/integration/NativeDirectSenderCredentialsProbe.kt
@@ -1,0 +1,130 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.monkopedia.sdbus.integration
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.MethodName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.UnixFd
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.callMethod
+import com.monkopedia.sdbus.createDirectBusConnection
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.createServerBusConnection
+import com.monkopedia.sdbus.method
+import kotlin.test.Test
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.cValue
+import kotlinx.cinterop.cstr
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.runBlocking
+import platform.linux.sockaddr_un
+import platform.posix.AF_UNIX
+import platform.posix.F_SETFD
+import platform.posix.SOCK_CLOEXEC
+import platform.posix.SOCK_STREAM
+import platform.posix.accept
+import platform.posix.bind
+import platform.posix.fcntl
+import platform.posix.getpid
+import platform.posix.getuid
+import platform.posix.listen
+import platform.posix.memset
+import platform.posix.sa_family_tVar
+import platform.posix.snprintf
+import platform.posix.socket
+import platform.posix.umask
+import platform.posix.unlink
+
+/**
+ * PROBE (not a contract assertion): reports what the NATIVE backend does with sender credentials on
+ * a brokerless direct connection, so #199's JVM finding can be compared against it. Prints its
+ * measurements; asserts nothing about the values.
+ */
+class NativeDirectSenderCredentialsProbe {
+
+    @Test
+    fun reportNativeDirectConnectionSenderCredentials() {
+        val socketPath = "/tmp/sdbus-kotlin-199-probe.sock"
+        val path = ObjectPath("/com/monkopedia/sdbus/probe199")
+        val iface = InterfaceName("com.monkopedia.sdbus.probe199.Iface")
+        val member = MethodName("Ping")
+
+        val listenFd = openUnixSocket(socketPath)
+        val context = newFixedThreadPoolContext(4, "probe199")
+
+        var observedSender: String? = "<not-run>"
+        var uidOutcome = "<not-run>"
+        var pidOutcome = "<not-run>"
+
+        runBlocking {
+            var server: com.monkopedia.sdbus.Connection? = null
+            val accepting = launch(context) {
+                val fd = accept(listenFd, null, null)
+                fcntl(fd, F_SETFD, SOCK_CLOEXEC)
+                server = createServerBusConnection(UnixFd.adopt(fd))
+                server?.startEventLoop()
+            }
+            val client = createDirectBusConnection("unix:path=$socketPath")
+            client.startEventLoop()
+            accepting.join()
+
+            val serverConnection = server!!
+            val obj = createObject(serverConnection, path)
+            val registration = obj.addVTable(iface) {
+                method(member) {
+                    call { token: Int ->
+                        val message = obj.currentlyProcessedMessage
+                        observedSender = message.sender?.value
+                        uidOutcome = runCatching { message.credsUid.toString() }
+                            .getOrElse { "THREW: ${it.message}" }
+                        pidOutcome = runCatching { message.credsPid.toString() }
+                            .getOrElse { "THREW: ${it.message}" }
+                        token
+                    }
+                }
+            }
+            val proxy = createProxy(client, EMPTY_DESTINATION, path, runEventLoopThread = false)
+            try {
+                proxy.callMethod<Int>(iface, member) { call(7) }
+            } finally {
+                registration.release()
+                proxy.release()
+                obj.release()
+                serverConnection.stopEventLoop()
+                client.stopEventLoop()
+                client.release()
+                serverConnection.release()
+            }
+        }
+        context.close()
+        unlink(socketPath)
+
+        println("PROBE199 process uid=${getuid()} pid=${getpid()}")
+        println("PROBE199 incoming direct-connection message sender=$observedSender")
+        println("PROBE199 credsUid=$uidOutcome")
+        println("PROBE199 credsPid=$pidOutcome")
+    }
+
+    private fun openUnixSocket(socketPath: String): Int = memScoped {
+        val sock = socket(AF_UNIX, SOCK_STREAM or SOCK_CLOEXEC, 0)
+        require(sock >= 0) { "Create socket failed" }
+        val sa = cValue<sockaddr_un>().getPointer(this)
+        memset(sa, 0, sizeOf<sockaddr_un>().convert())
+        sa[0].sun_family = AF_UNIX.convert()
+        val size = sizeOf<sockaddr_un>() - sizeOf<sa_family_tVar>()
+        snprintf(sa[0].sun_path, size.convert(), "%s", socketPath.cstr)
+        unlink(socketPath)
+        umask(0u)
+        require(bind(sock, sa.reinterpret(), sizeOf<sockaddr_un>().convert()) >= 0) { "Bind failed" }
+        require(listen(sock, 5) >= 0) { "Listen failed" }
+        return sock
+    }
+}

--- a/src/nativeTest/kotlin/integration/NativeDirectSenderCredentialsProbe.kt
+++ b/src/nativeTest/kotlin/integration/NativeDirectSenderCredentialsProbe.kt
@@ -15,8 +15,8 @@ import com.monkopedia.sdbus.createServerBusConnection
 import com.monkopedia.sdbus.method
 import kotlin.test.Test
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.convert
 import kotlinx.cinterop.cValue
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.cstr
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
@@ -123,7 +123,8 @@ class NativeDirectSenderCredentialsProbe {
         snprintf(sa[0].sun_path, size.convert(), "%s", socketPath.cstr)
         unlink(socketPath)
         umask(0u)
-        require(bind(sock, sa.reinterpret(), sizeOf<sockaddr_un>().convert()) >= 0) { "Bind failed" }
+        val bound = bind(sock, sa.reinterpret(), sizeOf<sockaddr_un>().convert())
+        require(bound >= 0) { "Bind failed" }
         require(listen(sock, 5) >= 0) { "Listen failed" }
         return sock
     }


### PR DESCRIPTION
**SPIKE — DO NOT MERGE.** Refs #199. This exists to price option 1 of that issue, not to decide it. No reviewer requested, no labels. If the answer is "document instead", close this unmerged; that outcome is a success for this branch.

## What #199 asked

Two defensible dispositions were on the table: (1) stop attaching this process's credentials when nothing authoritative stamped `sender`, or (2) document the gap. Option 1 is a behaviour change on a released artifact, which is why it was held. Below is what option 1 actually costs, measured.

## The price

Production change, in full:

| File | +/- | What |
|---|---|---|
| `WireDbusBackend.kt` | +16 / -6 | one `if (wire.direct) return this` guard at the top of `withLocalSenderCredentials`, plus its new `wire` parameter and comment updates |
| `DBusWireConnection.kt` | +5 / -1 | `private val direct` → `internal val direct` so the guard can read it, plus KDoc |
| `Message.kt` (commonMain) | +16 / -7 | KDoc only — see "the contract question" below |
| `Connection.kt` (commonMain) | +6 / -0 | KDoc only, on `createDirectBusConnection` |

**Ten changed non-comment lines.** No new class, no new API, no new dependency, no allocation on any hot path (the guard is a boolean read before the existing registry lookup, so the brokered path gets marginally *cheaper*).

Test cost is the real number: `JvmDirectSenderCredentialsTest.kt` is 174 lines, of which ~90 are a brokerless peer harness (SASL EXTERNAL handshake + a socket you can push frames down). That harness is near-duplicate of the private `DirectPeer` in `JvmDirectConnectionIdentityTest.kt`; if this ships, the two should be merged into one shared test fixture. I did not do that here because a spike should not refactor code it may not keep.

`NativeDirectSenderCredentialsProbe.kt` (130 lines) is measurement scaffolding for the cross-backend question below. It asserts nothing and would **not** be part of a real fix — delete it if this lands.

## Red, then green

Before the change, `:jvmTest --tests JvmDirectSenderCredentialsTest` failed. Verbatim from `build/test-results/jvmTest/*.xml`:

```
java.lang.AssertionError: Message.credsUid reported 1000 for a signal on a DIRECT connection
whose sender field was supplied by the peer; this JVM process runs as uid 1000. A direct
connection has no authoritative sender, so no uid should be reported at all.
expected null, but was:<1000>
	at com.monkopedia.sdbus.internal.jvmdbus.JvmDirectSenderCredentialsTest
	    .credentialsAreAbsentForAPeerSuppliedSenderOnADirectConnection(...:81)
```

After the change, the same run is green, and `JvmDirectConnectionIdentityTest` (the existing direct-mode coverage) still passes: 3 testcases, 0 failures, counted from freshly deleted-and-regenerated JUnit XML.

The regression guard that matters is `JvmRealBusIntegrationTest` — it asserts `credsPid` on a signal over a **brokered** session bus. That path is untouched by the guard and still passes. The full root-module JVM suite under `dbus-run-session`, counted from JUnit XML deleted immediately before the run:

```
tests=332 failures=0 errors=0 skipped=0
```

## Cross-backend: native does NOT have this

This is the finding that most changes the shape of the decision, and it was measured, not assumed. `NativeDirectSenderCredentialsProbe` sets up a real brokerless socket pair on linuxX64 (`createServerBusConnection` / `createDirectBusConnection`), makes a method call across it, and reports what the served handler sees:

```
PROBE199 process uid=1000 pid=1463251
PROBE199 incoming direct-connection message sender=null
PROBE199 credsUid=THREW: System.Error.ENODATA: Failed to get bus cred uid (No data available)
PROBE199 credsPid=1463251
```

Read that carefully:

- `sender` is **null** on native's direct path. sd-bus does not invent one, so there is nothing for a name lookup to key off even if the code wanted to.
- `credsUid` **throws** — sd-bus reports `ENODATA` rather than guessing.
- `credsPid` **returns the peer's real pid**, obtained by `sd_bus_query_sender_creds` from the socket. (Both ends are in one process in the probe, so the number equals ours — but it came from the kernel's peer credentials, not from a name.)

Corroborating grep (positive control: `getCreds` returns 8 rows in the same tree, so the query works): `resolveLocalUniqueName`, `localProcessCredentials`, `LocalJvmServiceRegistry`, `getuid`, `geteuid` return **zero** rows in `src/nativeMain/`. The mechanism does not exist on native.

**So #199 is a cross-backend divergence, not just a JVM bug**, and that reframes it: it is not "should we change behaviour" but "should the JVM match what native already does". That is materially easier to justify than a unilateral break — it is the same argument that settled the #141 parity items.

It also exposes a **strictly better option 1b that this spike does not implement**: junixsocket 2.10.1 (already a direct dependency) ships `AFUNIXSocket.getPeerCredentials()`, so the JVM could report the *peer's real* pid/uid/gid from `SO_PEERCRED` on a direct connection — correct credentials rather than merely absent ones, and closer to what native already does. I checked this is real rather than plausible, with a throwaway probe against a connected `AFUNIXSocket` (deleted, not in this branch):

```
PROBECREDS pid=1482522 uid=1000 gid=1000
PROBECREDS thisPid=1482522
```

It resolves. Option 1b is a bigger change — it also touches the incoming method-call path, which today attaches no credentials at all — and I deliberately did not build it. But the owner should know it exists before choosing between "absent" and "documented": **the honest set of options is three, not two.**

## The contract question: throw, null, or sentinel?

Explicitly asked, explicitly answered from the existing code — **throw**, and no API change is needed.

- JVM: `Message.jvm.kt:15` — `requireJvmCredential` throws `createError(-1, "$name failed: sender credentials unavailable on JVM")` for every `creds*` accessor whose backing field is null.
- Native: `Message.native.kt:697` — `sdbusRequire` throws on a negative return from `sd_bus_query_sender_creds`, which is exactly what the probe above observed (`ENODATA`).

Both backends already throw on unavailable credentials, so "report absent" needs no nullable overloads and no sentinel; it reuses a path that already exists and is already exercised (`JvmMessageSupportTest.credentialAccessors_doNotUseUnsupportedOperationExceptions`).

**The ambiguity is a finding in its own right.** The common KDoc said *"The PID of the sending process, if credentials are available"* and never said what happens when they are not — so a consumer reading the published docs cannot tell that `credsUid` is a throwing accessor. That is arguably the more consequential half of #199: a caller who does not know it can throw will not write a `runCatching` around it, and option 1 turns a silently-wrong number into an exception in exactly that unguarded code. The KDoc part of this diff fixes that, and **it is worth landing regardless of which disposition wins** — it is the entirety of option 2 plus the missing throw contract.

## Is this breaking? And does it move the API dumps?

**Source/binary API: no.** Nothing public changed shape; `direct` went from `private` to `internal` inside an internal class. `./gradlew ktlintCheck apiCheck` is **green with no regeneration** — `git status` after the run is empty, so **`api/*.api` does not move**. `api/sdbus-kotlin.klib.api` (consumed downstream by `blue-falcon-sdbus`) is not touched at all: the behaviour change is JVM-only and no native source is modified.

**Runtime behaviour: yes, for a narrow set.** Anyone on JVM + a brokerless direct connection + a *signal* handler + reading `creds*` goes from "gets our uid/pid" to "gets an exception". There is no deprecation cycle available for that — no compiler warning, no soft landing, it changes on upgrade.

Scope of who that is:
- brokered connections: unaffected (verified by the passing `JvmRealBusIntegrationTest`);
- native targets: unaffected (not modified);
- JVM incoming *method calls*: unaffected — that path never attached credentials, so `creds*` already throws there;
- `blue-falcon-sdbus`: unaffected — BlueZ is reached over the brokered system bus.

I found no consumer in this repo or its samples that reads `creds*` on a direct connection. That is evidence of narrow blast radius; it is **not** evidence about closed-source consumers, and I cannot see those.

## The case FOR making the change

1. **It is a divergence from our own other backend, measured above.** Native already refuses to answer rather than guess. Two backends of one library giving different answers to `credsUid` on the same topology is the class of defect #141 was created to eliminate, and every one of those items was resolved by moving the JVM toward native.
2. **The wrong answer is worse than no answer.** A thrown exception is loud and a developer fixes it in minutes. A plausible-looking uid that is silently ours is undetectable in review, in tests, and in production — it fails in the direction of *granting* access.
3. **The identity is derived from an attribute its own subject controls.** `sender` on a direct socket is peer-chosen; deriving anything trust-bearing from it is unsound independent of who the peer is. #174 fixed the same shape in this file already.
4. **The cost is ten lines and no API surface.** If the fix were expensive this would be a harder call; it isn't.
5. **Doing it now is cheaper than doing it later.** The population of direct-mode credential readers only grows.

## The case AGAINST making the change

1. **It changes observable behaviour on a shipped 1.0.x artifact, with no soft-landing path.** A consumer whose signal handler reads `credsUid` today receives a number; after this they receive a thrown `SdbusException`, on a *patch or minor* upgrade, with no compiler help and no deprecation window. If that handler runs on the dispatch path, an unguarded throw may take out signal delivery rather than merely returning a different value. "Wrong value" and "exception" have genuinely different failure modes, and this trades one for the other without asking the consumer.
2. **The severity is low and the issue says so itself.** A direct connection has exactly one peer, and *you dialled it*. "The peer can lie about its name" reduces to "the endpoint you deliberately connected to is not who it claims" — there is no privilege boundary crossed in the ordinary case, and D-Bus's own direct mode is specified as a trusted peer-to-peer transport. sd-bus makes no identity guarantee there either.
3. **The reachable surface is smaller than the issue's prose implies.** `withLocalSenderCredentials` has exactly one call site (`WireDbusBackend.kt:768`, inside `installSignalMatch`), so only *signal* handlers are affected. The natural reading of "a consumer reading `credsUid` for an authorization decision" — a check inside a served method handler — is already unaffected, because that path attaches no credentials at all.
4. **There is no evidence anyone is relying on this, in either direction.** No consumer in-repo reads `creds*` on a direct connection. That cuts both ways: it weakens the urgency of fixing as much as it weakens the risk of breaking, and "nobody is hurt today" is a real argument for the cheaper disposition.
5. **Documenting fully mitigates the actual harm.** The harm named in #199 is *"a consumer relies on a guarantee this library does not provide, and nothing says so."* That harm is a documentation defect, and a KDoc saying "direct connections have no authoritative sender; do not authorize on `creds*` there" removes it completely — without breaking a single caller. The doc half of this diff already does that, standalone.
6. **This diff may be the wrong fix to spend a break on.** Per the junixsocket finding above, "absent" is not the best achievable answer — `SO_PEERCRED` would give the *correct* answer. Spending a behaviour break now on the partial fix, and then potentially changing behaviour a second time when peer credentials land, is worse for consumers than documenting now and changing once, properly.

**Point 6 is, in my reading, the strongest single argument against merging this branch specifically** — distinct from the argument against fixing at all. One can believe #199 should be fixed and still think this is not the fix.

## What I could not settle

- Whether any closed-source consumer reads `creds*` on a direct connection. Unknowable from here.
- Whether `SO_PEERCRED` via junixsocket behaves correctly under all the transports `createDirectBusConnection` accepts. I measured it on a plain connected AF_UNIX socket only; abstract sockets and `tcp:` are untested, and it plainly cannot work for TCP — so option 1b would still need this diff's guard as its fallback. They compose rather than compete.
- Whether the same reasoning should extend to the *destination*-side registry lookups (`resolveLocalUniqueName` is also used for call routing at `WireDbusBackend.kt:410`). That is a routing decision, not a trust decision, so it is probably fine — but I did not test it and it is outside #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
