### PR TITLE
ci(soak): make cleaner-soak incapable of passing while selecting nothing

### DIFF
--- a/.github/workflows/stress-matrix.yaml
+++ b/.github/workflows/stress-matrix.yaml
@@ -256,6 +256,39 @@ jobs:
           dbus-run-session -- ./gradlew :linuxX64Test :jvmTest -PgcSoak \
             --rerun-tasks --stacktrace | tee cleaner-soak.log
 
+      - name: Assert Both Soak Halves Ran
+        # #196: `-PgcSoak` selects the suites with an include pattern, so a rename or a package move
+        # makes it match nothing. Gradle fails `:jvmTest` on that, but the Kotlin/Native test task
+        # ignores `failOnNoMatchingTests` and reports `:linuxX64Test` green while writing no results
+        # at all — and neither guard covers a task that is dropped from the command line above. The
+        # JUnit XML is the only artefact that records what actually executed, so assert on it: each
+        # half must have run at least one test, and every suite it ran must be a soak suite (that
+        # second half is what #120 needed, when a stray filter ran the whole integration suite here).
+        run: |
+          set -euo pipefail
+          status=0
+          for task in linuxX64Test jvmTest; do
+            xml=$(find "build/test-results/${task}" -maxdepth 1 -name '*.xml' 2>/dev/null | sort || true)
+            if [ -z "${xml}" ]; then
+              echo "SOAK GUARD FAILED (#196): ${task} wrote no JUnit XML — it selected no tests, or never ran."
+              status=1
+              continue
+            fi
+            cases=$(grep -ho '<testcase ' ${xml} | wc -l)
+            suites=$(sed -n 's/.*<testsuite name="\([^"]*\)".*/\1/p' ${xml} | sort -u)
+            echo "${task}: ${cases} test(s) in: $(echo ${suites})"
+            if [ "${cases}" -eq 0 ]; then
+              echo "SOAK GUARD FAILED (#196): ${task} recorded 0 tests."
+              status=1
+            fi
+            foreign=$(echo "${suites}" | grep -v 'Cleaner.*SoakTest' || true)
+            if [ -n "${foreign}" ]; then
+              echo "SOAK GUARD FAILED (#196): ${task} ran non-soak suites: $(echo ${foreign})"
+              status=1
+            fi
+          done
+          exit "${status}"
+
       - name: Upload Failure Artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/stress-matrix.yaml
+++ b/.github/workflows/stress-matrix.yaml
@@ -274,11 +274,18 @@ jobs:
               status=1
               continue
             fi
-            cases=$(grep -ho '<testcase ' ${xml} | wc -l)
+            # Everything below parses with `sed -n …p`, never `grep`, for the reason
+            # arm-build-test.yaml already records: a grep that matches nothing exits 1 under
+            # `pipefail`, which would kill this step with an empty log instead of the message below —
+            # the exact silence this guard exists to end. `awk` prints 0 on empty input.
+            recorded=$(sed -n 's/.*<testsuite [^>]*tests="\([0-9]*\)".*/\1/p' ${xml} | awk '{ n += $1 } END { print n + 0 }')
+            skipped=$(sed -n 's/.*<testsuite [^>]*skipped="\([0-9]*\)".*/\1/p' ${xml} | awk '{ n += $1 } END { print n + 0 }')
             suites=$(sed -n 's/.*<testsuite name="\([^"]*\)".*/\1/p' ${xml} | sort -u)
-            echo "${task}: ${cases} test(s) in: $(echo ${suites})"
-            if [ "${cases}" -eq 0 ]; then
-              echo "SOAK GUARD FAILED (#196): ${task} recorded 0 tests."
+            echo "${task}: ${recorded} test(s), ${skipped} skipped, in: $(echo ${suites})"
+            # A soak suite has no legitimate skip — #228 made a missing bus fail rather than skip — so
+            # an all-skipped half measured nothing just as surely as an empty one.
+            if [ "$((recorded - skipped))" -le 0 ]; then
+              echo "SOAK GUARD FAILED (#196): ${task} executed no tests (${recorded} recorded, ${skipped} skipped)."
               status=1
             fi
             foreign=$(echo "${suites}" | grep -v 'Cleaner.*SoakTest' || true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -235,12 +235,19 @@ tasks.register("crossRuntimeStressTests") {
 // stress-matrix.yaml). Driving the selection from this gate — rather than a command-line `--tests`
 // filter — is deliberate: `--tests` across multiple test tasks (`:linuxX64Test :jvmTest`) is applied
 // to only one task and silently runs the other unfiltered, which ran the full integration suite in CI.
+//
+// Every test task this gate touches owns soak suites (2 in nativeTest, 1 in jvmTest), so an include
+// pattern that matches nothing means the suites were renamed or moved, never a legitimate absence —
+// hence `failOnNoMatchingTests` is left at its default of `true`. It used to be forced to `false`,
+// which turned exactly that mistake into a green nightly (#196). Note it only covers the JVM half:
+// the Kotlin/Native test task does not honour the flag and stays green on an empty selection, so the
+// cleaner-soak job additionally asserts against the JUnit XML both halves write.
+val gcSoakSuites = "com.monkopedia.sdbus.unit.Cleaner*SoakTest"
 tasks.withType<org.gradle.api.tasks.testing.AbstractTestTask>().configureEach {
     if (project.hasProperty("gcSoak")) {
-        filter.isFailOnNoMatchingTests = false
-        filter.includeTestsMatching("com.monkopedia.sdbus.unit.Cleaner*SoakTest")
+        filter.includeTestsMatching(gcSoakSuites)
     } else {
-        filter.excludeTestsMatching("com.monkopedia.sdbus.unit.Cleaner*SoakTest")
+        filter.excludeTestsMatching(gcSoakSuites)
     }
 }
 


### PR DESCRIPTION
Fixes #196.

## First: the issue's headline is false, and the fix is not what it asked for

#196 claims `:jvmTest` under `-PgcSoak` selects **zero** tests and that `CleanerJvmLifecycleSoakTest`
has never run in CI. The follow-up comment on the issue had already withdrawn the timing evidence
behind that claim (Gradle prints `> Task :X` at *completion*, so the measured intervals meant nothing)
and left the headline `UNRESOLVED-NEEDS-BUILD`. I ran the confirming command. It is **not** what happens.

Measured on `e2a9f88`, from fresh JUnit XML rather than console text — `dbus-run-session -- ./gradlew
:linuxX64Test :jvmTest -PgcSoak --rerun-tasks --stacktrace`, `BUILD SUCCESSFUL in 38s`:

```
build/test-results/jvmTest/TEST-com.monkopedia.sdbus.unit.CleanerJvmLifecycleSoakTest.xml
  <testsuite name="CleanerJvmLifecycleSoakTest[jvm]" tests="1" skipped="0" failures="0" errors="0" time="0.244">
    <testcase name="servedObjectWithPropertyIsCollectedAfterRelease[jvm]"
              classname="com.monkopedia.sdbus.unit.CleanerJvmLifecycleSoakTest" time="0.242"/>

build/test-results/linuxX64Test/TEST-linuxX64Test.…CleanerLifecycleSoakTest.xml
  <testsuite name="linuxX64Test.com.monkopedia.sdbus.unit.CleanerLifecycleSoakTest" tests="4" …>
build/test-results/linuxX64Test/TEST-linuxX64Test.…CleanerSoakTest.xml
  <testsuite name="linuxX64Test.com.monkopedia.sdbus.unit.CleanerSoakTest" tests="6" …>
```

| half | suites selected | testcases |
|---|---|---|
| `:jvmTest` | `CleanerJvmLifecycleSoakTest` | **1** |
| `:linuxX64Test` | `CleanerSoakTest`, `CleanerLifecycleSoakTest` | **10** |

So the JVM half **does** run, and the nightly has been guarding the served-object leak that #119 fixed.
It is thin — one testcase against the native half's ten — but that is a coverage question, not a
silent-no-op, and this PR does not touch it.

## What is really broken: the gate cannot fail

`isFailOnNoMatchingTests = false` was not compensating for a half that legitimately matches nothing
(both halves own suites). It was disarming the only signal that would report a rename or a package
move. Demonstrated by pointing the pattern at a name that does not exist — the exact thing a rename
would do — on the **unmodified** `e2a9f88`:

```
$ ./gradlew :linuxX64Test :jvmTest -PgcSoak      # pattern: Cleaner*SoakTestNoSuchClass
> Task :linuxX64Test
> Task :jvmTest
BUILD SUCCESSFUL in 5s
### counts
  jvmTest: 0 <testcase> entries across 0 xml files
  linuxX64Test: 0 <testcase> entries across 0 xml files
```

Green, zero tests, no annotation, nothing to notice. That is the defect.

## The fix, classified per half

Zero selection is **never** a legitimate absence here — every test task the gate touches owns soak
suites (2 in `nativeTest`, 1 in `jvmTest`) — so both halves fail loudly. But they need different
mechanisms, because Gradle only covers one of them:

**`build.gradle.kts`** — drop the `isFailOnNoMatchingTests = false` override (back to Gradle's default
`true`), and hoist the pattern into one `gcSoakSuites` constant so the include and the exclude cannot
drift apart. This covers `:jvmTest`, in CI *and* in local `-PgcSoak` runs.

**`.github/workflows/stress-matrix.yaml`** — a new `Assert Both Soak Halves Ran` step. Two things
Gradle cannot do: the Kotlin/Native test task **ignores `failOnNoMatchingTests`** (measured below —
`:linuxX64Test` alone is still `BUILD SUCCESSFUL` on an empty selection even with the flag at its
default), and no in-task guard can notice a task that was dropped from the command line. So it asserts
on the JUnit XML — the only artefact that records what actually executed: each half must have written
XML, must have ≥1 `<testcase>`, and every `<testsuite>` it recorded must be a `Cleaner*SoakTest`.
That last clause also re-guards the #120 over-selection regression, where a stray filter ran the whole
integration suite in this job.

## Evidence — both directions, on the fix branch

Same worktree, only the pattern string swapped to simulate a rename. `JAVA_HOME=java-21-openjdk`,
everything under `dbus-run-session`.

**RED, native half alone** — this is why the workflow guard exists:

```
$ ./gradlew :linuxX64Test -PgcSoak            # pattern: Cleaner*SoakTestNoSuchClass
> Task :linuxX64Test
BUILD SUCCESSFUL in 1s                        <-- Gradle does NOT fail the native half
---- workflow guard ----
SOAK GUARD FAILED (#196): linuxX64Test wrote no JUnit XML — it selected no tests, or never ran.
SOAK GUARD FAILED (#196): jvmTest wrote no JUnit XML — it selected no tests, or never ran.
GUARD EXIT=1
```

**RED, both halves, exactly as the job invokes it:**

```
$ ./gradlew :linuxX64Test :jvmTest -PgcSoak    # pattern: Cleaner*SoakTestNoSuchClass
> Task :jvmTest FAILED

* What went wrong:
Execution failed for task ':jvmTest'.
> No tests found for given includes: [com.monkopedia.sdbus.unit.Cleaner*SoakTestNoSuchClass](filter.includeTestsMatching)

BUILD FAILED in 895ms
---- workflow guard ----
SOAK GUARD FAILED (#196): linuxX64Test wrote no JUnit XML — it selected no tests, or never ran.
SOAK GUARD FAILED (#196): jvmTest wrote no JUnit XML — it selected no tests, or never ran.
GUARD EXIT=1
```

**GREEN, real pattern, exactly as the job invokes it:**

```
$ ./gradlew :linuxX64Test :jvmTest -PgcSoak --rerun-tasks --stacktrace
BUILD SUCCESSFUL in 23s
11 actionable tasks: 11 executed
---- workflow guard ----
linuxX64Test: 10 test(s) in: linuxX64Test.…CleanerLifecycleSoakTest linuxX64Test.…CleanerSoakTest
jvmTest: 1 test(s) in: CleanerJvmLifecycleSoakTest[jvm]
GUARD EXIT=0
```

The guard step's script is extracted from the YAML with a parser (not retyped) and replayed against
nine saved result trees, so every branch of it is reached:

| scenario | guard |
|---|---|
| real selection, both halves (pre-fix baseline) | pass, 10 + 1 |
| real selection, both halves (post-fix) | pass, 10 + 1 |
| pattern matches nothing, pre-fix (build was green) | **fail**, no XML |
| pattern matches nothing, post-fix | **fail**, no XML |
| result directory absent entirely (task never invoked) | **fail**, no XML |
| only one half's results present | **fail**, naming `linuxX64Test` |
| XML present but `tests="0"` | **fail**, `executed no tests (0 recorded, 0 skipped)` |
| XML present but every test skipped | **fail**, `executed no tests (1 recorded, 1 skipped)` |
| a non-soak suite alongside the soak suites (#120 shape) | **fail**, naming `CommonApiIntegrationTest` |

The last three of those came from review. The `tests="0"` case originally killed the step on a
`grep … | wc -l` under its own `set -o pipefail` — grep exits 1 when it matches nothing, so the step
failed with an **empty log** and never examined the second half, which is the very silence this guard
exists to end (`arm-build-test.yaml:204` already documents the same trap). Counts are now summed from
the `<testsuite>` `tests`/`skipped` attributes with `sed -n …p | awk`, and the assertion is on
`recorded - skipped` so an all-skipped half fails too — a soak suite has no legitimate skip, #228
having made a missing bus fail rather than skip.

## Static gates

`./gradlew ktlintCheck apiCheck` → `BUILD SUCCESSFUL in 16s`. **No `api/*.api` movement** — `git status
--porcelain` after `apiCheck` lists nothing tracked. No production code is touched.

## Known residual gap (stated, not papered over)

A *local* `./gradlew :linuxX64Test -PgcSoak` with a broken pattern still passes silently, because the
Kotlin/Native test task ignores `failOnNoMatchingTests` and only the CI job runs the XML assertion.
Closing that would mean adding a test-listener/`doLast` counter to the build for one nightly job; the
job — the thing #196 is about — is now covered, and the workflow comment records the limitation.

