### PR TITLE
fix(codegen): pick the signal decoder from the argument count, not the type kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   `sdbus-kotlin-codegen` or the `com.monkopedia.sdbus.plugin` Gradle plugin; declare it directly instead.
   (#167)
 
+### Fixed — codegen
+
+- **A signal with exactly one argument of a parameterized type no longer generates code that fails
+  to compile.** The proxy's signal decoder was selected from the *kind* of the mapped Kotlin type
+  rather than from how many arguments the signal declares, so a single argument of an array or dict
+  type (`as`, `ai`, `a{sv}` — ordinary shapes in real interfaces) fell through to the
+  constructor-reference branch and emitted `call(::List<String>)`, which is not valid Kotlin. The
+  same fall-through gave a single argument of a *struct* type `call(::Entry)`, which compiled but
+  decoded two top-level arguments where the adaptor registers one; that is corrected too. Signals
+  with no arguments and with several arguments are unaffected, and regenerating XML that declares
+  neither shape produces byte-identical output. A `SignalArgShapesTest` fixture now covers every
+  signal argument shape, so `compile_test` guards this permanently. (#218)
+
 ### Fixed
 
 - **A method registered with `hasNoReply = true` now advertises

--- a/codegen/src/main/kotlin/ProxyGenerator.kt
+++ b/codegen/src/main/kotlin/ProxyGenerator.kt
@@ -26,7 +26,6 @@ import com.monkopedia.sdbus.Access.READWRITE
 import com.monkopedia.sdbus.Access.WRITE
 import com.monkopedia.sdbus.Annotations.METHOD_NO_REPLY
 import com.monkopedia.sdbus.Direction.OUT
-import com.monkopedia.sdbus.NamingManager.SimpleType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -36,7 +35,6 @@ import com.squareup.kotlinpoet.KModifier.SUSPEND
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.withIndent
 
@@ -150,6 +148,18 @@ class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOve
 
     override fun signalBuilder(intf: Interface, signal: Signal): FunSpec.Builder? = null
 
+    /**
+     * The decoder bound into `signalFlow` takes one lambda parameter per *top-level* signal
+     * argument, so the binding is chosen by how many arguments the signal declares -- not by what
+     * kind of type they map to. Only a multi-argument signal gets the constructor reference, and
+     * only because the generated aggregate's constructor happens to have exactly that arity; a
+     * single argument is decoded as itself, whatever its type.
+     *
+     * Keying this off the type instead used to emit `call(::List<String>)` for a single argument of
+     * a parameterized type (which is not valid Kotlin) and `call(::Entry)` for a single argument of
+     * a struct type (which decodes two top-level arguments where the adaptor registers one). See
+     * https://github.com/Monkopedia/sdbus-kotlin/issues/218.
+     */
     override fun signalValBuilder(intf: Interface, signal: Signal): PropertySpec.Builder? {
         val type = namingManager[signal.args]
         return PropertySpec.builder(
@@ -167,12 +177,10 @@ class ProxyGenerator(packageOverride: String? = null) : BaseGenerator(packageOve
                         signal.name
                     )
                     withIndent {
-                        if (type.reference == UNIT) {
-                            add("call { -> Unit }\n")
-                        } else if (type is SimpleType) {
-                            add("call { a: %T -> a }\n", type.reference)
-                        } else {
-                            add("call(::%T)\n", type.reference)
+                        when (signal.args.size) {
+                            0 -> add("call { -> Unit }\n")
+                            1 -> add("call { a: %T -> a }\n", type.reference)
+                            else -> add("call(::%T)\n", type.reference)
                         }
                     }
                     add("}\n")

--- a/codegen/src/test/resources/SignalArgShapesTest/adaptor.0.kt
+++ b/codegen/src/test/resources/SignalArgShapesTest/adaptor.0.kt
@@ -1,0 +1,72 @@
+package org.example.signals
+
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.addVTable
+import com.monkopedia.sdbus.emitSignal
+import com.monkopedia.sdbus.signal
+import kotlin.Int
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.collections.Map
+
+public abstract class ShapesAdaptor(
+  public val obj: Object,
+) : Shapes {
+  public override fun register() {
+    obj.addVTable(Shapes.Companion.INTERFACE_NAME) {
+      signal(SignalName("NoArgs")) {
+      }
+      signal(SignalName("OneSimple")) {
+        with<String>("reason")
+      }
+      signal(SignalName("OneArray")) {
+        with<List<String>>("paths")
+      }
+      signal(SignalName("OneDict")) {
+        with<Map<String, Variant>>("properties")
+      }
+      signal(SignalName("OneNestedDict")) {
+        with<Map<ObjectPath, Map<String, Map<String, Variant>>>>("objects")
+      }
+      signal(SignalName("OneStruct")) {
+        with<Entry>("entry")
+      }
+      signal(SignalName("TwoArgs")) {
+        with<Int>("index")
+        with<String>("label")
+      }
+    }
+  }
+
+  public suspend fun onNoArgs(): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("NoArgs")) {
+    call()
+  }
+
+  public suspend fun onOneSimple(reason: String): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("OneSimple")) {
+    call(reason)
+  }
+
+  public suspend fun onOneArray(paths: List<String>): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("OneArray")) {
+    call(paths)
+  }
+
+  public suspend fun onOneDict(properties: Map<String, Variant>): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("OneDict")) {
+    call(properties)
+  }
+
+  public suspend fun onOneNestedDict(objects: Map<ObjectPath, Map<String, Map<String, Variant>>>): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("OneNestedDict")) {
+    call(objects)
+  }
+
+  public suspend fun onOneStruct(entry: Entry): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("OneStruct")) {
+    call(entry)
+  }
+
+  public suspend fun onTwoArgs(index: Int, label: String): Unit = obj.emitSignal(Shapes.Companion.INTERFACE_NAME, SignalName("TwoArgs")) {
+    call(index, label)
+  }
+}

--- a/codegen/src/test/resources/SignalArgShapesTest/interface.0.kt
+++ b/codegen/src/test/resources/SignalArgShapesTest/interface.0.kt
@@ -1,0 +1,11 @@
+package org.example.signals
+
+import kotlin.String
+import kotlin.UInt
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Entry(
+  public val uInt: UInt,
+  public val string: String,
+)

--- a/codegen/src/test/resources/SignalArgShapesTest/interface.1.kt
+++ b/codegen/src/test/resources/SignalArgShapesTest/interface.1.kt
@@ -1,0 +1,11 @@
+package org.example.signals
+
+import com.monkopedia.sdbus.InterfaceName
+
+public interface Shapes {
+  public fun register()
+
+  public companion object {
+    public val INTERFACE_NAME: InterfaceName = InterfaceName("org.example.signals.Shapes")
+  }
+}

--- a/codegen/src/test/resources/SignalArgShapesTest/interface.2.kt
+++ b/codegen/src/test/resources/SignalArgShapesTest/interface.2.kt
@@ -1,0 +1,11 @@
+package org.example.signals
+
+import kotlin.Int
+import kotlin.String
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class TwoArgs(
+  public val index: Int,
+  public val label: String,
+)

--- a/codegen/src/test/resources/SignalArgShapesTest/proxy.0.kt
+++ b/codegen/src/test/resources/SignalArgShapesTest/proxy.0.kt
@@ -1,0 +1,54 @@
+package org.example.signals
+
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.Proxy
+import com.monkopedia.sdbus.SignalName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.signalFlow
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlinx.coroutines.flow.Flow
+
+public class ShapesProxy(
+  public val proxy: Proxy,
+) : Shapes {
+  public val noArgs: Flow<Unit> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("NoArgs")) {
+        call { -> Unit }
+      }
+
+  public val oneSimple: Flow<String> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("OneSimple")) {
+        call { a: String -> a }
+      }
+
+  public val oneArray: Flow<List<String>> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("OneArray")) {
+        call { a: List<String> -> a }
+      }
+
+  public val oneDict: Flow<Map<String, Variant>> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("OneDict")) {
+        call { a: Map<String, Variant> -> a }
+      }
+
+  public val oneNestedDict: Flow<Map<ObjectPath, Map<String, Map<String, Variant>>>> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("OneNestedDict")) {
+        call { a: Map<ObjectPath, Map<String, Map<String, Variant>>> -> a }
+      }
+
+  public val oneStruct: Flow<Entry> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("OneStruct")) {
+        call { a: Entry -> a }
+      }
+
+  public val twoArgs: Flow<TwoArgs> =
+      proxy.signalFlow(Shapes.Companion.INTERFACE_NAME, SignalName("TwoArgs")) {
+        call(::TwoArgs)
+      }
+
+  public override fun register() {
+  }
+}

--- a/codegen/src/test/resources/SignalArgShapesTest/test.xml
+++ b/codegen/src/test/resources/SignalArgShapesTest/test.xml
@@ -1,0 +1,39 @@
+<!-- Covers every argument shape a signal can have, because the proxy picks the decoder it binds
+     into signalFlow from the shape of the argument list: no args, one argument of a plain type,
+     one argument of a parameterized type (array/dict), one argument of a struct type, and several
+     arguments. Before #218 the single-parameterized-argument shape fell through to the
+     constructor-reference branch and emitted `call(::List<String>)`, which is not valid Kotlin;
+     no other checked-in fixture declares a signal of that shape, so nothing caught it. -->
+<node>
+  <interface name="org.example.signals.Shapes">
+
+    <signal name="NoArgs">
+    </signal>
+
+    <signal name="OneSimple">
+      <arg type="s" name="reason"/>
+    </signal>
+
+    <signal name="OneArray">
+      <arg type="as" name="paths"/>
+    </signal>
+
+    <signal name="OneDict">
+      <arg type="a{sv}" name="properties"/>
+    </signal>
+
+    <signal name="OneNestedDict">
+      <arg type="a{oa{sa{sv}}}" name="objects"/>
+    </signal>
+
+    <signal name="OneStruct">
+      <arg type="(us)" name="entry"/>
+    </signal>
+
+    <signal name="TwoArgs">
+      <arg type="i" name="index"/>
+      <arg type="s" name="label"/>
+    </signal>
+
+  </interface>
+</node>


### PR DESCRIPTION
Fixes #218.

## The defect

`ProxyGenerator.signalValBuilder` picked the decoder it binds into `signalFlow` from the **kind** of the mapped Kotlin type: `SimpleType` got an identity lambda, `UNIT` got `call { -> Unit }`, and *everything else* fell through to a constructor reference. A signal with exactly one argument of a parameterized type (`as`, `ai`, `a{sv}` — ordinary shapes in real interfaces) maps to a `LazyType`, so it took the fall-through and emitted:

```kotlin
call(::List<String>)
call(::Map<String, Variant>)
```

A callable reference cannot carry type arguments. The generated file does not compile.

## Red first — verbatim compiler error

New fixture `codegen/src/test/resources/SignalArgShapesTest/test.xml` added, goldens generated against the **unfixed** generator (`WRITE_FILES` flipped temporarily), then `./gradlew :compile_test:compileKotlinLinuxX64`:

```
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:29:9 Cannot infer type for type parameter 'R'. Specify it explicitly.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:29:9 Cannot infer type for type parameter 'B'. Specify it explicitly.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:29:16 Cannot infer type for type parameter 'T'. Specify it explicitly.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:29:20 Syntax error: Type arguments are not allowed.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:34:9 None of the following candidates is applicable:

fun <reified R : Any> call(crossinline handler: () -> R): TypedMethodCall<*>
fun <reified R : Any, reified A : Any> call(crossinline handler: (A) -> R): TypedMethodCall<*>
[... 9 more arities ...]
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:34:16 Unresolved reference 'Map'.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:34:19 Syntax error: Type arguments are not allowed.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:39:9 None of the following candidates is applicable:
[...]
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:39:16 Unresolved reference 'Map'.
e: .../TestFiles/SignalArgShapesTest/proxy.0.kt:39:19 Syntax error: Type arguments are not allowed.

> Task :compile_test:compileKotlinLinuxX64 FAILED
```

Line 29 is `OneArray` (`as`), 34 is `OneDict` (`a{sv}`), 39 is `OneNestedDict` (`a{oa{sa{sv}}}`).

## The fix

One branch, in `ProxyGenerator.signalValBuilder`:

```kotlin
when (signal.args.size) {
    0 -> add("call { -> Unit }\n")
    1 -> add("call { a: %T -> a }\n", type.reference)
    else -> add("call(::%T)\n", type.reference)
}
```

The decoder takes one lambda parameter per **top-level** signal argument, so the argument *count* is what actually selects the binding — not what kind of type the arguments map to. The constructor reference is correct only for the synthesized aggregate that stands in for a multi-argument signal, and only because its constructor happens to have exactly that arity.

`SimpleType` and `UNIT` imports drop out; no other change.

### The struct case, checked as #218 suggested

The issue asked to check the same fall-through for the other paths. Zero-arg and multi-arg were fine, but a **single argument of a struct type** was also wrong — it emitted `call(::Entry)`, which *compiles* but decodes two top-level arguments, while the adaptor for the very same signal registers one: `signal("OneStruct") { with<Entry>("entry") }`. That is a proxy/adaptor mismatch on the same generated pair. Switching on the count fixes it in the same line; the fixture covers it.

## Why `compile_test` missed it

**No fixture exercised the shape.** None of the 20 checked-in fixture inputs declares a single-argument signal with a parameterized (or struct) argument type — every signal golden in the tree is zero-arg, single-`s`/`x`, or multi-arg:

```
CommentsSampleTest/proxy.0.kt:17:        call(::PropertiesChanged)   # 3 args
VTableFlagsTest/proxy.0.kt:50,55:        call { a: String -> a }     # 1 x s
SimpleXmlTest/proxy.0.kt:18:             call { -> Unit }            # 0 args
MediaPlayer2/proxy.1.kt:103:             call { a: Long -> a }       # 1 x x
XMLAnnotationsTest/proxy.0.kt:29:        call(::PropertiesChanged)   # 3 args
```

`compile_test` symlinks the fixture tree and native-compiles it, so it proves exactly and only what the corpus contains. Worth noting the *second* guard missed it for the same reason: `codegen`'s `CompilationIntegrationTest` compiles generated code in-process, but its one XML declares a two-arg signal.

So the fixture is as much the deliverable as the code fix. `SignalArgShapesTest` declares one signal of **every** argument shape — no args, one plain (`s`), one array (`as`), one dict (`a{sv}`), one nested dict (`a{oa{sa{sv}}}`), one struct (`(us)`), and two args (`i`, `s`) — with a header comment saying why. The next variant of this bug now has somewhere to fail.

## Golden fixture diff

**None.** No existing golden changed — `git status` after regeneration lists only `ProxyGenerator.kt`, `CHANGELOG.md`, and the new `SignalArgShapesTest/` directory, and the 22 pre-existing fixtures' 66 `GeneratorTest` cases stayed green against unmodified goldens on the regeneration run. That is expected: none of them declares either affected shape. Consumers regenerating from XML without a single-parameterized-arg or single-struct-arg signal get byte-identical output.

`WRITE_FILES` is back to `false` in this branch (`GeneratorTest.kt:88`); it is not part of the diff — `git diff` shows the file unmodified.

## Verification

| task | result |
|---|---|
| `:codegen:test` | **86 tests, 0 failures, 0 skipped** (fresh JUnit XML, stale results deleted first) — includes 3 new `SignalArgShapesTest` cases (interface/adaptor/proxy) |
| `:compile_test:compileKotlinLinuxX64` | **BUILD SUCCESSFUL**, re-confirmed with `--rerun-tasks`, zero `e:` lines — this is the task that was red above |
| `ktlintCheck` | pass |
| `apiCheck` | pass |

Neither task needs a D-Bus session bus; none was used. Ran on JDK 21.

**`codegen/api/codegen.api` does not move.** `signalValBuilder` keeps its signature (`protected fun signalValBuilder (Lcom/monkopedia/sdbus/Interface;Lcom/monkopedia/sdbus/Signal;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;`); the change is entirely inside the method body plus two now-unused imports. No binary break for the published codegen artifact, so the open owner question on #217 is not touched.

## Unsettled

Nothing blocking. Worth noting for the record that the single-struct-arg correction is a **behavior** change for anyone whose XML declares that shape: their regenerated proxy will start decoding one struct argument instead of two flattened fields. It was decoding the wire wrongly before (and disagreeing with its own adaptor), so this is a fix rather than a regression — but it is not a no-op for such a consumer, and the CHANGELOG says so.
