### PR TITLE
docs: correct stale connection-factory and use-after-release claims, and list every module (#191, #202)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,9 @@ Guidance for agents working on sdbus-kotlin.
 
 A Kotlin Multiplatform D-Bus client (a port of sdbus-c++), targeting **jvm + linuxX64 + linuxArm64**. The native targets wrap `sd-bus` via cinterop; the JVM target is backed by an owned junixsocket connection with a pure-Kotlin marshaller and dispatcher (since 0.5.0 — no dbus-java, no native code). It also ships a code generator (`:codegen`, XML → Kotlin BlueZ proxies/adaptors) and a Gradle plugin (`:plugin`, id `com.monkopedia.sdbus.plugin`).
 
-Modules: root (the library), `:codegen`, `:plugin`, `:cross_test`, `:stress_test`, `samples/bluez-scan`.
+Modules (subprojects of the root build, per `settings.gradle.kts`): root (the library), `:codegen`, `:compile_test`, `:cross_test`, `:plugin`, `:stress_test`. Plus two **separate** Gradle builds that are not subprojects — `samples/bluez-scan` and `samples/demo-service` — each composing the library in with `includeBuild("../..")`.
+
+`:compile_test` is easy to miss and is the guard that the generated code actually compiles: its source directory is a **symlink** (`compile_test/src/nativeMain/kotlin/TestFiles` → `codegen/src/test/resources`), so a linuxX64 compile of that module type-checks every checked-in codegen golden against the real library — this is what caught the malformed signal decoder in #237, which `:codegen`'s own in-process `CompilationIntegrationTest` had missed. CI covers it because the root `allTests` reaches `:compile_test:compileKotlinLinuxX64`; run it directly with `./gradlew :compile_test:compileKotlinLinuxX64`. It is deliberately excluded from `ktlintCheck` and `apiCheck` (see `build.gradle.kts`).
 
 ## Building & verifying
 
@@ -29,4 +31,5 @@ Modules: root (the library), `:codegen`, `:plugin`, `:cross_test`, `:stress_test
   - The **Kotlin version** badge is hardcoded — bump it manually when the Kotlin version changes.
   - The **Build** badge tracks `.github/workflows/arm-build-test.yaml`; keep the workflow path correct if CI is renamed.
   - Maven Central has no public *download* count, so there is no downloads badge (only the namespace owner can see download stats in the Central Portal).
+- **Module list:** the `Modules:` paragraph under "What this is" must enumerate every `include(...)` in `settings.gradle.kts` plus the composite-build samples. When a module is added, removed or renamed, update it there **and** the matching list in `AGENTS.md` ("Project Structure & Module Organization") — nothing else prompts it, and `:compile_test` sat unlisted here for exactly that reason (#202).
 - Generated BlueZ proxy fixtures and the BCV `api/*.api` dumps are checked in. Regenerate the codegen goldens with `./gradlew :codegen:regenerateGoldens` after an intentional generator change, and the `api/*.api` dumps with `./gradlew apiDump` when the public surface changes; review the diff and commit it. `:codegen:test` only ever *compares* the goldens — it can never write them.

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -38,7 +38,7 @@ Every row below is pinned by tests on current `main`, not by intention:
 | **Serving exported objects to external processes** (incoming method calls, `Properties.Get`/`Set`/`GetAll`, `GetManagedObjects`) | ✅ | ✅ | **#90 closed (0.5.0):** the JVM backend serves incoming calls over its owned wire connection (`WireServe`), so an external client (busctl, another process) reaches a JVM-exported object exactly as on native — see "Server-side object export". Same-JVM calls still take an in-process shortcut (`JvmStaticDispatch`) |
 | `UnixFd` type semantics (dup constructor vs `adopt`, `release` closes) | ✅* | ✅ | *JVM dup needs junixsocket native support |
 | Unix FD passing over the wire | ⚠️ untested | ✅ | JVM has the conversion path but no independent-peer test |
-| Connection factories (11 total) | 9 of 11 | 11 of 11 | fd-based factories are native-only |
+| Connection factories (11 total) | 8 of 11 | 11 of 11 | the two fd-based factories and `createRemoteSystemBusConnection` are native-only; counted from the checked-in `api/*.api` dumps |
 | Behavior when the bus is unreachable | ✅ throws `Error` | ✅ throws `Error` | JVM fixed in #81; the in-process stub backend is an explicit internal test opt-in only |
 | Event loop (`startEventLoop`/`stopEventLoop`) | no-op (always running) | required for dispatch; `createObject`/`createProxy` auto-start it | Same calling pattern works on both; `startEventLoop` is idempotent (#114), and each native connection gets its own loop thread (#128) |
 | Strict deserialization (signature mismatch rejected) | ✅ | ✅ | Same `System.Error.ENXIO` error |
@@ -273,9 +273,9 @@ Backend differences:
 
 ## Connection factories
 
-There are 11 `create*Connection` entry points — 10 declared in the common API
-(`src/commonMain/.../Connection.kt`) plus one declared only in the native source set
-(`src/nativeMain/.../Connection.native.kt`):
+There are 11 `create*Connection` entry points — 8 declared in the common API
+(`src/commonMain/.../Connection.kt`, hence available on both backends) plus 3 declared only in
+the native source set (`src/nativeMain/.../Connection.native.kt`):
 
 | Factory | JVM | Native |
 | --- | --- | --- |
@@ -284,15 +284,18 @@ There are 11 `create*Connection` entry points — 10 declared in the common API
 | `createSessionBusConnection()` / `(name)` / `(address)` | ✅ | ✅ |
 | `createRemoteSystemBusConnection(host)` | ❌ native-only (not declared) | ✅ |
 | `createDirectBusConnection(address)` | ✅ | ✅ |
-| `createDirectBusConnection(fd: UnixFd)` | ❌ native-only | ✅ |
-| `createServerBusConnection(fd: UnixFd)` | ❌ native-only | ✅ |
+| `createDirectBusConnection(fd: UnixFd)` | ❌ native-only (not declared) | ✅ |
+| `createServerBusConnection(fd: UnixFd)` | ❌ native-only (not declared) | ✅ |
 
-- The two **fd-based factories** are native-only. The JVM actuals are marked
-  `@Deprecated(level = ERROR)` (`src/jvmMain/.../Connection.jvm.kt`), so calling them from
-  JVM-compiled code is a **compile-time error**; if invoked anyway (e.g. reflectively), the
-  JVM backend rejects the fd-based bus types (`JvmBusType.DIRECT_FD`/`SERVER_FD`, in
-  `WireDbusBackend.createConnection`).
+- The two **fd-based factories** are native-only: since #126 they are plain top-level funs in
+  `Connection.native.kt` with no `expect` declaration in commonMain and no JVM actual, so naming
+  them from JVM-compiled code is an **unresolved reference**. (They were briefly
+  `@Deprecated(level = ERROR)` JVM stubs before #126; that is no longer how they are guarded.)
   On native they adopt the descriptor as documented in their KDoc.
+  `WireDbusBackend.createConnection` still rejects `JvmBusType.DIRECT_FD`/`SERVER_FD`, but that
+  is a **defensive remnant with no reachable caller** — nothing constructs either enum value now
+  that the JVM symbols are gone, so treat the missing declaration, not the runtime check, as the
+  thing that stops you.
 - A **brokerless direct connection** has no daemon to run `Hello` against, so neither backend gets
   a bus-assigned unique name for it. The JVM backend synthesizes one **per connection**
   (`":jvm-wire-<n>"`) — the in-process registries are keyed by it, so two direct connections in one
@@ -370,7 +373,8 @@ the API docs will see it.
 ## JVM limitations at a glance
 
 1. **No fd-based connections**: `createDirectBusConnection(fd)` / `createServerBusConnection(fd)`
-   are compile-time errors on JVM (`@Deprecated(ERROR)` stubs).
+   are not declared in the JVM API at all (native-only funs since #126), so a JVM-compiled call is
+   an unresolved reference — see "Connection factories".
 2. **Raw-fd semantics depend on junixsocket native support**: without it, `UnixFd`
    duplication/closing degrade (no dup, no close). Wire fd passing is implemented but not
    CI-verified against an independent peer.
@@ -402,6 +406,10 @@ matched (they don't affect cross-process usage):
   where native returns an error.
 - A same-process `UnixFd` argument is passed by reference (not dup'd) on the local short-circuit,
   where native dups the descriptor.
-- `currentlyProcessedMessage` is not guarded against use after `release()` on JVM (native is).
+
+(`currentlyProcessedMessage` used to be listed here as unguarded against use after `release()` on
+JVM. That was closed in #172 — `WireDbusObject.currentlyProcessedMessage` now reads through to
+`connection.isReleased()` — and is pinned cross-backend by
+`FailurePathParityTest.currentlyProcessedMessageAfterReleaseThrowsOnBothBackends`.)
 
 These are tracked as post-1.0 items; none is on the cross-process path.


### PR DESCRIPTION
Fixes #191
Refs #202

Prose-only. `git diff --stat` is `CLAUDE.md | 5 +++-` and `docs/BACKENDS.md | 36 +++++-----`; no `.kt`, no `.kts`, no `api/*.api`. `./gradlew ktlintCheck apiCheck` → BUILD SUCCESSFUL.

Every claim below was re-measured against `main` @ `79bdbe5`, not read for plausibility. Command output is quoted where it settles the point.

---

## #191 — `docs/BACKENDS.md` "Connection factories": all five claims confirmed FALSE, all five corrected

### 1. The `@Deprecated(level = ERROR)` JVM actuals do not exist

**Was** (`docs/BACKENDS.md:290-294`):
> The JVM actuals are marked `@Deprecated(level = ERROR)` (`src/jvmMain/.../Connection.jvm.kt`), so calling them from JVM-compiled code is a **compile-time error**

**Contradiction.** With a positive control, because the shell's `grep` silently skips binary-flagged files:

```
$ /usr/bin/grep -ra "fun " --include='*.kt' src/jvmMain/ | wc -l
438                                        # positive control: the sweep does see this tree
$ /usr/bin/grep -ran "Deprecated" --include='*.kt' src/jvmMain/
WireServe.kt:359: "  <annotation name=\"org.freedesktop.DBus.Deprecated\" value=\"true\"/>\n"
WireServe.kt:546/554/561: deprecated = item.isDeprecated
$ /usr/bin/grep -ran "createServerBusConnection" --include='*.kt' src/jvmMain/
                                           # (no output)
```

The only `Deprecated` occurrences in `src/jvmMain` are introspection-XML strings in `WireServe.kt`. There is no `@Deprecated` annotation and no `createServerBusConnection` symbol. PR #126 removed them; `src/nativeMain/.../Connection.native.kt:96,122` now declares both as plain non-`actual` top-level funs, and `Connection.kt` has no `expect` for either. A JVM call is an **unresolved reference**.

**Now:** the bullet says they are native-only funs since #126 with no commonMain `expect` and no JVM actual, so naming them from JVM-compiled code is an unresolved reference — with one parenthetical noting the `@Deprecated(ERROR)` form is historical, so a reader who saw the old text knows it was replaced rather than that the doc drifted.

### 2. The runtime guard the doc cites has zero producers

**Was** (`docs/BACKENDS.md:292-294`):
> if invoked anyway (e.g. reflectively), the JVM backend rejects the fd-based bus types (`JvmBusType.DIRECT_FD`/`SERVER_FD`, in `WireDbusBackend.createConnection`).

**Contradiction.** Cross-checked two ways (`/usr/bin/grep -rn`, and an `awk` sweep per file in case of a binary-flag skip) — identical results, four hits total:

```
WireDbusBackend.kt:63:  if (fd != null || busType == JvmBusType.DIRECT_FD || busType == JvmBusType.SERVER_FD) {
WireDbusBackend.kt:75:      JvmBusType.DIRECT_FD, JvmBusType.SERVER_FD -> null
JvmDbusBackend.kt:30:   DIRECT_FD,
JvmDbusBackend.kt:31:   SERVER_FD
```

Two declarations, the guard, and the dead `null` branch. **No producer.** Every `createConnection` call site is one of the eight factories in `Connection.jvm.kt:40,44,53,57,66,70,79,88`, and each passes `DEFAULT`/`SYSTEM`/`SESSION`/`SESSION_ADDRESS`/`DIRECT_ADDRESS` with `fd = null`. `JvmDbusBackend` is `internal`, so there is no out-of-repo implementor either. The "reflectively" path the doc describes does not exist.

**Now:** the doc takes the issue's *second* option — it names the check a "defensive remnant with no reachable caller" and tells the reader the missing declaration, not the runtime check, is what stops them. **I did not delete the enum values or the guard**: that is code, and this PR is scoped to prose. If the owner prefers the delete, it is a separate one-file change.

### 3. "10 declared in the common API plus one native-only"

**Was** (`docs/BACKENDS.md:276-278`): "10 declared in the common API … plus one declared only in the native source set".

```
$ /usr/bin/grep -c "^expect fun create[A-Za-z]*BusConnection" src/commonMain/.../Connection.kt
8
$ /usr/bin/grep -rn "^fun create[A-Za-z]*BusConnection" src/nativeMain/.../Connection.native.kt
71: createRemoteSystemBusConnection(host)
96: createDirectBusConnection(fd: UnixFd)
122: createServerBusConnection(fd: UnixFd)
```

**Now:** "8 declared in the common API … plus 3 declared only in the native source set". Still 11 total, and the factory table below it was already correct (2+2+3+1+1+1+1 = 11).

### 4. The matrix row "9 of 11" for JVM

**Was** (`docs/BACKENDS.md:41`): `| Connection factories (11 total) | 9 of 11 | 11 of 11 | fd-based factories are native-only |`

From the checked-in API dumps, which are the authority:

```
$ /usr/bin/grep -c "fun create[A-Za-z]*BusConnection" api/sdbus-kotlin.api
8
$ /usr/bin/grep -o "com.monkopedia.sdbus/create[A-Za-z]*BusConnection([^)]*)" api/sdbus-kotlin.klib.api | sort -u | wc -l
11
```

**Now:** `8 of 11`. The note also names the third missing factory — the old note said only "fd-based factories are native-only", which accounts for 2 of the 3 absences and is part of why `9` looked self-consistent.

### 5. The `currentlyProcessedMessage` divergence bullet is stale

**Was** (`docs/BACKENDS.md:405`, under "documented rather than matched"):
> `currentlyProcessedMessage` is not guarded against use after `release()` on JVM (native is).

**Contradiction** — `WireDbusObject.kt:352-356`:

```kotlin
override fun currentlyProcessedMessage(): Message {
    // Native's ObjectImpl reads through to the connection, which rejects use after release()
    // (ConnectionImpl.checkNotReleased). Parity #141.
    require(!connection.isReleased()) { "Connection has already been released" }
```

Pinned cross-backend by `FailurePathParityTest.currentlyProcessedMessageAfterReleaseThrowsOnBothBackends` (`src/commonTest/.../FailurePathParityTest.kt:408`).

**Now:** removed from the divergence list, replaced by a short note naming #172 and the pinning test — so the next reader learns it was closed rather than rediscovering it.

---

## #202 — one fixed, one already fixed by #222, one split out

### Item 3 (CLAUDE.md module list) — CONFIRMED, FIXED

`settings.gradle.kts` includes `codegen`, **`compile_test`**, `cross_test`, `plugin`, `stress_test`; `CLAUDE.md:9` listed everything but `compile_test`, and named only one of the two samples.

`compile_test` earns more than a list entry, so it gets a sentence. `compile_test/src/nativeMain/kotlin/TestFiles` is a **tracked symlink** to `codegen/src/test/resources`:

```
$ ls -la compile_test/src/nativeMain/kotlin/
TestFiles -> ../../../../codegen/src/test/resources
$ git ls-files compile_test
compile_test/build.gradle.kts
compile_test/src/nativeMain/kotlin/TestFiles
```

so a linuxX64 compile of the module type-checks every checked-in codegen golden against the real library. I verified it is genuinely CI-covered rather than assuming it — CI runs `./gradlew allTests test` (`arm-build-test.yaml:81`), and:

```
$ ./gradlew allTests --dry-run | grep compile_test
:compile_test:compileKotlinLinuxX64 SKIPPED
:compile_test:linkDebugTestLinuxX64 SKIPPED
:compile_test:allTests SKIPPED          # --dry-run marks everything SKIPPED; the point is they are IN the graph
```

The samples are also described correctly now: they are **separate Gradle builds** using `includeBuild("../..")` (`samples/*/settings.gradle.kts`), not subprojects — `settings.gradle.kts` does not include them at all.

**Maintenance section: yes, added** (the issue asked for it explicitly, and without it this recurs). New bullet requires the `Modules:` paragraph to enumerate every `include(...)` plus the composite-build samples, and to be updated **together with** `AGENTS.md`'s "Project Structure & Module Organization" list — which, checked independently, is already complete (`AGENTS.md:18-24` lists `compile_test/` and both samples). CLAUDE.md was the only drifted copy.

### Item 2 (demo-service README version claim) — ALREADY FIXED by #222, no change made

The issue quotes:
> "That API does **not** exist in the artifact published to Maven Central (**1.0.0**). … the version coordinate there (`1.0.1`) is only a placeholder."

The first sentence is **gone**. `git log -- samples/demo-service/README.md` → `67ac247` ("ci: compile samples/ in CI and align their Gradle wrappers with the root (#222)") rewrote that section; `/usr/bin/grep -n "1\.0\.0" samples/demo-service/README.md` returns nothing.

The surviving "the version coordinate there (`1.0.1`) is only a placeholder" is **not a defect**, and I deliberately left it. In context (`README.md:30-40`) it is a statement about *composite-build substitution*, and it is accurate — `includeBuild("../..")` substitutes on `group:name` and ignores the version, so the literal in `build.gradle.kts:43` is inert while the sample is built in place. The very next paragraph already says the literal becomes real when the directory is copied out, and that the release checklist keeps it in step. Nothing here says 1.0.1 is unpublished. Rewording it would be churn.

### Item 1 (`Proxy.callMethod` blocking claim) — CONFIRMED TRUE, but SPLIT OUT

I verified the claim and then did **not** fix it, because the text lives in `src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt:94-102` and `commonMain` KDoc is being worked concurrently under #208/#209/#210. Editing it from here risks a conflicting edit in a file another agent may be holding.

The claim is real. `Proxy.kt:94-98` states unconditionally:
> "While blocking, other concurrent operations (in other threads) on the underlying bus connection are stalled until the call returns."

Traced on JVM: `Proxy.jvm.kt:21` → `WireDbusBackend.callMethod` (`:295-404`), which either dispatches in-process (`:345-365`) or calls `callRemote` (`:538`) → `DBusWireConnection.callBlocking` (`:389-410`). `callBlocking` does `future.get(timeout)` — it parks **only the calling thread**. The single `synchronized(writeLock)` on that path (`DBusWireConnection.kt:270`) is held for the duration of writing the message bytes, **not** across the reply wait, and the reader thread keeps dispatching throughout. There is no connection-wide lock.

So the sentence is native-accurate (sd-bus does serialize the connection) and false on JVM. As the issue notes, the failure direction is over-conservatism — a consumer avoiding a pattern that would have been fine — which is why it is the lowest-severity of the three.

**#202 therefore gets `Refs`, not `Fixes`**: item 1 is unresolved and still needs an owner or the KDoc agent to take it.

---

## What I ran, and what I did not

**Ran:** `./gradlew ktlintCheck apiCheck` (BUILD SUCCESSFUL, 16s); `./gradlew allTests --dry-run` (task-graph check only, nothing executed); all the greps and `awk` sweeps quoted above; `git status --short api/` → empty.

**Did not run:** any test suite, any bus-backed test, and **`:dokkaGeneratePublicationHtml`** — deliberately. Dokka's only prose input is `dokka/moduledoc.md` (`build.gradle.kts:262`, `includes.from(rootProject.file("dokka/moduledoc.md"))`); neither file I touched is a Dokka input, so a warning count from it would say nothing about this diff. Nothing here can move Dokka output.

## Guard rails honoured

- **`docs/BACKENDS.md:35`** — the `PropertiesChanged` ✅/✅ emission row — is **byte-identical to `origin/main`**, verified by `diff <(awk 'NR==35' docs/BACKENDS.md) <(git show origin/main:docs/BACKENDS.md | awk 'NR==35')`. Amending it is option 1 of the still-open #193 and is not mine to decide.
- **`docs/BACKENDS.md:45`** (`Method.NoReply`, corrected by #221) and **`AGENTS.md`** (verification command, corrected by #224) — untouched; `AGENTS.md` is not in this diff at all.
- **No code, no behaviour.** The one code change #191 offers as an alternative (deleting the unreachable `DIRECT_FD`/`SERVER_FD` guard) was left undone by design; see item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
