### PR TITLE
docs: document that the creds* accessors throw, and that a direct connection's sender is not authoritative (Refs #199)

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Connection.kt
@@ -284,6 +284,14 @@ expect fun createSessionBusConnection(address: String): Connection
 /**
  * Opens direct D-Bus connection at a custom address
  *
+ * A direct connection is **brokerless**: no `dbus-daemon` sits between the two ends. Nothing
+ * stamps the `sender` field of an incoming message the way a broker does — the single peer on the
+ * other end supplies it — so the sender of anything received here is peer-asserted rather than
+ * verified. Neither it nor [Message]'s `creds*` accessors are a sound basis for an authorization
+ * decision on this transport. What those accessors report over a direct connection is currently
+ * backend-dependent and is an open question — see
+ * [issue #199](https://github.com/Monkopedia/sdbus-kotlin/issues/199).
+ *
  * @param address ";"-separated list of addresses of bus brokers to try to connect to
  * @return [Connection] instance
  *

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -182,25 +182,63 @@ expect sealed class Message {
      */
     fun rewind(complete: Boolean)
 
-    /** The PID of the sending process, if credentials are available. */
+    /**
+     * The PID of the sending process.
+     *
+     * **This accessor throws rather than returning a fallback.** Credentials are not attached to
+     * every message, and when they are missing the read fails with [SdbusException] instead of
+     * yielding a null or a sentinel. Availability is not a guaranteed property of a message: it
+     * depends on the backend and on the transport the message arrived over, so a caller that can
+     * see messages without credentials has to guard the read.
+     *
+     * **Credentials are only as trustworthy as whatever attached them.** On a brokered bus the
+     * daemon stamps the `sender` field authoritatively, so credentials resolved through it
+     * describe the peer it names. A [direct connection][createDirectBusConnection] is brokerless:
+     * nothing stamps `sender`, the single peer on the other end supplies it, and anything derived
+     * from it is peer-asserted rather than verified. Credentials read over that transport are
+     * therefore not authoritative and must not be used to make an authorization decision. What
+     * they report there is currently backend-dependent and is an open question — see
+     * [issue #199](https://github.com/Monkopedia/sdbus-kotlin/issues/199) — so treat it as
+     * unspecified rather than as a contract.
+     *
+     * @throws SdbusException if credentials are unavailable for this message
+     */
     val credsPid: Int
 
-    /** The real UID of the sender, if credentials are available. */
+    /**
+     * The real UID of the sender. Carries the same availability and trust caveats as [credsPid],
+     * including throwing [SdbusException] when credentials are unavailable.
+     */
     val credsUid: UInt
 
-    /** The effective UID of the sender, if credentials are available. */
+    /**
+     * The effective UID of the sender. Carries the same availability and trust caveats as
+     * [credsPid], including throwing [SdbusException] when credentials are unavailable.
+     */
     val credsEuid: UInt
 
-    /** The real GID of the sender, if credentials are available. */
+    /**
+     * The real GID of the sender. Carries the same availability and trust caveats as [credsPid],
+     * including throwing [SdbusException] when credentials are unavailable.
+     */
     val credsGid: UInt
 
-    /** The effective GID of the sender, if credentials are available. */
+    /**
+     * The effective GID of the sender. Carries the same availability and trust caveats as
+     * [credsPid], including throwing [SdbusException] when credentials are unavailable.
+     */
     val credsEgid: UInt
 
-    /** The supplementary GIDs of the sender, if credentials are available. */
+    /**
+     * The supplementary GIDs of the sender. Carries the same availability and trust caveats as
+     * [credsPid], including throwing [SdbusException] when credentials are unavailable.
+     */
     val credsSupplementaryGids: List<UInt>
 
-    /** The SELinux security context of the sender. */
+    /**
+     * The SELinux security context of the sender. Carries the same availability and trust caveats
+     * as [credsPid], including throwing [SdbusException] when it is unavailable.
+     */
     val seLinuxContext: String
 }
 


### PR DESCRIPTION
**Documentation only. Refs #199 — this does not decide it, and #235 stays a draft.**

Same pattern as the #193 test-only extraction: take the part of a spike that is correct regardless of how the owner rules, and leave the ruling untouched.

## Why this is separable from the decision

#235 priced the behaviour change proposed in #199 and concluded *do not merge yet* — on sequencing, not severity: junixsocket 2.10.1 (already a direct dependency) exposes `AFUNIXSocket.getPeerCredentials()`, probed live as returning the peer's real pid/uid/gid. So the JVM could eventually report **correct** credentials on a direct connection rather than merely absent ones, which makes #199 a three-option decision, not two. Spending an un-deprecatable behaviour break now and then changing again later is worse for consumers than documenting now and changing once.

But two things #235 established are true under **every** option, and neither was written down:

1. **`credsPid` and the other `creds*` accessors throw when credentials are unavailable.** `requireJvmCredential` on JVM and `sdbusRequire` on native, both raising `SdbusException`; the native path was confirmed live as `System.Error.ENODATA`. The published KDoc said only *"if credentials are available"* and never stated that it throws — so a consumer could not tell it was calling a throwing accessor, and would not guard the read.
2. **A direct connection has no authoritative sender.** `dbus-daemon` stamps `sender` on a brokered bus; in brokerless direct mode nothing does, and the single peer supplies it. Credentials reached through that path are peer-asserted, not verified, and must not carry an authorization decision.

Both are true whether #199 ends in "leave credentials absent", "report the peer's real credentials via `SO_PEERCRED`", or "document only".

## What this deliberately does NOT say

The KDoc describes the accessors' contract **without blessing current behaviour**. It does not claim the present direct-connection behaviour is intended or settled; it marks what the accessors report there as **backend-dependent and unspecified**, and links #199 as the open question. A doc that closed #199 rhetorically would pre-empt the owner just as surely as merging the code would.

It also states the *contract* ("credentials on a direct connection are not authoritative") rather than any procedure — no impersonation recipe. The mechanism is already public in #199; this goes no further.

Note that #235's own doc hunk said direct connections report "no credentials at all", which is only true **after** its code change — on `main` the JVM still stamps credentials on the direct signal path. That wording was corrected here; this branch describes `main` as it actually is.

## Zero behaviour change

```
 .../kotlin/com/monkopedia/sdbus/Connection.kt      |  8 ++++
 .../kotlin/com/monkopedia/sdbus/Message.kt         | 52 +++++++++++++++++++---
 2 files changed, 53 insertions(+), 7 deletions(-)
```

Two files, both `commonMain`, both KDoc-comment-only. **No `.jvm.kt` / `.native.kt` production edits, no test files, no test-harness files.** None of #235's production or test changes are carried over.

## Verification — what I ran, and what I did not

**Ran** (JDK 21, this branch):

- `./gradlew ktlintCheck apiCheck` — **BUILD SUCCESSFUL**. `git status --porcelain` immediately afterwards is **empty**, so `api/*.api` did not move, as a KDoc-only change should not.
- `./gradlew :dokkaGeneratePublicationHtml` — **BUILD SUCCESSFUL**, which is the guard that matters here since malformed KDoc has broken this repo's docs build before (#189). Every KDoc link added resolves: Dokka's `Couldn't resolve link` warnings are emitted (8 of them, all pre-existing in untouched `jvmMain` files), and none names `Message.kt` or `Connection.kt` — so that is a working detector reporting absence, not a silent pass. Spot-checked the rendered output too: `build/dokka/.../-message/creds-pid.html` contains the new throw contract, the non-authoritative caveat, and the #199 link.

**Did not run:** the test suites (`jvmTest`, `linuxX64Test`, cross-tests). A comment-only change cannot alter behaviour, and CI covers them anyway. I am not claiming test verification I did not do.

Refs #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
