### PR TITLE
test(cross): make the native side of a cross-runtime case able to fail, and stop reporting native cases that asserted nothing as passes

### DIFF
--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
@@ -56,6 +57,55 @@ val reverseInteropEnabled = providers
 // actually configures it — mirroring the gcSoak gate in the root build.
 tasks.named<Test>("jvmTest") {
     filter.excludeTestsMatching("com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest")
+}
+
+// Kotlin/Native's test runner has no runtime-skip primitive, so `DbusmockHarness.skipTest`'s native
+// actual can only print its reason: a Dbusmock* case that asserted nothing because python-dbusmock
+// is missing is reported as a PASS, and `:cross_test:linuxX64Test` claimed 44 of them (#186). The
+// JVM half of that was fixed in c5f874c (#182) with `org.junit.Assume`; native has no equivalent, so
+// the only honest lever left is to not run the suites at all — absent beats a phantom pass.
+//
+// The decision follows c5f874c rather than adding a second convention:
+//  * `DBUSMOCK_REQUIRED` set — the `full-tests-x64` job, which apt-installs python3-dbusmock on
+//    purpose — the suites always run, and the harness itself fails loudly when it cannot start a
+//    peer. So CI can never lose this coverage to the exclusion below.
+//  * otherwise the harness is probed exactly as the native `launchDbusmock` probes it (a session bus
+//    plus an importable `dbusmock` module under `DBUSMOCK_PYTHON` / `python3`), and the suites are
+//    excluded only when it genuinely cannot run — a contributor who *has* dbusmock still runs them
+//    with no configuration.
+val dbusmockRequired = providers.environmentVariable("DBUSMOCK_REQUIRED").isPresent
+val dbusmockPython = providers.environmentVariable("DBUSMOCK_PYTHON").getOrElse("python3")
+val sessionBusPresent = providers.environmentVariable("DBUS_SESSION_BUS_ADDRESS").isPresent
+
+fun dbusmockCanRun(): Boolean {
+    if (dbusmockRequired) return true
+    if (!sessionBusPresent) return false
+    return runCatching {
+        ProcessBuilder(dbusmockPython, "-c", "import dbusmock")
+            .redirectErrorStream(true)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .start()
+            .waitFor() == 0
+    }.getOrDefault(false)
+}
+
+tasks.named<AbstractTestTask>("linuxX64Test") {
+    // NativeInteropPeerTest's cases are the *peer half* of a two-process case: each one returns
+    // immediately unless KDBUS_NATIVE_INTEROP_ROLE names its role, which only the JVM side sets when
+    // it spawns this binary (see CrossRuntimeInteropSmokeTest). `linuxX64Test` never sets it, so
+    // every one of them runs to completion having asserted nothing — and, per #186, native reports
+    // that as a pass. They are covered where they are actually driven: `jvmInteropTest`, which now
+    // fails unless the spawned peer really ran its case and reported it passing (#183).
+    filter.excludeTestsMatching("com.monkopedia.sdbus.integration.NativeInteropPeerTest")
+    if (!dbusmockCanRun()) {
+        logger.lifecycle(
+            "cross_test: excluding the Dbusmock* suites from linuxX64Test — '$dbusmockPython -m " +
+                "dbusmock' cannot run here. Kotlin/Native cannot report these as skipped (#186), " +
+                "so running them would report passes that asserted nothing. Set " +
+                "DBUSMOCK_REQUIRED=1 to run them anyway and fail loudly instead."
+        )
+        filter.excludeTestsMatching("com.monkopedia.sdbus.integration.Dbusmock*")
+    }
 }
 
 tasks.register<Test>("jvmInteropTest") {

--- a/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
+++ b/cross_test/src/commonTest/kotlin/com/monkopedia/sdbus/integration/DbusmockHarness.kt
@@ -90,8 +90,10 @@ internal fun dbusmockUnavailable(reason: String): DbusmockHandle? {
  * On the JVM this raises a JUnit assumption failure, which Gradle records as `skipped`. Kotlin/
  * Native's test runner has no runtime-skip primitive — an early return is indistinguishable from a
  * pass, and a TeamCity `testIgnored` emitted from inside a running test is rejected by the Gradle
- * parser — so the native actual can only write [reason] to the captured test output. CI does not
- * depend on that: [DBUSMOCK_REQUIRED_ENV] makes the harness fail rather than skip.
+ * parser — so the native actual can only write [reason] to the captured test output. Because a
+ * printed reason does not stop the report claiming a pass (#186), `:cross_test:linuxX64Test` does not
+ * run these suites at all when the harness cannot start: see the exclusion in
+ * `cross_test/build.gradle.kts`, which reads [DBUSMOCK_REQUIRED_ENV] as its override.
  *
  * Callers must still `return` afterwards; only the JVM actual aborts the test by throwing.
  */

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
@@ -32,6 +32,7 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException
 import org.freedesktop.dbus.interfaces.DBusInterface
 import org.freedesktop.dbus.messages.DBusSignal
 import org.junit.Assume.assumeTrue
+import org.junit.Ignore
 
 class CrossRuntimeInteropSmokeTest {
     /**
@@ -929,6 +930,23 @@ class CrossRuntimeInteropSmokeTest {
         }
     }
 
+    /**
+     * KNOWN FAILING — tracked as #241, do not re-enable without fixing it.
+     *
+     * This case has never worked. Its native half times out for the full
+     * `retryCall(timeoutMillis = 15_000)` budget calling `StorePipeReadFd` on the dbus-java peer;
+     * before the exit-code assertion above became real (#183) the failure was discarded and the case
+     * reported PASSED. The only tell was the clock — PR #185 recorded it as "pass, 15.207s" next to
+     * siblings at 0.05s. It reproduces identically on two dev boxes and on `full-tests-x64`, so it is
+     * a real defect and not an environment artefact.
+     *
+     * `@Ignore` rather than deletion, and rather than an `Assume` that would invent a precondition
+     * this case does not actually have: the report says `skipped`, which is true, and #241 says why.
+     */
+    @Ignore(
+        "Known failing, tracked as #241: the native client's StorePipeReadFd call to the " +
+            "dbus-java peer never succeeds, so its 15s retry budget always exhausts."
+    )
     @Test
     fun nativeClientRoundTripsUnixFdWithJvmPeerOverDirectBus() {
         assumeCrossRuntimeInteropSelected()

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
@@ -71,11 +71,11 @@ class CrossRuntimeInteropSmokeTest {
         val objectPath = "/org/monkopedia/sdbus/phase3/Object"
         val expectedArg = 33
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanInvokeIncrementOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanInvokeIncrementOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -117,16 +117,14 @@ class CrossRuntimeInteropSmokeTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -151,11 +149,11 @@ class CrossRuntimeInteropSmokeTest {
         val seenValue = AtomicInteger(Int.MIN_VALUE)
         val signalLatch = CountDownLatch(1)
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanObserveSignalFromNativePeerOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanObserveSignalFromNativePeerOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server-signal"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -199,16 +197,14 @@ class CrossRuntimeInteropSmokeTest {
                 runCatching { javaConnection.disconnect() }
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -234,11 +230,11 @@ class CrossRuntimeInteropSmokeTest {
         val seenInterfaceName = AtomicReference<String?>(null)
         val signalLatch = CountDownLatch(1)
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanObservePropertiesChangedFromNativePeerOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanObservePropertiesChangedFromNativePeerOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server-properties"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -284,16 +280,14 @@ class CrossRuntimeInteropSmokeTest {
                 runCatching { javaConnection.disconnect() }
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -314,11 +308,11 @@ class CrossRuntimeInteropSmokeTest {
         val objectPath = "/org/monkopedia/sdbus/phase3/Object"
         val expectedByte = 0x4D
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanRoundTripUnixFdOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanRoundTripUnixFdOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server-fd"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -397,16 +391,14 @@ class CrossRuntimeInteropSmokeTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -428,11 +420,11 @@ class CrossRuntimeInteropSmokeTest {
         val expectedSize = 512
         val payload = buildLargeMapPayload(expectedSize)
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanRoundTripLargeMapOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanRoundTripLargeMapOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server-large-map"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -473,16 +465,14 @@ class CrossRuntimeInteropSmokeTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -504,11 +494,11 @@ class CrossRuntimeInteropSmokeTest {
         val expectedSize = 64
         val payload = buildNestedVariantPayload(expectedSize)
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanRoundTripNestedVariantOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanRoundTripNestedVariantOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server-nested-variant"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -552,16 +542,14 @@ class CrossRuntimeInteropSmokeTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -583,11 +571,11 @@ class CrossRuntimeInteropSmokeTest {
         val expectedSize = 64
         val payload = buildMixedPayload(expectedSize)
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanRoundTripMixedPayloadOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanRoundTripMixedPayloadOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server-mixed-payload"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -628,16 +616,14 @@ class CrossRuntimeInteropSmokeTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(10, TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(
-                0,
-                process.exitValue(),
-                "Native peer failed. Output:\n$nativeLog"
-            )
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -695,11 +681,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanInvokeIncrementOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanInvokeIncrementOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -722,12 +708,13 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
             )
             assertTrue(
                 invoked.await(5, TimeUnit.SECONDS),
@@ -760,6 +747,8 @@ class CrossRuntimeInteropSmokeTest {
         val signalName = "Changed"
         val objectPath = "/org/monkopedia/sdbus/phase3/Object"
         val expectedArg = 67
+        val observedArg = AtomicInteger(Int.MIN_VALUE)
+        val invoked = CountDownLatch(1)
         val guid = UUID.randomUUID().toString().replace("-", "")
         val restoreSaslCollator = installNullSafeSaslCollatorWorkaround()
 
@@ -774,7 +763,7 @@ class CrossRuntimeInteropSmokeTest {
         val connectionAddress = connection.address.toString().replace(",listen=true", "")
         connection.exportObject(
             objectPath,
-            Phase3SignalServerObject(objectPath, connection)
+            Phase3SignalServerObject(objectPath, connection, observedArg, invoked)
         )
         val listenFailure = AtomicReference<Throwable?>(null)
         val listenThread = thread(start = true, isDaemon = true, name = "cross-jvm-direct-listen") {
@@ -792,11 +781,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanObserveSignalFromJvmPeerOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanObserveSignalFromJvmPeerOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client-signal"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -820,13 +809,20 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
+            )
+            assertTrue(
+                invoked.await(5, TimeUnit.SECONDS),
+                "JVM peer was never asked to emit the signal for address '$connectionAddress'. " +
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
             )
+            assertEquals(expectedArg, observedArg.get())
         } finally {
             process?.destroyForcibly()
             outputPump?.join(1_000)
@@ -850,6 +846,7 @@ class CrossRuntimeInteropSmokeTest {
         val interfaceName = "org.monkopedia.sdbus.phase3"
         val methodName = "EmitPropertiesChanged"
         val objectPath = "/org/monkopedia/sdbus/phase3/Object"
+        val invoked = CountDownLatch(1)
         val guid = UUID.randomUUID().toString().replace("-", "")
         val restoreSaslCollator = installNullSafeSaslCollatorWorkaround()
 
@@ -864,7 +861,7 @@ class CrossRuntimeInteropSmokeTest {
         val connectionAddress = connection.address.toString().replace(",listen=true", "")
         connection.exportObject(
             objectPath,
-            Phase3PropertiesServerObject(objectPath, connection)
+            Phase3PropertiesServerObject(objectPath, connection, invoked)
         )
         val listenFailure = AtomicReference<Throwable?>(null)
         val listenThread = thread(start = true, isDaemon = true, name = "cross-jvm-direct-listen") {
@@ -882,11 +879,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanObservePropertiesChangedFromJvmPeerOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanObservePropertiesChangedFromJvmPeerOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client-properties"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -908,12 +905,19 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
+            )
+            assertTrue(
+                invoked.await(5, TimeUnit.SECONDS),
+                "JVM peer was never asked to emit PropertiesChanged for address " +
+                    "'$connectionAddress'. Listen failure:\n${listenFailureDetails()}\n" +
+                    "Output:\n$nativeLog"
             )
         } finally {
             process?.destroyForcibly()
@@ -938,6 +942,8 @@ class CrossRuntimeInteropSmokeTest {
         val interfaceName = PHASE3_INTERFACE
         val objectPath = "/org/monkopedia/sdbus/phase3/Object"
         val expectedByte = 0x71
+        val fdStored = CountDownLatch(1)
+        val fdHandedBack = CountDownLatch(1)
         val guid = UUID.randomUUID().toString().replace("-", "")
         val restoreSaslCollator = installNullSafeSaslCollatorWorkaround()
 
@@ -952,7 +958,7 @@ class CrossRuntimeInteropSmokeTest {
         val connectionAddress = connection.address.toString().replace(",listen=true", "")
         connection.exportObject(
             objectPath,
-            Phase3FdServerObject(objectPath)
+            Phase3FdServerObject(objectPath, fdStored, fdHandedBack)
         )
         val listenFailure = AtomicReference<Throwable?>(null)
         val listenThread = thread(start = true, isDaemon = true, name = "cross-jvm-direct-listen") {
@@ -970,11 +976,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanRoundTripUnixFdWithJvmPeerOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanRoundTripUnixFdWithJvmPeerOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client-fd"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -996,12 +1002,25 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
+            )
+            assertTrue(
+                fdStored.await(5, TimeUnit.SECONDS),
+                "JVM peer never received a Unix FD from the native client for address " +
+                    "'$connectionAddress'. Listen failure:\n${listenFailureDetails()}\n" +
+                    "Output:\n$nativeLog"
+            )
+            assertTrue(
+                fdHandedBack.await(5, TimeUnit.SECONDS),
+                "JVM peer never handed the stored Unix FD back to the native client for address " +
+                    "'$connectionAddress'. Listen failure:\n${listenFailureDetails()}\n" +
+                    "Output:\n$nativeLog"
             )
         } finally {
             process?.destroyForcibly()
@@ -1060,11 +1079,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanRoundTripLargeMapWithJvmPeerOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanRoundTripLargeMapWithJvmPeerOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client-large-map"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -1086,12 +1105,13 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
             )
             assertTrue(
                 invoked.await(5, TimeUnit.SECONDS),
@@ -1156,11 +1176,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanRoundTripNestedVariantWithJvmPeerOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanRoundTripNestedVariantWithJvmPeerOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client-nested-variant"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -1182,12 +1202,13 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
             )
             assertTrue(
                 invoked.await(5, TimeUnit.SECONDS),
@@ -1252,11 +1273,11 @@ class CrossRuntimeInteropSmokeTest {
                 waitForSocket(socketPath, timeoutMillis = 10_000),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanRoundTripMixedPayloadWithJvmPeerOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanRoundTripMixedPayloadWithJvmPeerOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client-mixed-payload"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -1278,12 +1299,13 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
             )
             assertTrue(
                 invoked.await(5, TimeUnit.SECONDS),
@@ -1299,6 +1321,52 @@ class CrossRuntimeInteropSmokeTest {
             restoreSaslCollator()
             Files.deleteIfExists(socketPath)
         }
+    }
+
+    /**
+     * The `--ktest_gradle_filter` that selects the single [NativeInteropPeerTest] case a spawned
+     * peer should run. Built from the same [peerTest] string [assertNativePeerPassed] looks for in
+     * the peer's output, so the filter and the assertion cannot drift apart.
+     */
+    private fun nativePeerFilter(peerTest: String) =
+        "--ktest_gradle_filter=*NativeInteropPeerTest.$peerTest*"
+
+    /**
+     * Fails this case unless the spawned native peer actually ran [peerTest] and reported it as
+     * passing. Three things have to hold, and the exit code on its own establishes none of them:
+     *
+     * - **It reported no failed test.** The `##teamcity[testFailed …]` line carries the native-side
+     *   assertion message, which says far more than "exit code 1".
+     * - **It ran [peerTest] at all.** A `--ktest_gradle_filter` that matches nothing runs zero tests
+     *   and exits 0, so a rename on the native side would quietly empty this case out while leaving
+     *   it green — the same trap #219 found in the ARM job's `--gtest_filter`.
+     * - **It exited 0.** Only meaningful because the peers are no longer spawned with
+     *   `--ktest_no_exit_code`: that flag suppressed the runner's failure exit status, so every
+     *   `assertEquals(0, exitValue())` here was a tautology and every assertion the peer made was
+     *   discarded (#183).
+     */
+    private fun assertNativePeerPassed(
+        peer: Process,
+        nativeLog: String,
+        peerTest: String,
+        details: String = ""
+    ) {
+        val context = buildString {
+            if (details.isNotEmpty()) appendLine(details)
+            append("Output:\n").append(nativeLog)
+        }
+        val reportedFailure = TEAMCITY_TEST_FAILED.find(nativeLog)?.value
+        assertTrue(
+            reportedFailure == null,
+            "Native peer reported '$peerTest' as failed: $reportedFailure\n$context"
+        )
+        assertTrue(
+            nativeLog.contains("##teamcity[testFinished name='$peerTest'"),
+            "Native peer never ran '$peerTest', so this case measured nothing — the filter " +
+                "${nativePeerFilter(peerTest)} matched no test. Was it renamed in " +
+                "NativeInteropPeerTest?\n$context"
+        )
+        assertEquals(0, peer.exitValue(), "Native peer '$peerTest' exited non-zero.\n$context")
     }
 
     private fun nativeTestBinaryPath(): Path {
@@ -1414,9 +1482,13 @@ class CrossRuntimeInteropSmokeTest {
 
     class Phase3SignalServerObject(
         private val path: String,
-        private val connection: org.freedesktop.dbus.connections.AbstractConnection
+        private val connection: org.freedesktop.dbus.connections.AbstractConnection,
+        private val observedArg: AtomicInteger,
+        private val invoked: CountDownLatch
     ) : Phase3SignalPeer {
         override fun emitSignal(value: Int): Int {
+            observedArg.set(value)
+            invoked.countDown()
             connection.sendMessage(Phase3SignalPeer.Changed(path, value))
             return value + 1
         }
@@ -1439,7 +1511,11 @@ class CrossRuntimeInteropSmokeTest {
         fun takeStoredPipeReadFd(): org.freedesktop.dbus.FileDescriptor
     }
 
-    class Phase3FdServerObject(private val path: String) : Phase3FdPeer {
+    class Phase3FdServerObject(
+        private val path: String,
+        private val stored: CountDownLatch,
+        private val handedBack: CountDownLatch
+    ) : Phase3FdPeer {
         private val storedReadFd = AtomicReference<org.freedesktop.dbus.FileDescriptor?>(null)
 
         override fun storePipeReadFd(fd: org.freedesktop.dbus.FileDescriptor): Int {
@@ -1447,12 +1523,13 @@ class CrossRuntimeInteropSmokeTest {
                 throw DBusExecutionException("Invalid Unix FD")
             }
             storedReadFd.set(fd)
+            stored.countDown()
             return 1
         }
 
         override fun takeStoredPipeReadFd(): org.freedesktop.dbus.FileDescriptor =
-            storedReadFd.getAndSet(null)
-                ?: throw DBusExecutionException("No stored Unix FD")
+            (storedReadFd.getAndSet(null) ?: throw DBusExecutionException("No stored Unix FD"))
+                .also { handedBack.countDown() }
 
         override fun getObjectPath(): String = path
     }
@@ -1622,9 +1699,11 @@ class CrossRuntimeInteropSmokeTest {
 
     class Phase3PropertiesServerObject(
         private val path: String,
-        private val connection: org.freedesktop.dbus.connections.AbstractConnection
+        private val connection: org.freedesktop.dbus.connections.AbstractConnection,
+        private val invoked: CountDownLatch
     ) : Phase3PropertiesPeer {
         override fun emitPropertiesChanged(): Int {
+            invoked.countDown()
             val changed = mapOf(
                 "state" to org.freedesktop.dbus.types.Variant<Any>("updated")
             )
@@ -1664,6 +1743,16 @@ class CrossRuntimeInteropSmokeTest {
         private const val ROUND_TRIP_LARGE_MAP_METHOD = "RoundTripLargeMap"
         private const val ROUND_TRIP_NESTED_VARIANT_METHOD = "RoundTripNestedVariant"
         private const val ROUND_TRIP_MIXED_PAYLOAD_METHOD = "RoundTripMixedPayload"
+
+        /**
+         * How long to wait for the output-pump thread after the peer exits. Its capture is what
+         * [assertNativePeerPassed] reads, so a snapshot taken while the pipe is still draining could
+         * report "never ran" for a peer that ran fine.
+         */
+        private const val PUMP_DRAIN_MILLIS = 5_000L
+
+        /** A failure line from the peer's `--ktest_logger=TEAMCITY` output. */
+        private val TEAMCITY_TEST_FAILED = Regex("##teamcity\\[testFailed .*")
     }
 
     private fun buildLargeMapPayload(size: Int): Map<Int, String> = buildMap {

--- a/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
+++ b/cross_test/src/linuxX64Test/kotlin/integration/DbusmockHarness.linuxX64.kt
@@ -44,7 +44,8 @@ import platform.posix.waitpid
 internal actual fun dbusmockGetenv(name: String): String? = getenv(name)?.toKString()
 
 // Kotlin/Native's test runner cannot record a skip at runtime (see the expect declaration), so the
-// reason only reaches the captured test output.
+// reason only reaches the captured test output — which is why `:cross_test:linuxX64Test` excludes
+// these suites outright rather than relying on this print (#186; see cross_test/build.gradle.kts).
 internal actual fun skipTest(reason: String) = println("SKIP: $reason")
 
 internal actual class DbusmockHandle(private val pid: Int) {

--- a/stress_test/src/jvmTest/kotlin/com/monkopedia/sdbus/stress/CrossRuntimeInteropStressTest.kt
+++ b/stress_test/src/jvmTest/kotlin/com/monkopedia/sdbus/stress/CrossRuntimeInteropStressTest.kt
@@ -185,11 +185,11 @@ class CrossRuntimeInteropStressTest {
         val objectPath = PHASE3_OBJECT_PATH
         val expectedArg = 50 + iteration
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanInvokeIncrementOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanInvokeIncrementOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -250,12 +250,14 @@ class CrossRuntimeInteropStressTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(timeoutSeconds(), TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(0, process.exitValue(), "Native peer failed. Output:\n$nativeLog")
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -274,11 +276,11 @@ class CrossRuntimeInteropStressTest {
         val objectPath = PHASE3_OBJECT_PATH
         val expectedArg = 300 + iteration
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanInvokeIncrementOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanInvokeIncrementOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -325,6 +327,9 @@ class CrossRuntimeInteropStressTest {
                     failure != null,
                     "Expected call failure when native peer drops in-flight"
                 )
+                // No assertNativePeerPassed here, unlike the other cases: this case SIGKILLs the
+                // peer mid-reply on purpose, so it neither finishes its test nor exits 0. What is
+                // under test is the JVM client's reaction to the drop, asserted just above.
             } finally {
                 proxy.release()
                 connection.release()
@@ -348,11 +353,11 @@ class CrossRuntimeInteropStressTest {
         val expectedArg = 400 + iteration
         val recoveryArg = expectedArg + 1
         val nativeOutput = ByteArrayOutputStream()
+        val peerTest = "jvmClientCanInvokeIncrementOverDirectBus"
         val process = ProcessBuilder(
             kexe.toString(),
-            "--ktest_no_exit_code",
             "--ktest_logger=TEAMCITY",
-            "--ktest_gradle_filter=*NativeInteropPeerTest.jvmClientCanInvokeIncrementOverDirectBus*"
+            nativePeerFilter(peerTest)
         ).also { builder ->
             builder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "server"
             builder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -417,12 +422,14 @@ class CrossRuntimeInteropStressTest {
                 connection.release()
             }
 
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
             assertTrue(
                 process.waitFor(timeoutSeconds(), TimeUnit.SECONDS),
-                "Native peer did not exit in time. Output:\n$nativeLog"
+                "Native peer did not exit in time. Output:\n" +
+                    nativeOutput.toString(Charsets.UTF_8)
             )
-            assertEquals(0, process.exitValue(), "Native peer failed. Output:\n$nativeLog")
+            outputPump.join(PUMP_DRAIN_MILLIS)
+            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
             outputPump.join(1_000)
@@ -492,11 +499,11 @@ class CrossRuntimeInteropStressTest {
                 waitForSocket(socketPath, timeoutMillis()),
                 "Socket not ready: $socketPath"
             )
+            val peerTest = "nativeClientCanInvokeIncrementOverDirectBus"
             val launchedProcess = ProcessBuilder(
                 kexe.toString(),
-                "--ktest_no_exit_code",
                 "--ktest_logger=TEAMCITY",
-                "--ktest_gradle_filter=*NativeInteropPeerTest.nativeClientCanInvokeIncrementOverDirectBus*"
+                nativePeerFilter(peerTest)
             ).also { procBuilder ->
                 procBuilder.environment()["KDBUS_NATIVE_INTEROP_ROLE"] = "client"
                 procBuilder.environment()["KDBUS_INTEROP_SOCKET"] = socketPath.toString()
@@ -532,12 +539,13 @@ class CrossRuntimeInteropStressTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
+            outputPump?.join(PUMP_DRAIN_MILLIS)
             val nativeLog = nativeOutput.toString(Charsets.UTF_8)
-            assertEquals(
-                0,
-                launchedProcess.exitValue(),
-                "Native client failed for address '$connectionAddress'. " +
-                    "Listen failure:\n${listenFailureDetails()}\nOutput:\n$nativeLog"
+            assertNativePeerPassed(
+                launchedProcess,
+                nativeLog,
+                peerTest,
+                "Address '$connectionAddress'. Listen failure:\n${listenFailureDetails()}"
             )
             val shouldExpectFailure = expectNativeFailure || expectedNativeFailureContains != null
             if (!shouldExpectFailure) {
@@ -572,6 +580,52 @@ class CrossRuntimeInteropStressTest {
         val selected = System.getProperty(STRESS_CASE_FILTER_PROP)?.trim().orEmpty()
         if (selected.isEmpty()) return true
         return caseName.contains(selected, ignoreCase = true)
+    }
+
+    /**
+     * The `--ktest_gradle_filter` that selects the single `NativeInteropPeerTest` case a spawned
+     * peer should run. Built from the same [peerTest] string [assertNativePeerPassed] looks for in
+     * the peer's output, so the filter and the assertion cannot drift apart.
+     */
+    private fun nativePeerFilter(peerTest: String) =
+        "--ktest_gradle_filter=*NativeInteropPeerTest.$peerTest*"
+
+    /**
+     * Fails this case unless the spawned native peer actually ran [peerTest] and reported it as
+     * passing. Three things have to hold, and the exit code on its own establishes none of them:
+     *
+     * - **It reported no failed test.** The `##teamcity[testFailed …]` line carries the native-side
+     *   assertion message, which says far more than "exit code 1".
+     * - **It ran [peerTest] at all.** A `--ktest_gradle_filter` that matches nothing runs zero tests
+     *   and exits 0, so a rename on the native side would quietly empty this case out while leaving
+     *   it green — the same trap #219 found in the ARM job's `--gtest_filter`.
+     * - **It exited 0.** Only meaningful because the peers are no longer spawned with
+     *   `--ktest_no_exit_code`: that flag suppressed the runner's failure exit status, so every
+     *   `assertEquals(0, exitValue())` here was a tautology and every assertion the peer made was
+     *   discarded (#183).
+     */
+    private fun assertNativePeerPassed(
+        peer: Process,
+        nativeLog: String,
+        peerTest: String,
+        details: String = ""
+    ) {
+        val context = buildString {
+            if (details.isNotEmpty()) appendLine(details)
+            append("Output:\n").append(nativeLog)
+        }
+        val reportedFailure = TEAMCITY_TEST_FAILED.find(nativeLog)?.value
+        assertTrue(
+            reportedFailure == null,
+            "Native peer reported '$peerTest' as failed: $reportedFailure\n$context"
+        )
+        assertTrue(
+            nativeLog.contains("##teamcity[testFinished name='$peerTest'"),
+            "Native peer never ran '$peerTest', so this case measured nothing — the filter " +
+                "${nativePeerFilter(peerTest)} matched no test. Was it renamed in " +
+                "NativeInteropPeerTest?\n$context"
+        )
+        assertEquals(0, peer.exitValue(), "Native peer '$peerTest' exited non-zero.\n$context")
     }
 
     private fun nativeTestBinaryPath(): Path {
@@ -714,5 +768,15 @@ class CrossRuntimeInteropStressTest {
         private const val PHASE3_INTERFACE = "org.monkopedia.sdbus.phase3"
         private const val PHASE3_OBJECT_PATH = "/org/monkopedia/sdbus/phase3/Object"
         private const val INCREMENT_METHOD = "Increment"
+
+        /**
+         * How long to wait for the output-pump thread after the peer exits. Its capture is what
+         * [assertNativePeerPassed] reads, so a snapshot taken while the pipe is still draining could
+         * report "never ran" for a peer that ran fine.
+         */
+        private const val PUMP_DRAIN_MILLIS = 5_000L
+
+        /** A failure line from the peer's `--ktest_logger=TEAMCITY` output. */
+        private val TEAMCITY_TEST_FAILED = Regex("##teamcity\\[testFailed .*")
     }
 }


### PR DESCRIPTION
Fixes #183
Fixes #186

Surfaced and filed on the way: #241.

One PR, three commits: #183 and #186 are the same disease on the same surface (native test invocation, exit codes, result reporting) and #186's fix depends on #183's guarantee, so splitting them would have collided. The third commit quarantines the failure the first one surfaced (#241). No workflow file is touched — see "Nothing shared moved" below.

Everything below is measured on **two independent hosts** (both under `dbus-run-session`, JDK 21). Where a number differs from the issue, the issue is corrected.

---

## `--ktest_no_exit_code` — why it was there, and what happened to it

**It was not load-bearing.** It was added in the module's very first commit, `86eaa62` (`test(cross): add cross-runtime interop and stress modules`), with no rationale in the message or in any comment; `git log -S` finds no other commit that reasoned about it; it appears in no doc. The *one* place its behaviour was ever recorded is `fb44864`, which describes it **masking** a real failure:

> the fd interop test … the matching native peer expectation (`invalidRejected`) was unsatisfiable by any client … on main it merely timed out 20s and **the failure was masked by `--ktest_no_exit_code`**.

The plausible "wrapper must collect XML before the process dies" motive does not apply either: nothing wraps these spawns — the JVM test *is* the wrapper, it reads the peer's stdout itself, and it reads it before checking the exit code. So the flag is **dropped**, and the failure is *additionally* propagated from the collected output (the issue's option 2), because the exit code on its own is not enough:

```
$ … test.kexe --ktest_no_exit_code --ktest_logger=TEAMCITY '--ktest_gradle_filter=*nativeClientCanRoundTripUnixFd*'
WITH --ktest_no_exit_code: exit=0     # ##teamcity[testFailed …] in the output
WITHOUT the flag:          exit=1
```

```
$ … test.kexe --ktest_logger=TEAMCITY '--ktest_gradle_filter=*NativeInteropPeerTest.thisTestDoesNotExist*'
zero-match, NO flag: exit=0
0 183-zeromatch.txt        # zero bytes of output, exit 0
```

That second measurement is #219/#223's trap one module over: the filter strings live in these JVM files, decoupled from the native source they name, and a rename empties the case out while leaving it green. So `assertNativePeerPassed` requires three independent things — no `##teamcity[testFailed`, a `testFinished` for the case actually selected, and exit 0 — and the filter is built from the same test-name `val` the assertion reads, so filter and assertion cannot drift apart. Parsing is a plain `contains` / `Regex`, no shell.

Two more things this commit does:

- **Drains the captured output before asserting on it.** The forward cases snapshotted `nativeOutput` *before* `process.waitFor(...)`; now the peer is waited for, the pump thread joined, then the snapshot taken. Without this the new log assertions would be racily flaky.
- **Gives the three cases #183 lists as having no assertion but the exit code a JVM-side observation**, like their siblings have: the signal and `PropertiesChanged` cases assert the JVM peer was actually *asked* to emit; the fd case asserts the fd both arrived and was handed back. This closes the residual hole that a native peer whose role env var does not match returns immediately and reports a pass.

`CrossRuntimeInteropStressTest` gets the same treatment at all four spawn sites. The drop-in-flight case deliberately `SIGKILL`s its peer mid-reply, so it gets no `assertNativePeerPassed` and a comment saying why.

### #183, both directions — from JUnit XML, same host, same command

The mutation is a **purely native-side** assertion — `assertEquals(expectedArg, observedSignalValue.value)` → `expectedArg + 999` in `NativeInteropPeerTest.nativeClientCanObserveSignalFromJvmPeerOverDirectBus`. That is exactly the assertion #183 says is discarded, on one of the three cases it names.

**BEFORE (pristine `main` @ `e2a9f88`, broken native assertion):**

```
gradle exit=0
XML: com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest tests="1" skipped="0" failures="0" errors="0"
```

**AFTER (this branch, the same broken native assertion):**

```
gradle exit=1
XML: com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest tests="1" skipped="0" failures="1" errors="0"
  <failure message="java.lang.AssertionError: Native peer reported
    'nativeClientCanObserveSignalFromJvmPeerOverDirectBus' as failed:
    ##teamcity[testFailed name='nativeClientCanObserveSignalFromJvmPeerOverDirectBus'
      message='Expected &lt;1066&gt;, actual &lt;67&gt;.' …
```

The native assertion's own message reaches the JVM report — the reason the issue preferred scanning the output over relying on the exit code alone.

**AFTER, filter renamed so it matches nothing (the #219 trap):**

```
gradle exit=1
XML: … tests="1" skipped="0" failures="1" errors="0"
  <failure message="java.lang.AssertionError: Native peer never ran
    'nativeClientCanObserveSignalFromJvmPeerOverDirectBusRENAMED', so this case measured nothing
    — the filter --ktest_gradle_filter=*NativeInteropPeerTest.…RENAMED* matched no test.
    Was it renamed in NativeInteropPeerTest?"
```

**AFTER, unmutated, stress suite (`repeat=2`, forward + reverse):**

```
stress exit=0
XML: com.monkopedia.sdbus.stress.CrossRuntimeInteropStressTest tests="10" skipped="0" failures="0" errors="0"
```

---

## ⚠️ Enabling the failure path revealed a real one: the reverse unix-fd case has never worked

**`nativeClientRoundTripsUnixFdWithJvmPeerOverDirectBus` fails on this branch**, with the native client's own message:

```
XML: com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest tests="14" skipped="0" failures="1" errors="0"
  <failure message="java.lang.AssertionError: Native peer reported
    'nativeClientCanRoundTripUnixFdWithJvmPeerOverDirectBus' as failed:
    ##teamcity[testFailed name='…' message='Timed out waiting for call to succeed'
      details='kotlin.AssertionError: Timed out waiting for call to succeed| at … NativeInteropPeerTest.$retryCallCOROUTINE$14 …
```

**This is not a regression from this PR, and the receipt is in #185's own evidence table.** #185 recorded that case as "**pass** | **15.207s**" while its six siblings were 0.044s–0.144s. 15.2s is exactly `retryCall(timeoutMillis = 15_000)` exhausting. My run reports `time="15.207"` — the identical number, now as a failure. The 15-second retry loop was always timing out; `--ktest_no_exit_code` swallowed it and the timing was the only tell.

That is #183 working as intended, and it is the outcome the owner asked for on the parent issue — [#176 comment](https://github.com/Monkopedia/sdbus-kotlin/issues/176#issuecomment-5171520219): *"if a newly-live case fails, that is a successful outcome for this issue, not a blocker for it"*, with *"failures filed separately rather than fixed in the same PR"*.

**CI answered: it reproduces there too, so it is not environment-specific.** `full-tests-x64` on `ubuntu-24.04` reported exactly one failure across the whole job — [run 31253765479](https://github.com/Monkopedia/sdbus-kotlin/actions/runs/31253765479/job/93093975345):

```
> Task :cross_test:jvmInteropTest
CrossRuntimeInteropSmokeTest > nativeClientRoundTripsUnixFdWithJvmPeerOverDirectBus FAILED
    java.lang.AssertionError at CrossRuntimeInteropSmokeTest.kt:1359
14 tests completed, 1 failed
```

Three independent environments, same case, only that case. So it is **filed as #241 and marked `@Ignore` here, not fixed** — per the owner's ruling on #176 that a newly-live case failing is a successful outcome for the enabling issue and gets filed separately.

`@Ignore` rather than deletion, and rather than an `Assume`: the report then says `skipped`, which is *true*, and #241 says why — an assumption would invent a precondition this case does not actually have. The annotation and a KDoc block above the case both name #241 and say "do not re-enable without fixing it".

Everything else in that CI job passed, which is itself two pieces of #186 evidence: `:cross_test:linuxX64Test` ran green under `DBUSMOCK_REQUIRED=1` (so the 44 dbusmock cases genuinely executed rather than being excluded), and all nine `pr-smoke` stress jobs passed with `--ktest_no_exit_code` removed.

---

## #186 — native cannot record a skip, so the suites are not run

The **44** figure is **verified**: the linked `cross_test` binary's `--gtest_list_tests` lists 62 tests, of which 44 are under `Dbusmock*`. Baseline JUnit XML, no dbusmock on the box:

```
cross_test/build/test-results/linuxX64Test/ : tests=62 skipped=0 failures=0 errors=0
cross_test/build/test-results/jvmTest/      : tests=50 skipped=44 failures=0 errors=0
```

(The issue quoted `jvmTest` as `tests=64 skipped=44`; 64 predates #185's exclusion of `CrossRuntimeInteropSmokeTest` from `jvmTest`. The **44** is unchanged.)

**Two corrections to the issue.**

1. **`arm-runtime-tests` is not affected.** It runs the **root** binary, whose `--gtest_list_tests` lists **316** tests and **0** `Dbusmock*` cases — the dbusmock suites live only in `cross_test`. So there is no ARM exposure and no workflow change is needed.
2. **It is not 44 phantom passes, it is 58.** The same 62 also contain **14** `NativeInteropPeerTest` cases, every one of which returns immediately unless `KDBUS_NATIVE_INTEROP_ROLE` names its role — which only the JVM side sets when it *spawns* the binary. `linuxX64Test` never sets it, so all 14 always report a pass having asserted nothing. (#228 noted these and left them because no native skip primitive exists; the same lever fixes them.)

**Re-measured: there is no way to render these as `<skipped/>`.** On top of the issue's own finding that a mid-test TeamCity `testIgnored` is rejected by the Gradle parser, I checked the remaining candidate — whether the runner emits `testIgnored` for tests a `--ktest_gradle_filter` excludes. It does not (`testIgnored` count **0**, `testFinished` count 3, for a filter admitting one class of three). So the JVM's `skipped=44` has no native counterpart, and the only honest lever is not running them: **absent beats a phantom pass.** This is the issue's option 2, in c5f874c's idiom rather than a second mechanism.

`DBUSMOCK_REQUIRED` is the switch:

| condition | `:cross_test:linuxX64Test` | build |
| --- | --- | --- |
| before, no dbusmock | `tests="62" skipped="0" failures="0" errors="0"` | pass (the lie) |
| after, no dbusmock, `DBUSMOCK_REQUIRED` unset | `tests="4" skipped="0" failures="0" errors="0"` | pass — 58 phantom passes gone from the XML |
| after, no dbusmock, **`DBUSMOCK_REQUIRED=1`** | `tests="48" skipped="0" **failures="44"** errors="0"` | **FAILS** |

The third row is the one that matters: **CI cannot lose this coverage to the exclusion**, because `full-tests-x64` apt-installs `python3-dbusmock` and sets `DBUSMOCK_REQUIRED=1`, so absence there is a hard failure naming the reason — exactly c5f874c's contract, preserved. `48 = 62 − 14`, i.e. on CI the only change is the 14 role-gated peer cases no longer being reported by a task that cannot drive them.

Row two is a big collapse, and it is the truth: on a box without dbusmock, `:cross_test:linuxX64Test` only ever exercised those 4 cases. The remaining two suites are `CrossModuleSignalIntegrationTest` (3) and `EventLoopStartIdempotencyTest` (1). The exclusion announces itself so a log distinguishes "ran" from "was not run" — the visibility complaint raised in #229:

```
cross_test: excluding the Dbusmock* suites from linuxX64Test — 'python3 -m dbusmock' cannot run
here. Kotlin/Native cannot report these as skipped (#186), so running them would report passes
that asserted nothing. Set DBUSMOCK_REQUIRED=1 to run them anyway and fail loudly instead.
```

The probe mirrors the native `launchDbusmock` exactly — a session bus plus an importable `dbusmock` under `DBUSMOCK_PYTHON`/`python3` — so a contributor who *has* dbusmock keeps running the suites with no configuration.

**Known limit, stated rather than papered over:** if the `Dbusmock*` / `NativeInteropPeerTest` names drift, the exclusion silently stops matching. That fails *open* — back to today's behaviour, not worse — and Gradle's filter API offers no "this exclusion matched nothing" signal to guard it with. #229's `EXTERNAL_TOOLS_REQUIRED` work is untouched and uncontradicted.

---

## Gates and shared files

- `./gradlew ktlintCheck apiCheck` → **BUILD SUCCESSFUL**; `git status --porcelain api/` **empty** — `api/*.api` does not move (test-only + build-script changes).
- **No workflow file is touched.** #223 changed `arm-build-test.yaml` recently and the #196 agent may want it; this PR needs nothing from it, because `DBUSMOCK_REQUIRED=1` is already set in `full-tests-x64` and the root binary the ARM job drives has no dbusmock cases. Nothing to sequence.

## Tasks executed (all under `dbus-run-session`)

`:cross_test:linkDebugTestLinuxX64`, `:linkDebugTestLinuxX64`, `:cross_test:linuxX64Test`, `:cross_test:jvmTest`, `:cross_test:jvmInteropTest` (with and without `-Dkdbus.crossRuntimeInterop.reverse.enabled=true`, and with `--tests` on a single case), `:stress_test:jvmInteropStressTest`, `ktlintCheck`, `apiCheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
