### PR TITLE
test(cross): address the non-blocking review findings from #240

### DIFF
--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -69,10 +69,18 @@ tasks.named<Test>("jvmTest") {
 //  * `DBUSMOCK_REQUIRED` set — the `full-tests-x64` job, which apt-installs python3-dbusmock on
 //    purpose — the suites always run, and the harness itself fails loudly when it cannot start a
 //    peer. So CI can never lose this coverage to the exclusion below.
-//  * otherwise the harness is probed exactly as the native `launchDbusmock` probes it (a session bus
-//    plus an importable `dbusmock` module under `DBUSMOCK_PYTHON` / `python3`), and the suites are
-//    excluded only when it genuinely cannot run — a contributor who *has* dbusmock still runs them
-//    with no configuration.
+//  * otherwise the harness is probed — a session bus plus an importable `dbusmock` module under
+//    `DBUSMOCK_PYTHON` / `python3` — and the suites are excluded only when it cannot run, so a
+//    contributor who *has* dbusmock still runs them with no configuration.
+//
+// Two limits, stated because both fail *open* (back to the phantom passes, not to something worse):
+//  * The probe is weaker than the launch. `launchDbusmock` forks `python3 -m dbusmock --session
+//    [-t <template>] …` and gives it a liveness window; this only checks the module imports. On a
+//    box where `dbusmock` imports but a peer cannot actually start — an older dbusmock missing a
+//    template like `bluez5`, a bus-name claim failure — the suites still run and native still
+//    reports passes that asserted nothing.
+//  * If the class names below drift, the exclusions silently stop matching. Gradle's filter API
+//    offers no "this exclusion matched nothing" signal to guard that with.
 val dbusmockRequired = providers.environmentVariable("DBUSMOCK_REQUIRED").isPresent
 val dbusmockPython = providers.environmentVariable("DBUSMOCK_PYTHON").getOrElse("python3")
 val sessionBusPresent = providers.environmentVariable("DBUS_SESSION_BUS_ADDRESS").isPresent

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/CrossRuntimeInteropSmokeTest.kt
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.freedesktop.dbus.annotations.DBusInterfaceName
 import org.freedesktop.dbus.annotations.DBusMemberName
@@ -123,8 +125,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -203,8 +204,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -286,8 +286,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -397,8 +396,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -471,8 +469,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -548,8 +545,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -622,8 +618,7 @@ class CrossRuntimeInteropSmokeTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -699,9 +694,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -709,8 +705,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -800,9 +795,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -810,8 +806,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -896,9 +891,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -906,8 +902,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -1010,9 +1005,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -1020,8 +1016,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -1113,9 +1108,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -1123,8 +1119,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -1210,9 +1205,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -1220,8 +1216,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -1307,9 +1302,10 @@ class CrossRuntimeInteropSmokeTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "cross-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "cross-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
 
             assertTrue(
                 launchedProcess.waitFor(30, TimeUnit.SECONDS),
@@ -1317,8 +1313,7 @@ class CrossRuntimeInteropSmokeTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -1339,6 +1334,24 @@ class CrossRuntimeInteropSmokeTest {
             restoreSaslCollator()
             Files.deleteIfExists(socketPath)
         }
+    }
+
+    /**
+     * Waits for the output pump to finish draining and returns everything the peer printed.
+     *
+     * An incomplete drain must report itself: [assertNativePeerPassed] reads this text, so a
+     * truncated snapshot would otherwise surface as "never ran <case>", pointing at a rename that
+     * did not happen. The peer has already exited and spawns no children, so the pipe is at EOF and
+     * this returns in microseconds.
+     */
+    private fun drainedPeerOutput(pump: Thread, sink: ByteArrayOutputStream): String {
+        pump.join(PUMP_DRAIN_MILLIS)
+        assertFalse(
+            pump.isAlive,
+            "Native peer output was still draining after ${PUMP_DRAIN_MILLIS}ms, so the capture " +
+                "below is incomplete and cannot be asserted on:\n" + sink.toString(Charsets.UTF_8)
+        )
+        return sink.toString(Charsets.UTF_8)
     }
 
     /**
@@ -1373,9 +1386,10 @@ class CrossRuntimeInteropSmokeTest {
             if (details.isNotEmpty()) appendLine(details)
             append("Output:\n").append(nativeLog)
         }
-        val reportedFailure = TEAMCITY_TEST_FAILED.find(nativeLog)?.value
-        assertTrue(
-            reportedFailure == null,
+        val failedMarker = "##teamcity[testFailed name='$peerTest'"
+        val reportedFailure = nativeLog.lineSequence().firstOrNull { failedMarker in it }
+        assertNull(
+            reportedFailure,
             "Native peer reported '$peerTest' as failed: $reportedFailure\n$context"
         )
         assertTrue(
@@ -1768,9 +1782,6 @@ class CrossRuntimeInteropSmokeTest {
          * report "never ran" for a peer that ran fine.
          */
         private const val PUMP_DRAIN_MILLIS = 5_000L
-
-        /** A failure line from the peer's `--ktest_logger=TEAMCITY` output. */
-        private val TEAMCITY_TEST_FAILED = Regex("##teamcity\\[testFailed .*")
     }
 
     private fun buildLargeMapPayload(size: Int): Map<Int, String> = buildMap {

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -79,8 +79,11 @@ weakening it.
   headline a couple of points; the per-area shape is stable.
 - **Tooling note:** `WireDbusBackend.kt` is flagged binary/`data` by the OS, so `grep` silently
   returns no matches on it — use `awk`/`rg`/Read when auditing that file.
-- **dbusmock suites can false-pass locally** without a configured dbusmock venv; trust CI / the venv
-  for those rows, not a bare local green.
+- **Do not trust a bare local green for the dbusmock rows** without a configured dbusmock venv —
+  trust CI or the venv. Since #182 `jvmTest` reports them as a real `<skipped/>`, and since #186
+  `:cross_test:linuxX64Test` does not run them at all when the harness cannot start (Kotlin/Native
+  cannot record a skip, so running them would report passes that asserted nothing). Both are honest,
+  but neither *measures* anything: locally those rows are typically unmeasured rather than covered.
 
 ## Re-measuring
 

--- a/stress_test/src/jvmTest/kotlin/com/monkopedia/sdbus/stress/CrossRuntimeInteropStressTest.kt
+++ b/stress_test/src/jvmTest/kotlin/com/monkopedia/sdbus/stress/CrossRuntimeInteropStressTest.kt
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.TimeoutCancellationException
@@ -255,8 +257,7 @@ class CrossRuntimeInteropStressTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -427,8 +428,7 @@ class CrossRuntimeInteropStressTest {
                 "Native peer did not exit in time. Output:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(outputPump, nativeOutput)
             assertNativePeerPassed(process, nativeLog, peerTest)
         } finally {
             process.destroyForcibly()
@@ -525,9 +525,10 @@ class CrossRuntimeInteropStressTest {
                 procBuilder.redirectErrorStream(true)
             }.start()
             process = launchedProcess
-            outputPump = thread(start = true, isDaemon = true, name = "stress-native-output") {
+            val pump = thread(start = true, isDaemon = true, name = "stress-native-output") {
                 launchedProcess.inputStream.use { input -> input.copyTo(nativeOutput) }
             }
+            outputPump = pump
             dropConnectionAfterMs?.let { delayMs ->
                 Thread.sleep(delayMs)
                 runCatching { connection.disconnect() }
@@ -539,8 +540,7 @@ class CrossRuntimeInteropStressTest {
                     "Listen failure:\n${listenFailureDetails()}\nOutput:\n" +
                     nativeOutput.toString(Charsets.UTF_8)
             )
-            outputPump?.join(PUMP_DRAIN_MILLIS)
-            val nativeLog = nativeOutput.toString(Charsets.UTF_8)
+            val nativeLog = drainedPeerOutput(pump, nativeOutput)
             assertNativePeerPassed(
                 launchedProcess,
                 nativeLog,
@@ -583,6 +583,24 @@ class CrossRuntimeInteropStressTest {
     }
 
     /**
+     * Waits for the output pump to finish draining and returns everything the peer printed.
+     *
+     * An incomplete drain must report itself: [assertNativePeerPassed] reads this text, so a
+     * truncated snapshot would otherwise surface as "never ran <case>", pointing at a rename that
+     * did not happen. The peer has already exited and spawns no children, so the pipe is at EOF and
+     * this returns in microseconds.
+     */
+    private fun drainedPeerOutput(pump: Thread, sink: ByteArrayOutputStream): String {
+        pump.join(PUMP_DRAIN_MILLIS)
+        assertFalse(
+            pump.isAlive,
+            "Native peer output was still draining after ${PUMP_DRAIN_MILLIS}ms, so the capture " +
+                "below is incomplete and cannot be asserted on:\n" + sink.toString(Charsets.UTF_8)
+        )
+        return sink.toString(Charsets.UTF_8)
+    }
+
+    /**
      * The `--ktest_gradle_filter` that selects the single `NativeInteropPeerTest` case a spawned
      * peer should run. Built from the same [peerTest] string [assertNativePeerPassed] looks for in
      * the peer's output, so the filter and the assertion cannot drift apart.
@@ -614,9 +632,10 @@ class CrossRuntimeInteropStressTest {
             if (details.isNotEmpty()) appendLine(details)
             append("Output:\n").append(nativeLog)
         }
-        val reportedFailure = TEAMCITY_TEST_FAILED.find(nativeLog)?.value
-        assertTrue(
-            reportedFailure == null,
+        val failedMarker = "##teamcity[testFailed name='$peerTest'"
+        val reportedFailure = nativeLog.lineSequence().firstOrNull { failedMarker in it }
+        assertNull(
+            reportedFailure,
             "Native peer reported '$peerTest' as failed: $reportedFailure\n$context"
         )
         assertTrue(
@@ -775,8 +794,5 @@ class CrossRuntimeInteropStressTest {
          * report "never ran" for a peer that ran fine.
          */
         private const val PUMP_DRAIN_MILLIS = 5_000L
-
-        /** A failure line from the peer's `--ktest_logger=TEAMCITY` output. */
-        private val TEAMCITY_TEST_FAILED = Regex("##teamcity\\[testFailed .*")
     }
 }


### PR DESCRIPTION
Follows up #240 (which fixed #183 and #186) with four of the six **non-blocking** findings from its review. No behaviour under test changes; the two gates #240 installed are re-verified in both directions afterwards.

## What changed

**1. An incomplete output drain now reports itself.** `outputPump.join(PUMP_DRAIN_MILLIS)` threw away whether the pump had actually finished. Since `assertNativePeerPassed` reads that capture, a timed-out drain would have failed as *"Native peer never ran 'X', so this case measured nothing"* — the most misleading of the three messages, because it accuses a rename that never happened. The join and the snapshot move into one helper:

```kotlin
private fun drainedPeerOutput(pump: Thread, sink: ByteArrayOutputStream): String {
    pump.join(PUMP_DRAIN_MILLIS)
    assertFalse(pump.isAlive, "Native peer output was still draining after …")
    return sink.toString(Charsets.UTF_8)
}
```

The reverse cases (seven in `cross_test`, one in `stress_test`) hoist the pump into a local `val` and assign that to the existing `var outputPump: Thread?`, so the helper takes a non-null `Thread` rather than a `!!` on a nullable.

**2. The `testFailed` lookup is scoped to the case actually selected.** It matched *any* `##teamcity[testFailed` line and then reported it under `peerTest`'s name, so the message would have lied if the filter ever admitted more than one test. It now looks for that test's own marker. This drops the `TEAMCITY_TEST_FAILED` regex constant from both companions — the check is a plain `contains` over lines — and `assertTrue(x == null)` becomes `assertNull`. Coverage is unchanged: a `testFailed` for some *other* test still fails the case through the exit-code leg.

**3. The build-script comment no longer overstates the probe.** It claimed the configuration-time check works "**exactly** as the native `launchDbusmock` probes it". It does not: `launchDbusmock` forks `python3 -m dbusmock --session [-t <template>] …` and gives it a liveness window, while the probe only checks that the module imports. So on a box where `dbusmock` imports but a peer cannot actually start — an older dbusmock missing a template like `bluez5`, a bus-name claim failure — the suites still run and native still reports passes that asserted nothing. That window is now documented next to the name-drift limit #240 already stated, with both labelled as failing **open** (back to the phantom passes, not to something worse).

**4. `docs/TEST_COVERAGE.md` refreshed.** "dbusmock suites can false-pass locally" is stale in mechanism — since #182 `jvmTest` reports a real `<skipped/>`, and since #186 `:cross_test:linuxX64Test` does not run them at all. Its *advice* still holds and is arguably more important now, so the sentence is restated rather than deleted: those rows are typically **unmeasured** locally, not covered.

## Deliberately not changed

The `assertNativePeerPassed` / `nativePeerFilter` duplication across `cross_test` and `stress_test`. The reviewer verified rather than assumed this: `stress_test` depends on `project(":")` only and has no route to `cross_test`'s test source set, and the two files already duplicated four helpers. Sharing would cost a new module or a test-fixtures publication for two functions. The duplicated count is now **7** — this PR adds `drainedPeerOutput` to the set, so the "if it grows again" trigger below is already tripped and is filed as a follow-up issue rather than being actioned here.

## Evidence — both gates still work, both directions, on two hosts

Re-run after the refactor, because a cleanup that quietly disarms the gate it is cleaning up would be exactly the defect #183 was about. Identical results on two hosts (Arch, JDK 21, under `dbus-run-session`, no python-dbusmock):

| check | result (`<testsuite …>` from fresh JUnit XML) |
| --- | --- |
| interop suite, reverse on — **green** | `tests="14" skipped="1" failures="0" errors="0"`, exit 0 |
| the `@Ignore`d #241 case | present as a `<skipped/>` entry, not vanished, not passed |
| **RED** — native-only assertion broken (`expectedArg` → `expectedArg + 999`) | `tests="1" skipped="0" failures="1" errors="0"`, exit **1**, message `Native peer reported 'nativeClientCanObserveSignalFromJvmPeeer…' as failed: ##teamcity[testFailed …` |
| #186 — no dbusmock, `DBUSMOCK_REQUIRED` unset | `linuxX64Test` = 4 tests (3 + 1), exit 0 — no phantom passes |
| #186 — no dbusmock, **`DBUSMOCK_REQUIRED=1`** | 48 tests, **44 failures**, exit **1** — still fails loudly |
| stress smoke, forward + reverse, `repeat=2` | `tests="10" skipped="0" failures="0" errors="0"`, exit 0 |

`./gradlew ktlintCheck apiCheck` → `BUILD SUCCESSFUL`; `git status --porcelain api/` **empty** — `api/*.api` does not move.

No workflow file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
