### PR TITLE
test(codegen): split golden regeneration out of GeneratorTest so the gate cannot write its own answer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ Needs no D-Bus session bus:
   validator; if you intentionally change public API, regenerate with `./gradlew apiDump` and commit
   the `api/*.api` diff.
 - `./gradlew codegen:fatJar`: build the standalone codegen JAR used in releases.
+- `./gradlew :codegen:regenerateGoldens`: rewrite the checked-in codegen golden fixtures from their
+  `test.xml` inputs after an intentional generator change, then review the `git diff` before
+  committing it. `:codegen:test` only compares the goldens; it never writes them.
 - `./gradlew :dokkaGeneratePublicationHtml`: generate docs into `build/dokka` (this is what
   `pages.yaml` runs; the older `dokkaHtml` task still exists but is not what CI publishes).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,4 +29,4 @@ Modules: root (the library), `:codegen`, `:plugin`, `:cross_test`, `:stress_test
   - The **Kotlin version** badge is hardcoded — bump it manually when the Kotlin version changes.
   - The **Build** badge tracks `.github/workflows/arm-build-test.yaml`; keep the workflow path correct if CI is renamed.
   - Maven Central has no public *download* count, so there is no downloads badge (only the namespace owner can see download stats in the Central Portal).
-- Generated BlueZ proxy fixtures and the BCV `api/*.api` dumps are checked in — regenerate (`apiDump`) and commit them when the public surface changes.
+- Generated BlueZ proxy fixtures and the BCV `api/*.api` dumps are checked in. Regenerate the codegen goldens with `./gradlew :codegen:regenerateGoldens` after an intentional generator change, and the `api/*.api` dumps with `./gradlew apiDump` when the public surface changes; review the diff and commit it. `:codegen:test` only ever *compares* the goldens — it can never write them.

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -51,6 +51,17 @@ tasks.test {
     useJUnitPlatform()
 }
 
+// Rewrites the checked-in golden files GeneratorTest compares against, for use after an
+// intentional generator change. Kept separate from the test task on purpose: the test only reads
+// goldens, this only writes them, so neither can pass itself off as the other.
+tasks.register<JavaExec>("regenerateGoldens") {
+    group = "build"
+    description = "Regenerates the codegen golden fixtures from their test.xml inputs."
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("com.monkopedia.sdbus.RegenerateGoldensKt")
+    args(layout.projectDirectory.dir("src/test/resources").asFile.absolutePath)
+}
+
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)

--- a/codegen/src/test/kotlin/GeneratorTest.kt
+++ b/codegen/src/test/kotlin/GeneratorTest.kt
@@ -22,51 +22,47 @@
  */
 package com.monkopedia.sdbus
 
-import com.squareup.kotlinpoet.FileSpec
 import java.io.File
-import kotlinx.serialization.decodeFromString
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
+/**
+ * Verifies the generators against the golden files checked in beside each fixture's `test.xml`.
+ *
+ * This test only ever reads the goldens. Rewriting them after an intentional generator change is
+ * `./gradlew :codegen:regenerateGoldens` (see `RegenerateGoldens.kt`), so that no run of this suite
+ * can produce the output it is about to compare against.
+ */
 class GeneratorTest {
     @ParameterizedTest
     @MethodSource("data")
     fun testInterface(testRoot: File) {
-        val xmlStr = File(testRoot, "test.xml").readText()
-        val xml = introspectionXml.decodeFromString<XmlRootNode>(xmlStr)
-        val gen = InterfaceGenerator().transformXmlToFile(xml).sortedBy { it.name }
-        assertFiles(testRoot, "interface", gen)
+        assertGoldens(testRoot, GoldenFixture.INTERFACE)
     }
 
     @ParameterizedTest
     @MethodSource("data")
     fun testAdaptor(testRoot: File) {
-        val xmlStr = File(testRoot, "test.xml").readText()
-        val xml = introspectionXml.decodeFromString<XmlRootNode>(xmlStr)
-        val gen = AdaptorGenerator().transformXmlToFile(xml).sortedBy { it.name }
-        assertFiles(testRoot, "adaptor", gen)
+        assertGoldens(testRoot, GoldenFixture.ADAPTOR)
     }
 
     @ParameterizedTest
     @MethodSource("data")
     fun testProxy(testRoot: File) {
-        val xmlStr = File(testRoot, "test.xml").readText()
-        val xml = introspectionXml.decodeFromString<XmlRootNode>(xmlStr)
-        val gen = ProxyGenerator().transformXmlToFile(xml).sortedBy { it.name }
-        assertFiles(testRoot, "proxy", gen)
+        assertGoldens(testRoot, GoldenFixture.PROXY)
     }
 
-    private fun assertFiles(root: File, prefix: String, actual: List<FileSpec>) {
-        if (WRITE_FILES) {
-            val writeRoot = File("src/test/resources/${root.name}")
-            actual.forEachIndexed { index, fileSpec ->
-                File(writeRoot, "$prefix.$index.kt").writeText(fileSpec.toString())
-            }
-        }
-        val expected = root.listFiles().orEmpty()
-            .filter { it.name.startsWith("$prefix.") && it.name.endsWith(".kt") }
-            .sortedBy { it.name }
+    private fun assertGoldens(testRoot: File, fixture: GoldenFixture) {
+        val expected = fixture.goldenFiles(testRoot)
+        // Without this, a fixture with no goldens of this kind would compare nothing and pass.
+        assertTrue(
+            expected.isNotEmpty(),
+            "No ${fixture.prefix}.*.kt golden files in ${testRoot.name}; " +
+                "run :codegen:regenerateGoldens and commit them"
+        )
+        val actual = fixture.generate(testRoot)
         assertEquals(expected.size, actual.size)
         expected.zip(actual).forEach { (expected, actual) ->
             val expectedContent = expected.readText()
@@ -84,7 +80,5 @@ class GeneratorTest {
                     File(it).parentFile.listFiles()
                 }.orEmpty()
                 .map { arrayOf(it) }
-
-        private const val WRITE_FILES = false
     }
 }

--- a/codegen/src/test/kotlin/GoldenFixture.kt
+++ b/codegen/src/test/kotlin/GoldenFixture.kt
@@ -1,0 +1,53 @@
+/**
+ *
+ * (C) 2016 - 2021 KISTLER INSTRUMENTE AG, Winterthur, Switzerland
+ * (C) 2016 - 2024 Stanislav Angelovic <stanislav.angelovic@protonmail.com>
+ * (C) 2024 - 2025 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus
+
+import com.squareup.kotlinpoet.FileSpec
+import java.io.File
+import kotlinx.serialization.decodeFromString
+
+/**
+ * The three sets of golden files each fixture directory under `codegen/src/test/resources` holds,
+ * named after the file prefix they are stored under (`interface.0.kt`, `adaptor.0.kt`, ...).
+ *
+ * [GeneratorTest] verifies the checked-in goldens against this, and `:codegen:regenerateGoldens`
+ * rewrites them from this — the single definition keeps the writer and the verifier in lockstep
+ * without either being able to stand in for the other.
+ */
+internal enum class GoldenFixture(val prefix: String, private val generator: () -> BaseGenerator) {
+    INTERFACE("interface", ::InterfaceGenerator),
+    ADAPTOR("adaptor", ::AdaptorGenerator),
+    PROXY("proxy", ::ProxyGenerator);
+
+    fun generate(testRoot: File): List<FileSpec> {
+        val xml = introspectionXml.decodeFromString<XmlRootNode>(
+            File(testRoot, "test.xml").readText()
+        )
+        return generator().transformXmlToFile(xml).sortedBy { it.name }
+    }
+
+    /** The golden files checked in for this fixture, in the order [generate] produces them. */
+    fun goldenFiles(testRoot: File): List<File> = testRoot.listFiles().orEmpty()
+        .filter { it.name.startsWith("$prefix.") && it.name.endsWith(".kt") }
+        .sortedBy { it.name }
+}

--- a/codegen/src/test/kotlin/RegenerateGoldens.kt
+++ b/codegen/src/test/kotlin/RegenerateGoldens.kt
@@ -1,0 +1,57 @@
+/**
+ *
+ * (C) 2016 - 2021 KISTLER INSTRUMENTE AG, Winterthur, Switzerland
+ * (C) 2016 - 2024 Stanislav Angelovic <stanislav.angelovic@protonmail.com>
+ * (C) 2024 - 2025 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus
+
+import java.io.File
+
+/**
+ * Rewrites the checked-in golden files of every fixture directory under the test-resources
+ * directory named by the single argument, from its `test.xml`. For use after an intentional
+ * generator change: `./gradlew :codegen:regenerateGoldens`, then review the resulting `git diff`
+ * before committing it.
+ *
+ * This is deliberately a separate entry point from [GeneratorTest], which only ever compares.
+ * Regenerating and verifying are then different operations that cannot be mistaken for each other —
+ * no run of the test suite can write the answer it is about to check.
+ */
+fun main(args: Array<String>) {
+    require(args.size == 1) { "usage: RegenerateGoldens <test-resources-dir>" }
+    val resources = File(args[0])
+    val fixtures = resources.listFiles().orEmpty()
+        .filter { File(it, "test.xml").isFile }
+        .sortedBy { it.name }
+    require(fixtures.isNotEmpty()) { "No fixture directories with a test.xml found in $resources" }
+
+    var written = 0
+    for (testRoot in fixtures) {
+        for (fixture in GoldenFixture.entries) {
+            val generated = fixture.generate(testRoot)
+            fixture.goldenFiles(testRoot).forEach { it.delete() }
+            generated.forEachIndexed { index, fileSpec ->
+                File(testRoot, "${fixture.prefix}.$index.kt").writeText(fileSpec.toString())
+                written++
+            }
+        }
+    }
+    println("Regenerated $written golden files across ${fixtures.size} fixtures in $resources")
+}


### PR DESCRIPTION
Fixes #206.

> **Reworded after review.** The first version of this description (and of the commit message) claimed the old `WRITE_FILES = true` path "could not fail" and would have kept CI green. That was a prediction, not a measurement, and the reviewer measured it out at **24 failures on the first run**. The mechanism below is the corrected, measured one; the diff is unchanged apart from the reviewer's non-blocking `GoldenFixture` simplification.

## The defect

`GeneratorTest.assertFiles` wrote the goldens (`WRITE_FILES` branch) and then **fell through** to the comparison that reads them back. What that produced is not an unconditional pass but a **self-healing gate: red once, then vacuously green forever.**

The write targeted `File("src/test/resources/${root.name}")` — relative to the test task's working directory, i.e. the `codegen` project dir — while the comparison reads `root`, resolved off the test **classpath** at `codegen/build/resources/test/<name>`. `processTestResources` has already copied by the time the test task runs, so the **first** invocation still compares against the committed goldens. But it leaves the rewritten files in `src/test/resources`, so the next invocation copies those in and from then on the comparison is the generator's output against a copy of itself.

Measured on `e2a9f88` with `WRITE_FILES = true` and a perturbed `InterfaceGenerator` (`"INTERFACE_NAME"` → `"INTERFACE_NAME_PROBE"`), stale results deleted, `--rerun`:

| run (same tree) | tests | failures | `GeneratorTest` |
|---|---|---|---|
| 1 | 86 | **24** | 23 of 23 `testInterface` RED; 25 goldens rewritten in the working tree |
| 2 | 86 | 1 | **69/69 green — vacuous** (the 1 is `CompilationIntegrationTest`, which reads no goldens) |

So a fresh single-invocation CI checkout would have caught a left-behind `true` once. The **normal developer loop — run, see red, run again — lands on run 2**, where the gate is silently dead and `git status` is the only trace. Nothing else guards it either: the flag is test-only, so neither `ktlintCheck` nor `apiCheck` sees it, and this is the codegen project's **only** output-correctness gate.

(Credit where due: those two runs were measured by the reviewer on this PR, not by me. #206 hedged correctly — "unreliable rather than obviously broken" — and my first draft dropped the hedge.)

## The fix — regeneration and verification are now different operations

Rather than two branches of one method (issue options 1/2/3, all of which keep a mode that can be left on the wrong side), the write path moved out of the test entirely:

- **`GeneratorTest` only reads.** `WRITE_FILES` is deleted — there is no mode left to mis-set, so "the committed default is the verifying one" is structural rather than something a reviewer has to re-check on every diff.
- **`./gradlew :codegen:regenerateGoldens`** (new `JavaExec` task → `RegenerateGoldens.kt`) rewrites the goldens from each fixture's `test.xml` for the workflow the flag existed to serve. It deletes the previous `prefix.*.kt` files first, so a generator that emits fewer files no longer leaves stale goldens behind — something `WRITE_FILES` got wrong.
- **`GoldenFixture`** is the single definition of what a golden is (which generator, which prefix, which files, what order), shared by the writer and the verifier so the two cannot drift.
- **Pre-flight guard**, in the spirit of #223: a fixture with no goldens of a given kind previously compared `0 == 0` and passed. No fixture is in that state today (#206 measured that) and now none can reach it silently.

Docs: `AGENTS.md` gains the command; the `CLAUDE.md` maintenance bullet said to regenerate the checked-in fixtures with `apiDump`, which only ever regenerated the BCV dumps — it now names the right task for each.

## Demonstrated RED — the gate can fail now

All runs on the fixed branch, fresh JUnit XML, stale `test-results` deleted first.

**A. A golden diverges from the generator** — `public fun register()` → `registerCORRUPTED()` in `SimpleXmlTest/interface.0.kt`:

```
XMLFILES=5 tests=86 failures=1 errors=0 skipped=0
GeneratorTest > testInterface(File) > [21] .../build/resources/test/SimpleXmlTest FAILED
    org.opentest4j.AssertionFailedError at GeneratorTest.kt:70
FAILED: [21] .../SimpleXmlTest | org.opentest4j.AssertionFailedError: expected: <package org.foo
...
public interface Background {
  public fun registerCORRUPTED()
...
```

**B. The generator diverges from the goldens** — `add("call { -> Unit }\n")` → `add("call { -> Unit } /* probe */\n")` in `ProxyGenerator.kt:181`:

```
XMLFILES=5 tests=86 failures=2 errors=0 skipped=0
FAILED: [20] .../SignalArgShapesTest | org.opentest4j.AssertionFailedError: expected: <package org.example.signals ...
FAILED: [21] .../SimpleXmlTest      | org.opentest4j.AssertionFailedError: expected: <package org.foo ...
```

Under the old code this is the case that decays: the two fixtures get overwritten with the probe output, and the *next* run of the same suite reports them green.

**C. Goldens missing entirely** (the new pre-flight) — `rm SimpleXmlTest/proxy.0.kt`:

```
XMLFILES=5 tests=86 failures=1 errors=0 skipped=0
FAILED: [21] .../SimpleXmlTest | org.opentest4j.AssertionFailedError:
  No proxy.*.kt golden files in SimpleXmlTest; run :codegen:regenerateGoldens and commit them
  ==> expected: <true> but was: <false>
```

Each break was reverted; `git status --porcelain` after the sequence listed only this PR's own files. (A) and (C) were re-run after the reword commit and still go red identically.

## Demonstrated regeneration

- **Idempotent against the committed tree**: `./gradlew :codegen:regenerateGoldens` → `Regenerated 80 golden files across 23 fixtures`, and `git status --porcelain codegen/src/test/resources` came back **empty**. The regenerator reproduces every checked-in golden byte-for-byte. Re-confirmed after the reword commit.
- **Tracks a real generator change**: with the `/* probe */` edit above still applied, the same command updated exactly the two affected goldens —

  ```
   M codegen/src/test/resources/SignalArgShapesTest/proxy.0.kt
   M codegen/src/test/resources/SimpleXmlTest/proxy.0.kt
  -        call { -> Unit }
  +        call { -> Unit } /* probe */
  ```

  and `:codegen:test` then went green against them (86/0/0), which is the intended workflow. Reverting `ProxyGenerator.kt` and re-running the task restored both goldens.

## Verification

| task | result |
|---|---|
| `:codegen:test` (fresh XML, `--rerun`, stale results deleted) | **86 tests, 0 failures, 0 errors, 0 skipped** — `GeneratorTest` 69 (23 fixtures × 3), `Xml2KotlinOptionsTest` 7, `CodegenNamingAndTypeTest` 5, `CodegenParsingEdgeCaseTest` 4, `CompilationIntegrationTest` 1 |
| `ktlintCheck apiCheck` | **BUILD SUCCESSFUL** |

Pure JVM; no D-Bus session bus was used or needed. JDK 21. Both re-run after the reword commit.

**No golden fixture changed.** `git status --porcelain` on the final tree is empty; the commit touches only `AGENTS.md`, `CLAUDE.md`, `codegen/build.gradle.kts`, `codegen/src/test/kotlin/GeneratorTest.kt`, and the two new test files.

**`codegen/api/codegen.api` does not move** — the change is confined to the test source set and the build script, and `apiCheck` passes unchanged. No binary break, so the open owner question on #217 is untouched.

## Review follow-ups taken

- **Blocking**: commit message and this body reworded to the measured mechanism above; the `0 failures` prediction is gone.
- **Non-blocking**: `GoldenFixture.generate()`'s `when (this)` replaced by a constructor parameter (`INTERFACE("interface", ::InterfaceGenerator)`), as suggested.
- **Non-blocking, not taken**: the "generator emits zero files → pre-flight advises a regeneration that cannot fix it" corner is unreachable today (all 23 fixtures have all three prefixes, 80 files) and would be a generator bug rather than a fixture one, so it did not seem worth a caveat in the message.
