### PR TITLE
docs: correct three commonMain KDoc claims the actuals do not honour (UnixFd scope-exit close, Message 'complete'/isValid/peekType, JVM sender credentials)

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -151,7 +151,20 @@ expect sealed class Message {
      */
     fun peekType(): PeekedType
 
-    /** Whether this message wraps a valid underlying D-Bus message. */
+    /**
+     * Whether this message wraps a valid underlying D-Bus message.
+     *
+     * **Backend-dependent — do not branch on this from common code.** On native it is exactly
+     * "wraps a live `sd_bus_message`", which is `true` for every message this library hands out,
+     * locally built ones included. On the JVM backend it reports an internal flag that only the
+     * paths which build a message from the wire or from a dispatch result set: a message from
+     * [createPlainMessage] reads `false` there, and [MethodCall.createErrorReply] sets the flag
+     * `false` deliberately to mean "this reply carries an error" — a different concept from the
+     * one this property is named for, sharing the same field. So `if (!isValid) return` discards
+     * locally built messages on JVM and keeps them on native. Which of the two definitions this
+     * property should have is unsettled; treat the value as unspecified for anything but native
+     * `msg != null`.
+     */
     val isValid: Boolean
 
     /** Whether this message carries no body data. */
@@ -160,12 +173,24 @@ expect sealed class Message {
     /**
      * Whether the read cursor has reached the end of the message body.
      *
+     * **[complete] is honoured on native only.** The JVM backend ignores it and answers a third
+     * question instead — whether the cursor has consumed the flat payload — with no regard to
+     * container nesting, so `isAtEnd(true)` there can report `true` while containers are still
+     * open, and `isAtEnd(false)` does not stop at the end of the current container.
+     *
      * @param complete When `true`, also requires that any open containers have been exited
      */
     fun isAtEnd(complete: Boolean): Boolean
 
     /**
      * Copies the contents of this message into [destination].
+     *
+     * **[complete] is honoured on native only**, and the JVM backend copies more than the
+     * contents. On JVM the flag is ignored — the whole payload is always copied from the start,
+     * never from the cursor — and the copy additionally overwrites [destination]'s metadata
+     * (interface, member, path, sender, destination, validity flag and sender credentials) with
+     * this message's. Native's `sd_bus_message_copy` moves body data only and leaves the
+     * destination's header alone.
      *
      * @param destination Message to copy into
      * @param complete When `true`, copy the whole message; otherwise copy from the current cursor
@@ -177,6 +202,11 @@ expect sealed class Message {
 
     /**
      * Resets the read cursor to the start of the message.
+     *
+     * **[complete] is honoured on native only.** The JVM backend ignores it and always rewinds to
+     * the very beginning of the body, so `rewind(false)` inside a container does not return the
+     * cursor to the start of that container — it returns it to the start of the message, and the
+     * next read yields a value from there rather than failing.
      *
      * @param complete When `true`, rewind past all containers to the very beginning
      */
@@ -201,6 +231,19 @@ expect sealed class Message {
      * [issue #199](https://github.com/Monkopedia/sdbus-kotlin/issues/199) — so treat it as
      * unspecified rather than as a contract.
      *
+     * **On the JVM backend no credential ever describes another process.** Credentials are
+     * attached on exactly one path there — a received signal whose sender resolves to another
+     * connection inside this same JVM — and the values attached are read from the *receiving*
+     * process (`ProcessHandle.current()` plus `com.sun.security.auth.module.UnixSystem`), which
+     * on that path is the same process. Every other message, including any signal or method call
+     * that came from a different process, carries no credentials at all, so these accessors throw.
+     * Resolving an external peer would need a `GetConnectionCredentials` call the backend does not
+     * make. There is therefore no JVM configuration in which these properties report a remote
+     * principal: they either throw or describe you. The native backend queries real per-sender
+     * credentials for any peer and any message type. Do not write a portable authorization check
+     * on these properties — on JVM a comparison against the local uid succeeds because both sides
+     * of it came from the same process, not because the sender was authorized.
+     *
      * @throws SdbusException if credentials are unavailable for this message
      */
     val credsPid: Int
@@ -214,6 +257,12 @@ expect sealed class Message {
     /**
      * The effective UID of the sender. Carries the same availability and trust caveats as
      * [credsPid], including throwing [SdbusException] when credentials are unavailable.
+     *
+     * **The JVM backend does not report an effective UID here.** On its one credential-bearing
+     * path it stores `getuid()` — the real UID, the same value as [credsUid] — in this field; it
+     * never calls `geteuid()`. The result is a plausible wrong answer rather than a failure, so a
+     * check that reads it can pass for a process whose effective identity differs from its real
+     * one. Only the native backend reports a genuine effective UID.
      */
     val credsEuid: UInt
 
@@ -226,6 +275,9 @@ expect sealed class Message {
     /**
      * The effective GID of the sender. Carries the same availability and trust caveats as
      * [credsPid], including throwing [SdbusException] when credentials are unavailable.
+     *
+     * **The JVM backend does not report an effective GID here**, for the same reason as
+     * [credsEuid]: it stores `getgid()`, identical to [credsGid], and never calls `getegid()`.
      */
     val credsEgid: UInt
 
@@ -247,7 +299,16 @@ expect sealed class Message {
  * for container types, the signature of the contained elements.
  */
 class PeekedType(
-    /** The D-Bus type code of the value at the read position, or `null` if at the end. */
+    /**
+     * The D-Bus type code of the value at the read position, or `null` if at the end.
+     *
+     * **`null` is overloaded on the JVM backend.** There it also means "the value at the cursor is
+     * Kotlin `null`" and "the value at the cursor is an in-process object whose D-Bus signature
+     * cannot be inferred" — the latter being a path the JVM backend deliberately supports for
+     * same-process traffic. `type == null` is therefore a sound end-of-message test on native
+     * (where it maps to sd-bus's end-of-container return) but not on JVM, where it can report the
+     * end mid-body and silently truncate a read.
+     */
     val type: Char?,
     /** For container types, the signature of the contained elements, otherwise `null`. */
     val contents: String?

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
@@ -319,11 +319,32 @@ value class Signature(
 /**
  * UnixFd is a representation of file descriptor D-Bus type that owns
  * the underlying fd, provides access to it, and closes the fd when
- * the UnixFd goes out of scope.
+ * the UnixFd is released.
+ *
+ * **Nothing closes the fd at scope exit.** Release is either explicit — [release], or a
+ * `use { }` block, since [UnixFd] is a [Resource] — or it happens at some later, unpredictable
+ * garbage collection, which both backends use only as a backstop (a `kotlin.native.ref.Cleaner`
+ * on native, a `java.lang.ref.Cleaner` on JVM). Dropping the last reference to a `UnixFd` and
+ * letting the variable fall out of scope therefore returns the descriptor at no defined time, so
+ * code that acquires fds in a loop must release them deterministically or it can exhaust the
+ * process fd table. (This paragraph corrects the class documentation published up to and
+ * including 1.0.1, which said the fd is closed "when the UnixFd goes out of scope"; that was
+ * never true of either backend.)
  *
  * UnixFd can be default constructed (owning invalid fd), or constructed from
  * an explicitly provided fd by either duplicating ([UnixFd] primary constructor)
  * or adopting that fd as-is ([UnixFd.adopt]).
+ *
+ * **Duplicating and closing are backend-dependent on JVM.** The native backend always `dup(2)`s
+ * in the primary constructor — throwing if the syscall fails — and always `close(2)`s on release.
+ * The JVM backend reaches the descriptor through junixsocket's *optional* native support; when
+ * that support is absent (no native binary for the platform, or a consumer where the reflective
+ * access it needs is denied, e.g. a JPMS-modular application) the primary constructor returns the
+ * caller's fd **unchanged**, so the instance aliases the caller's descriptor instead of owning a
+ * duplicate, and [release] then closes nothing. Both degradations are silent: no exception, no
+ * log, and no public way to ask which mode is in effect. On JVM, consequently, do not assume the
+ * fd you passed in is still exclusively yours after `UnixFd(fd)`, and do not treat a completed
+ * `release()` as proof that a descriptor was closed.
  */
 expect class UnixFd internal constructor(fd: Int, adoptFd: Unit) : Resource {
 
@@ -343,6 +364,10 @@ expect class UnixFd internal constructor(fd: Int, adoptFd: Unit) : Resource {
          * close [fd] afterwards. Contrast with the primary `UnixFd(fd)`
          * constructor, which duplicates the descriptor and leaves the
          * caller's fd untouched.
+         *
+         * Both halves of that contrast are unconditional only on the native backend; on JVM the
+         * duplication, and the close on release, depend on junixsocket's optional native support.
+         * See the [UnixFd] class documentation.
          */
         fun adopt(fd: Int): UnixFd
     }


### PR DESCRIPTION
**Documentation only.** Two files, both `commonMain`, both KDoc-comment-only. No `actual` edits, no test edits, no build edits.

Three issues, one PR, because all three are `commonMain` KDoc asserting behaviour an `actual` does not honour, in two overlapping files (`Message.kt` twice, `Types.kt` once).

Same defect class as #179 → #178: a KDoc that was wrong since it was written, unchecked because nobody had reason to look at that path, and a false claim in `commonMain` is a promise made on behalf of **both** backends — so it is wrong about one of them or wrong about both.

## Claim / contradiction / correction

### #208 — `UnixFd` closes the fd "when the UnixFd goes out of scope"

**Claimed** (`src/commonMain/.../Types.kt:319-322`): *"owns the underlying fd, provides access to it, and closes the fd when the UnixFd goes out of scope."*

**Contradicted by** both backends: native registers a `kotlin.native.ref.createCleaner` (`src/nativeMain/.../UnixFd.kt:61-63`), JVM a `java.lang.ref.Cleaner` (`src/jvmMain/.../Types.jvm.kt:22,62-64`). Both are GC-time and non-deterministic; nothing runs at scope exit. The native `actual`'s copy of the same sentence had **already been corrected** to "when the UnixFd is released" (`src/nativeMain/.../UnixFd.kt:39-42`) — the fix never reached the `expect`, which is the declaration Dokka publishes, so the published docs still carried the wrong sentence while the `adopt` KDoc 20 lines below stated the correct GC-based contract.

**Corrected to** "closes the fd when the UnixFd is released", plus a paragraph naming the two release routes (`release`, or `use { }` since `UnixFd` is a `Resource`) and the GC backstop, and stating in #221's style what changed and that it was never true.

**Second claim, same issue** (`Types.kt:343-345`): *"the primary `UnixFd(fd)` constructor, which duplicates the descriptor and leaves the caller's fd untouched."* Unconditional on native (`dup(2)`, throws on failure — `UnixFd.kt:99-108`); on JVM conditional on a reflective probe of junixsocket's non-exported `NativeUnixSocket` (`Types.jvm.kt:210-244`, inside `runCatching { … }.getOrNull()`). When that probe fails, `checkedDup` returns the caller's fd unchanged and `closeFd` returns `false` without closing (`Types.jvm.kt:86-100`), and the `false` is discarded by `OwnedFdState.run()` (`:69-72`). Both halves of the documented contract invert, silently, with `supportsFdDuplicationSemantics` `internal` so a consumer cannot query which mode is live. **Corrected** by a class-level paragraph stating the JVM condition and what degrades, and a cross-reference from `adopt`.

### #209 — four `Message` claims documenting native's behaviour only

| Claim | Contradiction | Correction |
|---|---|---|
| `Message.kt:163/171/181` — `@param complete` on `isAtEnd` / `copyTo` / `rewind` | Native passes it to `sd_bus_message_at_end` / `_copy` / `_rewind` (`Message.native.kt:591-609`); all three JVM actuals never read it (`Message.jvm.kt:186-195`) | Each `@param` now says the flag is honoured on native only, and what JVM does instead — per method, since the wrong answer differs (`rewind(false)` goes to the start of the body not the container; `copyTo(dst,false)` re-copies consumed values; `isAtEnd` ignores container nesting entirely) |
| `Message.kt:168` — *"Copies the contents of this message into [destination]"* | `Message.jvm.kt:189` also does `destination.metadata = metadata` — identity, not contents: interface/member/path/sender/destination, `valid`, and all sender credentials. Native's `sd_bus_message_copy` is body-only | States that the JVM copy replaces the destination's metadata and native's does not |
| `Message.kt:212` — `PeekedType.type` is *"null if at the end"* | Native sets it from `takeIf { r > 0 }`, exactly sd-bus's end signal (`Message.native.kt:581`). JVM returns `null` in two further cases: a Kotlin-`null` value, and a value `inferSignature` cannot type (`Message.jvm.kt:177-181`, `:220`, `:254`) — the latter being the raw in-process object path the backend deliberately supports (`:618-621`) | States that `null` is overloaded on JVM and is not a sound end-of-message test there, though it is on native |
| `Message.kt:154` — *"Whether this message wraps a valid underlying D-Bus message"* | Native: `msg != null` (`Message.native.kt:586-587`), true for every message. JVM: `metadata.valid`, defaulting `false` (`Message.jvm.kt:40,182-183`), so `createPlainMessage().isValid` is `false` on JVM and `true` on native — and `createErrorReply` sets it `false` on purpose (`:471-474`) with `MethodCall.send` reading it back as "not an error reply" (`:447`), a different concept in the same field | States the divergence, that the field carries two concepts on JVM, and that the value is unspecified for anything but native's `msg != null` |

Per the #141 route: these are documented as divergences rather than asserted into a cross-backend test, because no single assertion passes on both.

### #210 — the `creds*` KDoc is native-only

**Note what #236 (merged, `680e981`) already covered, and is NOT duplicated here:** that the accessors **throw** rather than returning a sentinel, and that a direct connection's `sender` is peer-asserted so credentials reached through it are not authoritative. #210 was filed at `17:25Z`, ~8h before #236 merged, and its "the types are non-nullable so availability has no representation" observation is that PR's subject. What #236 did **not** say, and this PR adds:

**(a) On JVM no credential ever describes another process.** The only site that populates them is `withLocalSenderCredentials` (`WireDbusBackend.kt:815-835`), called from exactly one place — `:768`, the received-signal path — and it returns the metadata unchanged unless the sender resolves to a connection in this same JVM (`:817`). The values come from `localProcessWireCredentials` (`:798-813`) = `ProcessHandle.current().pid()` + `UnixSystem()`, i.e. **this** process. Everything else leaves the fields `null` and the accessor throws (`Message.jvm.kt:15-16`). Verified by search: `credsUid =` / `credsEuid =` / `withLocalSenderCredentials` occur nowhere else in `src/`. So on JVM these properties either throw or describe *you* — never a remote principal. The doc now says that, and says a comparison against the local uid succeeds on JVM because both sides came from the same process, not because the sender was authorized.

**(b) `credsEuid` / `credsEgid` are not effective ids.** `WireDbusBackend.kt:830,832` assign `credsEuid = creds.uid` and `credsEgid = creds.gid`, and those come from `UnixSystem().uid`/`.gid` = `getuid()`/`getgid()`. `geteuid()` is never called. `JvmCredentialsTest.kt:14-15` documents the shortcut as "euid/egid equal uid/gid for a non-setuid process" — true for the test runner, false in general. Both properties now say plainly that JVM does not report an effective id there.

## Behaviour changes NOT made here — split out

A doc PR that quietly changes behaviour is worse than two PRs, so each of these is filed rather than done:

- **#245** — the `UnixFd` suite asserts the degraded JVM fd mode as a valid outcome (`UnixFdCommonTest.kt` has an `else` branch per test asserting the degraded contract against `FdTestSupport.jvm.kt`'s synthetic-integer fd table, where no real descriptor is ever opened). **Partly stale already:** #208 cited `JvmUnixFdTest.kt:9`'s bare `if (!supported) return`, which #228 replaced with `org.junit.Assume.assumeTrue` at `20:05` on 2026-08-07, ~7h after #208 was filed. Only the `commonTest` else-branches and the fake fd table remain.
- **#246** — make the JVM honour `complete`, stop copying metadata in `copyTo`, and split the error-reply flag out of `Metadata.valid`; plus the parity assertion that distinguishes `complete = true` from `false`, which exists on neither backend today.
- **#247** — stop reporting `getuid()`/`getgid()` as `credsEuid`/`credsEgid`; leave them absent so the accessor throws. #210's author called this non-optional regardless of how the rest resolves, and I agree: a throw is recoverable, a wrong uid that passes a root check is not.

`docs/BACKENDS.md` has no sender-credential row, which is where a consumer would look for (a) — **not touched**, that file is being edited under #191/#202 right now. Noted in #247 instead.

## #208's UNRESOLVED question, settled

#208 left "which fd branch is live in CI" as `UNRESOLVED-NEEDS-BUILD`, noting that if the degraded branch were live, its items would not be latent. **Measured:** `dbus-run-session -- ./gradlew :jvmTest --tests '*JvmUnixFdTest*'` (JDK 21, x86_64) → `tests="1" skipped="0"`, the case executing in 0.082s. `assumeTrue` passed, so `supportsFdDuplicationSemantics` was `true` and the real `assertNotEquals(first.fd, second.fd)` ran. The degraded branch is **not** live on this host, so #208's items 1-2 are latent and item 3 is hardening, not a live hole. Not measured on the CI runners — flagged in #245.

## Verification — what I ran, and what I did not

**Ran** (JDK 21, this branch):

- `./gradlew ktlintCheck apiCheck` — **BUILD SUCCESSFUL**, and `git status --porcelain` immediately after shows only the two edited source files: `api/*.api` did not move, as a KDoc-only change must not.
- `./gradlew :dokkaGeneratePublicationHtml` — **BUILD SUCCESSFUL** (the guard that matters, since malformed KDoc has broken this build before — #189). Dokka emits **8** `Couldn't resolve link` warnings, all pre-existing in untouched `jvmMain` files (`DBusWireConnection.kt` ×4, `WireDbusBackend.kt` ×4) and **none naming `Message.kt` or `Types.kt`** — a working detector reporting absence, not a silent pass. Every link I added (`[release]`, `[Resource]`, `[createPlainMessage]`, `[MethodCall.createErrorReply]`, `[credsUid]`, `[credsGid]`, `[credsEuid]`, `[complete]`, `[destination]`) resolves.
- Spot-checked the rendered HTML, so the KDoc is genuinely published and not silently dropped: `-unix-fd/index.html` contains "Nothing closes the fd at scope exit" and the junixsocket paragraph, `-message/creds-euid.html` contains "does not report an effective UID", `-peeked-type/type.html` contains "overloaded on the JVM backend".
- The `:jvmTest` fd measurement above.

**Did not run:** the rest of the test suites (`jvmTest` in full, `linuxX64Test`, cross-tests). A comment-only change cannot alter behaviour and CI covers them; I am not claiming test verification I did not do.

## Incidental, and corrected at the source

**#199 was closed by automation while the decision it names is still open** — `closed by monkopedia-reviewer` at `01:30:37Z` with `stateReason: COMPLETED`, coincident with #236's merge, and `monkopedia-coder` commented *"the decision here is untouched and this issue stays open"* **32 seconds later**. #236's body says "Refs #199 — this does not decide it". The KDoc on `main` (which this PR extends) tells readers it is an open question, which a closed issue contradicts. Reopened with the timeline cited; no labels or code touched.

Fixes #208
Fixes #209
Fixes #210
Refs #199, #245, #246, #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
