### PR TITLE
fix(codegen): bound what hostile introspection XML can make the generator do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   emitted statement changes — so this is additive documentation rather than a behavior change.
   XML that documents nothing generates exactly what it did before. (#160)
 
+### Fixed — codegen
+
+- **Introspection XML can no longer make the generator do unbounded work.** Two inputs used to cost
+  build availability rather than failing: a `<!DOCTYPE>` internal subset declaring XML entities (the
+  parser expanded them with no limit — ten-fold per nesting level, and an entity referencing itself
+  never terminated at all), and a type signature with thousands of array type codes (unbounded
+  recursion, `StackOverflowError`). An internal subset is now refused outright — introspection XML
+  has no use for one, and the external `introspect.dtd` doctype a real `dbus-daemon` sends still
+  parses — and a signature is held to the D-Bus specification's own 255-character maximum, which
+  bounds the recursion by construction. Both report which limit they hit. Generated output for
+  valid XML is unchanged. (#194)
+
 ### Changed — codegen
 
 - **Standard D-Bus annotations are now mapped onto the runtime vtable/proxy flags.** The generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   never terminated at all), and a type signature with thousands of array type codes (unbounded
   recursion, `StackOverflowError`). An internal subset is now refused outright — introspection XML
   has no use for one, and the external `introspect.dtd` doctype a real `dbus-daemon` sends still
-  parses — and a signature is held to the D-Bus specification's own 255-character maximum, which
-  bounds the recursion by construction. Both report which limit they hit. Generated output for
-  valid XML is unchanged. (#194)
+  parses, byte order mark and all — and a signature is held to the D-Bus specification's own
+  255-character maximum, which bounds the recursion by construction. A document whose prolog cannot
+  be read as far as its root element is refused too, rather than assumed to declare nothing. All
+  three report what they refused. Generated output for valid XML is unchanged. (#194)
 
 ### Changed — codegen
 

--- a/codegen/src/main/kotlin/NamingManager.kt
+++ b/codegen/src/main/kotlin/NamingManager.kt
@@ -283,7 +283,33 @@ private fun MutableMap<String, NamingType>.buildSingleType(
     this[type.type] = type
 }
 
+/**
+ * The D-Bus specification's own maximum length for a type signature. It is what bounds the
+ * recursion in [buildValidatedType]: every level consumes at least one character of the signature,
+ * so a signature within the limit cannot nest more than 255 deep. `dbus-daemon` enforces the same
+ * number on every message it relays, so nothing a conforming service can describe is refused —
+ * the longest signature in the checked-in fixtures is 15 characters.
+ */
+private const val MAX_SIGNATURE_LENGTH = 255
+
 fun MutableMap<String, NamingType>.buildType(pkg: String, name: String, type: String): NamingType {
+    require(type.length <= MAX_SIGNATURE_LENGTH) {
+        "Type signature for '$name' is ${type.length} characters, over the D-Bus maximum of " +
+            "$MAX_SIGNATURE_LENGTH"
+    }
+    return buildValidatedType(pkg, name, type)
+}
+
+/**
+ * [buildType] once its signature is known to be within [MAX_SIGNATURE_LENGTH]. The recursive calls
+ * are all to this rather than back to [buildType]: they descend into suffixes of an already
+ * validated signature, so re-checking each one would be re-asserting the same fact.
+ */
+private fun MutableMap<String, NamingType>.buildValidatedType(
+    pkg: String,
+    name: String,
+    type: String
+): NamingType {
     (this[type] as? SimpleType)?.let { return it }
     if (type.isEmpty()) {
         return this.getOrPut(type) {
@@ -320,12 +346,12 @@ fun MutableMap<String, NamingType>.buildType(pkg: String, name: String, type: St
             if (type[1] == '{') {
                 // Map
                 val keyTypeStr = type.substring(2)
-                val keyType = buildType(pkg, name + "Key", keyTypeStr)
+                val keyType = buildValidatedType(pkg, name + "Key", keyTypeStr)
                 require(keyTypeStr.startsWith(keyType.type)) {
                     "Invalid type parsed out, expected $keyTypeStr but got ${keyType.type}"
                 }
                 val valueTypeStr = keyTypeStr.substring(keyType.type.length)
-                val valueType = buildType(pkg, name + "Value", valueTypeStr)
+                val valueType = buildValidatedType(pkg, name + "Value", valueTypeStr)
                 require(valueTypeStr.startsWith(valueType.type)) {
                     "Invalid type parsed out, expected $valueTypeStr but got ${valueType.type}"
                 }
@@ -344,7 +370,7 @@ fun MutableMap<String, NamingType>.buildType(pkg: String, name: String, type: St
             } else {
                 // List
                 val valueTypeStr = type.substring(1)
-                val valueType = buildType(pkg, name + "Value", valueTypeStr)
+                val valueType = buildValidatedType(pkg, name + "Value", valueTypeStr)
                 require(valueTypeStr.startsWith(valueType.type)) {
                     "Invalid type parsed out, expected $valueTypeStr but got ${valueType.type}"
                 }
@@ -359,7 +385,7 @@ fun MutableMap<String, NamingType>.buildType(pkg: String, name: String, type: St
             val types = sequence {
                 var currentType = type.substring(1)
                 while (currentType.isNotEmpty() && currentType[0] != ')') {
-                    val nextType = buildType(pkg, name + "${index++}", currentType)
+                    val nextType = buildValidatedType(pkg, name + "${index++}", currentType)
                     require(currentType.startsWith(nextType.type)) {
                         "Invalid type parsed out, expected $currentType but got ${nextType.type}"
                     }

--- a/codegen/src/main/kotlin/Xml2Kotlin.kt
+++ b/codegen/src/main/kotlin/Xml2Kotlin.kt
@@ -66,8 +66,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with sdbus-kotlin. If not, see <http://www.gnu.org/licenses/>.
  */
-@file:OptIn(ExperimentalSerializationApi::class)
-
 package com.monkopedia.sdbus
 
 import com.github.ajalt.clikt.core.CliktCommand
@@ -78,8 +76,6 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 import java.io.File
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
 
 fun main(args: Array<String>) = Xml2Kotlin().main(args)
 
@@ -102,7 +98,7 @@ class Xml2Kotlin : CliktCommand() {
 
     override fun run() {
         val packageOverride = outputPackage?.trim()?.takeUnless { it.isEmpty() }
-        val xml = introspectionXml.decodeFromString<XmlRootNode>(input.readText())
+        val xml = parseIntrospectionXml(input.readText())
         if (!keep) {
             output.deleteRecursively()
         }

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -24,6 +24,7 @@ package com.monkopedia.sdbus
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
 import nl.adaptivity.xmlutil.QName
 import nl.adaptivity.xmlutil.XmlReader
@@ -37,9 +38,10 @@ import nl.adaptivity.xmlutil.serialization.XmlValue
 import nl.adaptivity.xmlutil.serialization.structure.XmlDescriptor
 
 /**
- * The single parser for D-Bus introspection XML, shared by the [Xml2Kotlin] CLI and the tests so
- * the golden fixtures assert against the configuration the tool actually ships. Unknown content
- * is dropped rather than failing, so vendor extensions don't break generation.
+ * The serialization format the [Xml2Kotlin] CLI and the tests share, so the golden fixtures assert
+ * against the configuration the tool actually ships. Unknown content is dropped rather than
+ * failing, so vendor extensions don't break generation. Call [parseIntrospectionXml] rather than
+ * this directly — it is what applies the limits hostile XML is held to.
  *
  * `XML.compat` is deprecated in xmlutil 1.0, but its replacements deliberately change the parsing
  * defaults and xmlutil offers no non-deprecated route back to the old ones. Switching is a
@@ -59,6 +61,77 @@ internal val introspectionXml: XML = XML.compat {
         ): List<ParsedData<*>> = emptyList()
     }
 }
+
+/**
+ * Parses D-Bus introspection XML into the model the generators consume. The one entry point the CLI
+ * and the tests both use, so what the golden fixtures assert against and what the tool ships are
+ * held to the same limit.
+ *
+ * Introspection XML is supplied by the service being introspected, and `:codegen` runs inside a
+ * developer's build (the Gradle plugin calls it in-process), so a hostile document costs build
+ * availability rather than anything at runtime.
+ */
+internal fun parseIntrospectionXml(xml: String): XmlRootNode {
+    require(!declaresDtdInternalSubset(xml)) {
+        "Introspection XML declares a DTD internal subset (<!DOCTYPE ... [ ... ]>). " +
+            "Introspection XML has no use for one, and the entities it can declare are expanded " +
+            "without any limit, so the declaration is refused rather than parsed."
+    }
+    return introspectionXml.decodeFromString(xml)
+}
+
+/**
+ * Whether [xml] opens a DTD internal subset in its prolog, i.e. `<!DOCTYPE node [ ... ]>`.
+ *
+ * The subset is the only place introspection XML can declare XML entities, and xmlutil's parser
+ * expands them with no limit of any kind: measured against xmlutil 1.0.1, a 421-byte document
+ * nesting six ten-fold entities decodes to a 1,000,000-character attribute value in 30ms — each
+ * further level multiplies by ten — and `<!ENTITY a "&a;">` never terminates at all. There is no
+ * configuration knob for that (the JVM path is xmlutil's own `KtXmlReader`, not JAXP, so the
+ * `jdk.xml.entityExpansionLimit` default does not apply), and `expandEntities = false` would not
+ * help either because attribute values are expanded unconditionally.
+ *
+ * Refusing the subset outright is both the complete fix and the narrowest one: it is the only route
+ * to a declared entity, external entities the parser already rejects on its own, and what a real
+ * service emits is at most the external `introspect.dtd` doctype, which still parses.
+ *
+ * Only the prolog is scanned — the XML declaration, comments and processing instructions that may
+ * precede the doctype are skipped over — so a literal `<!DOCTYPE` in a comment or in element
+ * content is not mistaken for a declaration.
+ */
+private fun declaresDtdInternalSubset(xml: String): Boolean {
+    var i = 0
+    while (i < xml.length) {
+        when {
+            xml[i].isWhitespace() -> i++
+            xml.startsWith("<!--", i) -> i = xml.endOf("-->", i + 4) ?: return false
+            xml.startsWith("<?", i) -> i = xml.endOf("?>", i + 2) ?: return false
+            xml.startsWith("<!DOCTYPE", i) -> return doctypeOpensSubset(xml, i + "<!DOCTYPE".length)
+            // The root element, or something the parser will reject on its own.
+            else -> return false
+        }
+    }
+    return false
+}
+
+/** Whether the doctype declaration running from [start] in [xml] opens an internal subset. */
+private fun doctypeOpensSubset(xml: String, start: Int): Boolean {
+    var i = start
+    while (i < xml.length) {
+        when (val c = xml[i]) {
+            '[' -> return true
+            '>' -> return false
+            // A quoted public or system literal; '[' and '>' inside it mean neither of the above.
+            '\'', '"' -> i = xml.endOf(c.toString(), i + 1) ?: return false
+            else -> i++
+        }
+    }
+    return false
+}
+
+/** The index just past the next [token] at or after [from], or null if there isn't one. */
+private fun String.endOf(token: String, from: Int): Int? =
+    indexOf(token, from).takeIf { it >= 0 }?.plus(token.length)
 
 @Serializable
 @XmlSerialName("node")

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -88,17 +88,27 @@ internal fun parseIntrospectionXml(xml: String): XmlRootNode {
  * `expandEntities = false` would not help either because attribute values are expanded
  * unconditionally.
  *
- * Refusing the subset outright is both the complete fix and the narrowest one: it is the only route
- * to a declared entity, external entities the parser already rejects on its own, and what a real
- * service emits is at most the external `introspect.dtd` doctype, which still parses.
+ * Refusing the subset outright covers that whole class and is the narrowest thing that does: it is
+ * the only route to a declared entity, external entities the parser already rejects on its own, and
+ * what a real service emits is at most the external `introspect.dtd` doctype, which still parses.
+ * The cover is only as good as this scan's reading of the prolog, which is why what it cannot read
+ * is refused rather than passed on.
  *
  * Only the prolog is read — the byte order mark, XML declaration, comments and processing
  * instructions that may precede the doctype are stepped over — so a literal `<!DOCTYPE` in a
  * comment or in element content is not mistaken for a declaration. **A prolog this cannot read is
  * refused rather than assumed to declare nothing**: the scan is what decides whether entities are
  * possible, so treating what it does not model as safe is how a leading byte order mark got past an
- * earlier version of it. The only thing that legitimately ends the scan is the root element, which
- * is a `<` opening neither a markup declaration nor a processing instruction.
+ * earlier version of it.
+ *
+ * The one thing that legitimately ends the scan is the root element — a `<` opening neither a
+ * markup declaration nor a processing instruction — and that is the only branch this returns null
+ * from. A doctype without an internal subset is read *past* rather than stopped at, because the
+ * parser honours a second `<!DOCTYPE` later in the prolog even though two of them is not
+ * well-formed; stopping at the first one's `>` let a subset behind the doctype every real service
+ * sends declare entities freely. Stopping at the root element is safe for the reason a second
+ * doctype is not: measured against xmlutil 1.0.1, a declaration after the root element is never
+ * applied, and an entity referenced inside the root fails with `Unknown entity` instead.
  */
 private fun prologRefusal(xml: String): String? {
     var i = if (xml.startsWith(BYTE_ORDER_MARK)) 1 else 0
@@ -107,7 +117,11 @@ private fun prologRefusal(xml: String): String? {
             xml[i].isWhitespace() -> i++
             xml.startsWith("<!--", i) -> i = xml.endOf("-->", i + 4) ?: return UNREADABLE_PROLOG
             xml.startsWith("<?", i) -> i = xml.endOf("?>", i + 2) ?: return UNREADABLE_PROLOG
-            xml.startsWith("<!DOCTYPE", i) -> return doctypeRefusal(xml, i + "<!DOCTYPE".length)
+            xml.startsWith(DOCTYPE, i) -> {
+                val end = endOfDoctypeBody(xml, i + DOCTYPE.length) ?: return UNREADABLE_PROLOG
+                if (xml[end] == '[') return INTERNAL_SUBSET
+                i = end + 1
+            }
             xml[i] == '<' && !xml.startsWith("<!", i) -> return null // The root element.
             else -> return UNREADABLE_PROLOG
         }
@@ -115,19 +129,22 @@ private fun prologRefusal(xml: String): String? {
     return UNREADABLE_PROLOG
 }
 
-/** [prologRefusal] for the doctype declaration running from [start] in [xml]. */
-private fun doctypeRefusal(xml: String, start: Int): String? {
+/**
+ * The index of the character ending the doctype declaration whose body starts at [start] in [xml] —
+ * either the `[` opening an internal subset or the `>` closing the declaration — or null if it is
+ * unterminated. Quoted public and system literals are stepped over, since neither character means
+ * either of those things inside one.
+ */
+private fun endOfDoctypeBody(xml: String, start: Int): Int? {
     var i = start
     while (i < xml.length) {
         when (val c = xml[i]) {
-            '[' -> return INTERNAL_SUBSET
-            '>' -> return null
-            // A quoted public or system literal; '[' and '>' inside it mean neither of the above.
-            '\'', '"' -> i = xml.endOf(c.toString(), i + 1) ?: return UNREADABLE_PROLOG
+            '[', '>' -> return i
+            '\'', '"' -> i = xml.endOf(c.toString(), i + 1) ?: return null
             else -> i++
         }
     }
-    return UNREADABLE_PROLOG
+    return null
 }
 
 /** The index just past the next [token] at or after [from], or null if there isn't one. */
@@ -135,6 +152,8 @@ private fun String.endOf(token: String, from: Int): Int? =
     indexOf(token, from).takeIf { it >= 0 }?.plus(token.length)
 
 private const val BYTE_ORDER_MARK = '\uFEFF'
+
+private const val DOCTYPE = "<!DOCTYPE"
 
 private const val INTERNAL_SUBSET =
     "Introspection XML declares a DTD internal subset (<!DOCTYPE ... [ ... ]>). Introspection " +

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -72,66 +72,79 @@ internal val introspectionXml: XML = XML.compat {
  * availability rather than anything at runtime.
  */
 internal fun parseIntrospectionXml(xml: String): XmlRootNode {
-    require(!declaresDtdInternalSubset(xml)) {
-        "Introspection XML declares a DTD internal subset (<!DOCTYPE ... [ ... ]>). " +
-            "Introspection XML has no use for one, and the entities it can declare are expanded " +
-            "without any limit, so the declaration is refused rather than parsed."
-    }
+    prologRefusal(xml)?.let { throw IllegalArgumentException(it) }
     return introspectionXml.decodeFromString(xml)
 }
 
 /**
- * Whether [xml] opens a DTD internal subset in its prolog, i.e. `<!DOCTYPE node [ ... ]>`.
+ * Why [xml]'s prolog must not be handed to the parser, or null to go ahead.
  *
- * The subset is the only place introspection XML can declare XML entities, and xmlutil's parser
- * expands them with no limit of any kind: measured against xmlutil 1.0.1, a 421-byte document
- * nesting six ten-fold entities decodes to a 1,000,000-character attribute value in 30ms — each
- * further level multiplies by ten — and `<!ENTITY a "&a;">` never terminates at all. There is no
- * configuration knob for that (the JVM path is xmlutil's own `KtXmlReader`, not JAXP, so the
- * `jdk.xml.entityExpansionLimit` default does not apply), and `expandEntities = false` would not
- * help either because attribute values are expanded unconditionally.
+ * A `<!DOCTYPE ... [ ... ]>` internal subset is the only place introspection XML can declare XML
+ * entities, and xmlutil's parser expands them with no limit of any kind: measured against xmlutil
+ * 1.0.1, a 421-byte document nesting six ten-fold entities decodes to a 1,000,000-character
+ * attribute value in 30ms — each further level multiplies by ten — and `<!ENTITY a "&a;">` never
+ * terminates at all. There is no configuration knob for that (the JVM path is xmlutil's own
+ * `KtXmlReader`, not JAXP, so the `jdk.xml.entityExpansionLimit` default does not apply), and
+ * `expandEntities = false` would not help either because attribute values are expanded
+ * unconditionally.
  *
  * Refusing the subset outright is both the complete fix and the narrowest one: it is the only route
  * to a declared entity, external entities the parser already rejects on its own, and what a real
  * service emits is at most the external `introspect.dtd` doctype, which still parses.
  *
- * Only the prolog is scanned — the XML declaration, comments and processing instructions that may
- * precede the doctype are skipped over — so a literal `<!DOCTYPE` in a comment or in element
- * content is not mistaken for a declaration.
+ * Only the prolog is read — the byte order mark, XML declaration, comments and processing
+ * instructions that may precede the doctype are stepped over — so a literal `<!DOCTYPE` in a
+ * comment or in element content is not mistaken for a declaration. **A prolog this cannot read is
+ * refused rather than assumed to declare nothing**: the scan is what decides whether entities are
+ * possible, so treating what it does not model as safe is how a leading byte order mark got past an
+ * earlier version of it. The only thing that legitimately ends the scan is the root element, which
+ * is a `<` opening neither a markup declaration nor a processing instruction.
  */
-private fun declaresDtdInternalSubset(xml: String): Boolean {
-    var i = 0
+private fun prologRefusal(xml: String): String? {
+    var i = if (xml.startsWith(BYTE_ORDER_MARK)) 1 else 0
     while (i < xml.length) {
         when {
             xml[i].isWhitespace() -> i++
-            xml.startsWith("<!--", i) -> i = xml.endOf("-->", i + 4) ?: return false
-            xml.startsWith("<?", i) -> i = xml.endOf("?>", i + 2) ?: return false
-            xml.startsWith("<!DOCTYPE", i) -> return doctypeOpensSubset(xml, i + "<!DOCTYPE".length)
-            // The root element, or something the parser will reject on its own.
-            else -> return false
+            xml.startsWith("<!--", i) -> i = xml.endOf("-->", i + 4) ?: return UNREADABLE_PROLOG
+            xml.startsWith("<?", i) -> i = xml.endOf("?>", i + 2) ?: return UNREADABLE_PROLOG
+            xml.startsWith("<!DOCTYPE", i) -> return doctypeRefusal(xml, i + "<!DOCTYPE".length)
+            xml[i] == '<' && !xml.startsWith("<!", i) -> return null // The root element.
+            else -> return UNREADABLE_PROLOG
         }
     }
-    return false
+    return UNREADABLE_PROLOG
 }
 
-/** Whether the doctype declaration running from [start] in [xml] opens an internal subset. */
-private fun doctypeOpensSubset(xml: String, start: Int): Boolean {
+/** [prologRefusal] for the doctype declaration running from [start] in [xml]. */
+private fun doctypeRefusal(xml: String, start: Int): String? {
     var i = start
     while (i < xml.length) {
         when (val c = xml[i]) {
-            '[' -> return true
-            '>' -> return false
+            '[' -> return INTERNAL_SUBSET
+            '>' -> return null
             // A quoted public or system literal; '[' and '>' inside it mean neither of the above.
-            '\'', '"' -> i = xml.endOf(c.toString(), i + 1) ?: return false
+            '\'', '"' -> i = xml.endOf(c.toString(), i + 1) ?: return UNREADABLE_PROLOG
             else -> i++
         }
     }
-    return false
+    return UNREADABLE_PROLOG
 }
 
 /** The index just past the next [token] at or after [from], or null if there isn't one. */
 private fun String.endOf(token: String, from: Int): Int? =
     indexOf(token, from).takeIf { it >= 0 }?.plus(token.length)
+
+private const val BYTE_ORDER_MARK = '\uFEFF'
+
+private const val INTERNAL_SUBSET =
+    "Introspection XML declares a DTD internal subset (<!DOCTYPE ... [ ... ]>). Introspection " +
+        "XML has no use for one, and the entities it can declare are expanded without any limit, " +
+        "so the declaration is refused rather than parsed."
+
+private const val UNREADABLE_PROLOG =
+    "The XML prolog of the introspection XML could not be read as far as the root element, so " +
+        "whether it may declare entities is unknown. It is refused rather than guessed at; the " +
+        "parser would reject it in any case."
 
 @Serializable
 @XmlSerialName("node")

--- a/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
+++ b/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
@@ -1,0 +1,170 @@
+/**
+ *
+ * (C) 2016 - 2021 KISTLER INSTRUMENTE AG, Winterthur, Switzerland
+ * (C) 2016 - 2024 Stanislav Angelovic <stanislav.angelovic@protonmail.com>
+ * (C) 2024 - 2025 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The limits [parseIntrospectionXml] and [buildType] hold introspection XML to.
+ *
+ * Introspection XML comes from the service being introspected and `:codegen` runs inside a
+ * developer's build, so an input that makes the parser do unbounded work costs build availability.
+ * Each case below pairs the input that used to be unbounded with a positive control that the
+ * limit does not touch, so the suite discriminates the defect rather than the input shape.
+ *
+ * Every parse here runs under [parseWithin]: the point of these limits is that the answer arrives
+ * promptly, so a regression has to fail the suite rather than hang it.
+ */
+class CodegenHostileXmlTest {
+
+    @Test
+    fun entityDeclarationThatExpandsTenFoldPerLevel_isRefusedRatherThanExpanded() {
+        // Four levels expand to 10,000 characters, which the parser produced in 2ms before the
+        // limit; the shape is what matters, not the size. Levels are a multiplier, so the same
+        // document with three more of them is 10MB and with a few more it exhausts the heap of
+        // whatever build ran it.
+        val failure = parseWithin(TEN_FOLD_ENTITIES_FOUR_LEVELS)
+            ?: fail("expected the entity declaration to be refused, but the document parsed")
+        assertTrue(
+            failure.message.orEmpty().contains("DTD internal subset"),
+            "expected the failure to name the declaration it refused, got: ${failure.message}"
+        )
+    }
+
+    @Test
+    fun entityThatReferencesItself_isRefusedRatherThanNeverTerminating() {
+        // Before the limit this document did not fail, and did not succeed either: the parser
+        // re-injected the entity into its own replacement text indefinitely.
+        val failure = parseWithin(SELF_REFERENTIAL_ENTITY)
+            ?: fail("expected the entity declaration to be refused, but the document parsed")
+        assertTrue(
+            failure.message.orEmpty().contains("DTD internal subset"),
+            "expected the failure to name the declaration it refused, got: ${failure.message}"
+        )
+    }
+
+    /** The doctype a real `dbus-daemon` puts on every `Introspect` reply. */
+    @Test
+    fun externalDoctypeOfARealIntrospectReply_stillParses() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+             "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+            <!-- a comment mentioning <!DOCTYPE node [ to prove only the prolog is scanned -->
+            <node>
+              <interface name="org.example.Real">
+                <method name="Ping"/>
+              </interface>
+            </node>
+        """.trimIndent()
+
+        assertEquals(null, parseWithin(xml))
+        assertEquals("org.example.Real", TestXmlSupport.parse(xml).interfaces.single().name)
+    }
+
+    @Test
+    fun signatureLongerThanTheSpecMaximum_isRefusedRatherThanOverflowingTheStack() {
+        // 5000 array type codes overflowed the stack in NamingManager.buildType before the limit;
+        // 255 is the specification's own maximum signature length.
+        val failure = namingManagerFailureFor("a".repeat(5000) + "s")
+            ?: fail("expected the signature to be refused, but it was accepted")
+        assertTrue(
+            failure.message.orEmpty().contains("over the D-Bus maximum of 255"),
+            "expected the failure to name the limit it hit, got: " +
+                "${failure::class.simpleName}: ${failure.message}"
+        )
+    }
+
+    @Test
+    fun signatureAtTheSpecMaximum_stillParses() {
+        // 254 array type codes around an 's' is 255 characters, so it is legal and still resolves
+        // through 255 levels of recursion. This passed before the limit too — it is the control
+        // that keeps the case above from being satisfied by refusing deep signatures generally.
+        assertEquals(null, namingManagerFailureFor("a".repeat(254) + "s"))
+    }
+
+    private fun namingManagerFailureFor(signature: String): Throwable? = runCatching {
+        NamingManager(
+            TestXmlSupport.parse(
+                """
+                <node>
+                  <interface name="org.example.Signature">
+                    <method name="Get">
+                      <arg name="value" type="$signature" direction="out"/>
+                    </method>
+                  </interface>
+                </node>
+                """
+            )
+        )
+    }.exceptionOrNull()
+
+    /**
+     * Parses [xml] and returns what it failed with, or null if it parsed. Fails the test if the
+     * parse has not finished within [PARSE_TIMEOUT_MS] — an unbounded parse is exactly the defect
+     * under test, and a test that hangs takes out the job meant to catch it.
+     */
+    private fun parseWithin(xml: String, timeoutMs: Long = PARSE_TIMEOUT_MS): Throwable? {
+        var failure: Throwable? = null
+        val parse = Thread { failure = runCatching { TestXmlSupport.parse(xml) }.exceptionOrNull() }
+        parse.isDaemon = true
+        parse.start()
+        parse.join(timeoutMs)
+        if (parse.isAlive) fail("parse had not finished after ${timeoutMs}ms")
+        return failure
+    }
+
+    companion object {
+        private const val PARSE_TIMEOUT_MS = 30_000L
+
+        private val TEN_FOLD_ENTITIES_FOUR_LEVELS = """
+            <!DOCTYPE node [
+              <!ENTITY a "aaaaaaaaaa">
+              <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+              <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+              <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+            ]>
+            <node>
+              <interface name="org.example.Expanding">
+                <method name="Get">
+                  <annotation name="org.gtk.GDBus.DocString" value="&d;"/>
+                </method>
+              </interface>
+            </node>
+        """.trimIndent()
+
+        private val SELF_REFERENTIAL_ENTITY = """
+            <!DOCTYPE node [ <!ENTITY a "&a;"> ]>
+            <node>
+              <interface name="org.example.Recursive">
+                <method name="Get">
+                  <annotation name="org.gtk.GDBus.DocString" value="&a;"/>
+                </method>
+              </interface>
+            </node>
+        """.trimIndent()
+    }
+}

--- a/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
+++ b/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
@@ -46,23 +46,58 @@ class CodegenHostileXmlTest {
         // limit; the shape is what matters, not the size. Levels are a multiplier, so the same
         // document with three more of them is 10MB and with a few more it exhausts the heap of
         // whatever build ran it.
-        val failure = parseWithin(TEN_FOLD_ENTITIES_FOUR_LEVELS)
-            ?: fail("expected the entity declaration to be refused, but the document parsed")
-        assertTrue(
-            failure.message.orEmpty().contains("DTD internal subset"),
-            "expected the failure to name the declaration it refused, got: ${failure.message}"
-        )
+        assertRefusedAsInternalSubset(TEN_FOLD_ENTITIES_FOUR_LEVELS)
     }
 
     @Test
     fun entityThatReferencesItself_isRefusedRatherThanNeverTerminating() {
         // Before the limit this document did not fail, and did not succeed either: the parser
         // re-injected the entity into its own replacement text indefinitely.
-        val failure = parseWithin(SELF_REFERENTIAL_ENTITY)
-            ?: fail("expected the entity declaration to be refused, but the document parsed")
+        assertRefusedAsInternalSubset(SELF_REFERENTIAL_ENTITY)
+    }
+
+    /**
+     * A byte order mark is what `File.readText()` leaves at the front of a UTF-8 document that has
+     * one, and the parser accepts it, so the prolog has to be read past it rather than given up on.
+     * Both entity cases get their own case behind one, since they fail differently without it: this
+     * one parses, and the self-referential one below does not come back at all.
+     */
+    @Test
+    fun entityDeclarationBehindAByteOrderMark_isStillRefused() {
+        assertRefusedAsInternalSubset(BOM + TEN_FOLD_ENTITIES_FOUR_LEVELS)
+    }
+
+    @Test
+    fun selfReferentialEntityBehindAByteOrderMark_isStillRefused() {
+        assertRefusedAsInternalSubset(BOM + SELF_REFERENTIAL_ENTITY)
+    }
+
+    @Test
+    fun documentBehindAByteOrderMark_stillParses() {
+        val xml = BOM + """
+            <node>
+              <interface name="org.example.Marked">
+                <method name="Ping"/>
+              </interface>
+            </node>
+        """.trimIndent()
+
+        assertEquals(null, parseWithin(xml))
+        assertEquals("org.example.Marked", TestXmlSupport.parse(xml).interfaces.single().name)
+    }
+
+    /**
+     * The prolog scan decides whether a document may declare entities, so what it does with a
+     * prolog it cannot read is the whole question: assuming such a document safe is how the byte
+     * order mark got past it.
+     */
+    @Test
+    fun prologTheScanCannotRead_isRefusedRatherThanAssumedToDeclareNothing() {
+        val failure = parseWithin("stray text <node/>")
+            ?: fail("expected the unreadable prolog to be refused, but the document parsed")
         assertTrue(
-            failure.message.orEmpty().contains("DTD internal subset"),
-            "expected the failure to name the declaration it refused, got: ${failure.message}"
+            failure.message.orEmpty().contains("prolog"),
+            "expected the failure to say the prolog could not be read, got: ${failure.message}"
         )
     }
 
@@ -106,6 +141,15 @@ class CodegenHostileXmlTest {
         assertEquals(null, namingManagerFailureFor("a".repeat(254) + "s"))
     }
 
+    private fun assertRefusedAsInternalSubset(xml: String) {
+        val failure = parseWithin(xml)
+            ?: fail("expected the entity declaration to be refused, but the document parsed")
+        assertTrue(
+            failure.message.orEmpty().contains("DTD internal subset"),
+            "expected the failure to name the declaration it refused, got: ${failure.message}"
+        )
+    }
+
     private fun namingManagerFailureFor(signature: String): Throwable? = runCatching {
         NamingManager(
             TestXmlSupport.parse(
@@ -138,7 +182,11 @@ class CodegenHostileXmlTest {
     }
 
     companion object {
-        private const val PARSE_TIMEOUT_MS = 30_000L
+        /** Two orders of magnitude over the green path, which answers in under a hundredth. */
+        private const val PARSE_TIMEOUT_MS = 5_000L
+
+        /** Spelled out rather than written literally, since the character itself is invisible. */
+        private const val BOM = "\uFEFF"
 
         private val TEN_FOLD_ENTITIES_FOUR_LEVELS = """
             <!DOCTYPE node [

--- a/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
+++ b/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
@@ -72,6 +72,59 @@ class CodegenHostileXmlTest {
         assertRefusedAsInternalSubset(BOM + SELF_REFERENTIAL_ENTITY)
     }
 
+    /**
+     * A second `<!DOCTYPE` after the one a real service sends. Two of them is not well-formed XML,
+     * but the parser honours the second and declares its entities, so the scan has to keep reading
+     * to the root element rather than stopping at the first declaration's `>`.
+     */
+    @Test
+    fun secondDoctypeBehindARealIntrospectReplyDoctype_isStillRefused() {
+        assertRefusedAsInternalSubset(
+            REAL_INTROSPECT_DOCTYPE + "\n" + TEN_FOLD_ENTITIES_FOUR_LEVELS
+        )
+    }
+
+    @Test
+    fun selfReferentialEntityInASecondDoctype_isStillRefused() {
+        assertRefusedAsInternalSubset(REAL_INTROSPECT_DOCTYPE + "\n" + SELF_REFERENTIAL_ENTITY)
+    }
+
+    /**
+     * The scan resumes after a doctype rather than after the next declaration in particular, so a
+     * comment or processing instruction between the two does not hide the second one either.
+     */
+    @Test
+    fun secondDoctypeBehindACommentAndAProcessingInstruction_isStillRefused() {
+        assertRefusedAsInternalSubset(
+            "<!DOCTYPE node>\n<!-- a comment -->\n<?vendor data?>\n" + TEN_FOLD_ENTITIES_FOUR_LEVELS
+        )
+    }
+
+    /**
+     * Why the root element may end the scan when the first doctype's `>` may not: the parser does
+     * not apply a declaration that follows the root element, so there is nothing left to refuse
+     * once the root is reached. This is the parser behaviour [parseIntrospectionXml] relies on.
+     */
+    @Test
+    fun entityDeclaredAfterTheRootElement_isNotHonouredByTheParser() {
+        val failure = parseWithin(
+            """
+            <node>
+              <interface name="org.example.Late">
+                <method name="Get">
+                  <annotation name="org.gtk.GDBus.DocString" value="&a;"/>
+                </method>
+              </interface>
+            </node>
+            <!DOCTYPE node [ <!ENTITY a "&a;"> ]>
+            """
+        ) ?: fail("expected the entity reference to fail, but the document parsed")
+        assertTrue(
+            failure.message.orEmpty().contains("Unknown entity"),
+            "expected the parser not to honour the late declaration, got: ${failure.message}"
+        )
+    }
+
     @Test
     fun documentBehindAByteOrderMark_stillParses() {
         val xml = BOM + """
@@ -89,25 +142,35 @@ class CodegenHostileXmlTest {
     /**
      * The prolog scan decides whether a document may declare entities, so what it does with a
      * prolog it cannot read is the whole question: assuming such a document safe is how the byte
-     * order mark got past it.
+     * order mark got past it. Each shape below is one the scan does not model, and none of them may
+     * be waved through on the grounds that no `<!DOCTYPE` was recognised.
      */
     @Test
     fun prologTheScanCannotRead_isRefusedRatherThanAssumedToDeclareNothing() {
-        val failure = parseWithin("stray text <node/>")
-            ?: fail("expected the unreadable prolog to be refused, but the document parsed")
-        assertTrue(
-            failure.message.orEmpty().contains("prolog"),
-            "expected the failure to say the prolog could not be read, got: ${failure.message}"
+        val unreadablePrologs = mapOf(
+            "text before the root element" to "stray text ",
+            "a space inside the declaration name" to """<! DOCTYPE node [ <!ENTITY a "x"> ]>""",
+            "a lower-case declaration name" to """<!doctype node [ <!ENTITY a "x"> ]>""",
+            "a CDATA section, which a prolog cannot contain" to "<![CDATA[ <!DOCTYPE node [ ]]>",
+            "a second byte order mark" to BOM + BOM,
+            "the bytes of a UTF-16 byte order mark read as UTF-8" to "\uFFFE"
         )
+
+        for ((shape, prolog) in unreadablePrologs) {
+            val failure = parseWithin(prolog + "<node/>")
+                ?: fail("expected $shape to be refused, but the document parsed")
+            assertTrue(
+                failure.message.orEmpty().contains("prolog"),
+                "expected $shape to say the prolog could not be read, got: ${failure.message}"
+            )
+        }
     }
 
     /** The doctype a real `dbus-daemon` puts on every `Introspect` reply. */
     @Test
     fun externalDoctypeOfARealIntrospectReply_stillParses() {
-        val xml = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-             "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+        val xml = REAL_INTROSPECT_DOCTYPE + "\n" + """
+            <?vendor data?>
             <!-- a comment mentioning <!DOCTYPE node [ to prove only the prolog is scanned -->
             <node>
               <interface name="org.example.Real">
@@ -187,6 +250,13 @@ class CodegenHostileXmlTest {
 
         /** Spelled out rather than written literally, since the character itself is invisible. */
         private const val BOM = "\uFEFF"
+
+        /** What a real `dbus-daemon` puts in front of every `Introspect` reply, and nothing else. */
+        private val REAL_INTROSPECT_DOCTYPE = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+             "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+        """.trimIndent()
 
         private val TEN_FOLD_ENTITIES_FOUR_LEVELS = """
             <!DOCTYPE node [

--- a/codegen/src/test/kotlin/GoldenFixture.kt
+++ b/codegen/src/test/kotlin/GoldenFixture.kt
@@ -24,7 +24,6 @@ package com.monkopedia.sdbus
 
 import com.squareup.kotlinpoet.FileSpec
 import java.io.File
-import kotlinx.serialization.decodeFromString
 
 /**
  * The three sets of golden files each fixture directory under `codegen/src/test/resources` holds,
@@ -40,9 +39,7 @@ internal enum class GoldenFixture(val prefix: String, private val generator: () 
     PROXY("proxy", ::ProxyGenerator);
 
     fun generate(testRoot: File): List<FileSpec> {
-        val xml = introspectionXml.decodeFromString<XmlRootNode>(
-            File(testRoot, "test.xml").readText()
-        )
+        val xml = parseIntrospectionXml(File(testRoot, "test.xml").readText())
         return generator().transformXmlToFile(xml).sortedBy { it.name }
     }
 

--- a/codegen/src/test/kotlin/TestXmlSupport.kt
+++ b/codegen/src/test/kotlin/TestXmlSupport.kt
@@ -1,7 +1,5 @@
 package com.monkopedia.sdbus
 
-import kotlinx.serialization.decodeFromString
-
 internal object TestXmlSupport {
-    fun parse(text: String): XmlRootNode = introspectionXml.decodeFromString(text.trimIndent())
+    fun parse(text: String): XmlRootNode = parseIntrospectionXml(text.trimIndent())
 }


### PR DESCRIPTION
Fixes #194

`:codegen` turns introspection XML supplied by the service being introspected into Kotlin, and the Gradle plugin does that **inside a consumer's build** (`SdbusGenerationTask` calls `Xml2Kotlin().main(...)` in-process). Two inputs therefore cost build availability rather than failing: the parse never came back, or the recursion ran off the stack.

## What the parser actually did by default — the question #194 left open

The issue's verification comment flagged the 10 MB figure as `UNRESOLVED-NEEDS-BUILD`, on the grounds that a JDK default (`jdk.xml.entityExpansionLimit` = 64,000) might bound expansion without appearing in `XmlFormat.kt`. **It does not, and here is why: there is no JAXP on this path.** `xmlutil` 1.0.1's `core-jvm` jar contains no StAX bridge at all — the JVM reader is xmlutil's own `KtXmlReader` (`xmlStreaming.newReader("<node/>")` returns `nl.adaptivity.xmlutil.core.KtXmlReader`), a pure-Kotlin parser with its own `EntityMap`, so no `jdk.xml.*` property applies. Measured, one document per level:

| entity nesting levels | input | decoded attribute value | time |
|---|---|---|---|
| 2 | 233 B | 100 chars | 1 ms |
| 4 | 327 B | 10,000 chars | 2 ms |
| 6 | 421 B | 1,000,000 chars | 30 ms |

Exactly ten-fold per level, no knee, no limit — so the issue's 10 MB figure at seven levels is confirmed, and it keeps going. An entity that references itself is worse: 130 bytes that **never terminate** (still running at a watchdog; the reader re-injects the entity into its own replacement text through `InjectingInOutBuffer`, which has no depth counter). And `<arg type="aaa…s">` overflows the stack at 5,000 array codes (1,000 was fine).

**Where the exposure is narrower than filed**, all measured rather than assumed:

- **External entities really are rejected**, as the issue said — `<!ENTITY xxe SYSTEM "file:///etc/hostname">` fails with `XmlException: Unexpected content in document type declaration: '>'`. So this is availability only; there is no file-disclosure path to fix here.
- **There is no configuration knob to reach for.** `KtXmlReader.expandEntities` defaults to `false`, but that governs only whether entity references surface as `ENTITY_REF` events in *content* — attribute values call `pushEntity(true)` unconditionally, and the issue's own vector is an attribute (`<annotation value="&g;"/>`). Setting it would have looked like a fix and changed nothing.
- **Item 4 of the issue (hostile names → uncompilable output) is not fixed here** — see "Not in scope" below.

## The fix

**Refuse a DTD internal subset** (`XmlFormat.kt`). It is the only route to a declared entity, introspection XML has no legitimate use for one, and what a real `dbus-daemon` puts on an `Introspect` reply is the *external* `introspect.dtd` doctype, which still parses. That covers the whole expansion class — ten-fold nesting, quadratic blowup and self-reference alike — without inventing a threshold for something no real input does.

Deciding that means reading the prolog, and the scan that does it has been through two rounds of review, each of which found it passing something it should have refused:

1. It gave up on the first character it did not recognise, and `U+FEFF` is not whitespace — so a byte order mark, which `File.readText()` keeps and the parser accepts, walked the whole document past the check. **The bail is now inverted: a prolog the scan cannot read as far as the root element is refused**, not assumed to declare nothing. That closed a second member of the family nobody had found (`U+0085`, which `Char.isWhitespace()` is false for and the parser treats as ignorable).
2. It stopped at the *first* doctype's `>`, so **a second `<!DOCTYPE` later in the prolog was never looked at — and the parser honours it.** Two doctypes is not well-formed XML, but `KtXmlReader` declares the second one's entities anyway, so the expansion class came back in full behind the exact external doctype every real service sends. The doctype helper now reports where the declaration ends instead of deciding the answer, the loop continues past it, and `null` — go ahead — can only come from the root-element branch. That is what the KDoc already claimed; the code now matches it.

**Hold signatures to the D-Bus specification's own 255-character maximum** (`NamingManager.kt`). This is the same choice as #190/#204 — use the specification's number so it is a conformance check rather than an invented threshold, and `dbus-daemon` enforces the same one on every message it relays. It also makes the recursion bounded *structurally* rather than adding a depth counter beside it: every level of `buildType` consumes at least one character of the signature, so a signature within the limit cannot nest deeper than 255, which is comfortably inside the stack (measured: 1,000 levels resolve fine). The recursive calls go to a private `buildValidatedType`, since they descend into suffixes of an already-validated signature and re-checking would only re-assert the same fact.

Parsing now goes through one entry point, `parseIntrospectionXml`, so the golden fixtures and the shipped CLI are held to the same limit — `GoldenFixture`, `TestXmlSupport` and `Xml2Kotlin` all call it.

## What the guard covers, and what it does not

Stated plainly, because a parser guard that reads as a guarantee is worse than none.

**Covered, each measured on this branch:**

- An internal subset anywhere in the prolog: first thing in the document, behind an XML declaration, behind a byte order mark, behind comments and processing instructions, and behind one or more earlier doctypes — including the external `introspect.dtd` doctype a real `dbus-daemon` sends.
- Anything the scan cannot read to the root element is **refused rather than passed on**: leading text, `<!` with a space or a lower-case name, a CDATA section in the prolog, a second byte order mark, UTF-16 byte order mark bytes read as UTF-8, an unterminated comment, processing instruction or doctype. These are already-malformed documents the parser would reject; refusing them earlier is what keeps an unmodelled shape from becoming the next bypass.

**Not covered — say so rather than imply otherwise:**

- **This is not a general hardening of xmlutil.** It refuses the one declaration route measured to reach unbounded expansion. Nothing else about the parser is guarded, and I did not audit it.
- **It is not a well-formedness check.** Whatever the scan passes still goes to the parser, which decides.
- **Nothing bounds document size, element count or nesting depth.** I found no amplification there — a document with no entity declarations does work linear in its length — but there is no cap, so a large document is still a large parse.
- **A doctype after the root element is not refused**, because it is not honoured: measured, a declaration following the root is never applied, and an entity referenced inside the root fails with `Unknown entity`. That measurement is what makes the root element a safe place to stop, and it is pinned by a test so a parser change cannot quietly invalidate it.
- **The scan is a hand-rolled reading of the prolog, and I do not claim it is exhaustive.** Two rounds of review each found a shape it got wrong. What can be claimed is that it is now fail-closed by construction, so the next unmodelled shape should land in the refusal branch rather than in the parser — and the suite has a case that fails if that default flips back.
- Item 4 of #194, and the two diagnostics notes in item 3, are untouched — see "Not in scope".

## Red first

Each fix commit is preceded by a tests-only commit that fails against the code as it then stood.

**The second-doctype hole** — the last one open. Tests only at `c8b0a08`, `./gradlew :codegen:test --tests "com.monkopedia.sdbus.CodegenHostileXmlTest"`, verbatim from that commit's JUnit XML: **13 tests, 3 failed**, suite 5.159 s:

```
FAIL  0.011  secondDoctypeBehindACommentAndAProcessingInstruction_isStillRefused()
               expected the entity declaration to be refused, but the document parsed
FAIL  0.004  secondDoctypeBehindARealIntrospectReplyDoctype_isStillRefused()
               expected the entity declaration to be refused, but the document parsed
FAIL  5.004  selfReferentialEntityInASecondDoctype_isStillRefused()
               parse had not finished after 5000ms
PASS  0.002  externalDoctypeOfARealIntrospectReply_stillParses()
PASS  0.002  entityDeclaredAfterTheRootElement_isNotHonouredByTheParser()
PASS  0.001  prologTheScanCannotRead_isRefusedRatherThanAssumedToDeclareNothing()
PASS  0.002  documentBehindAByteOrderMark_stillParses()
   … 6 more passing, including the two signature cases
```

After `fbfca93`, all 13 pass and the self-referential one goes from a 5 s watchdog abort to **0.001 s**:

```
PASS  0.001  secondDoctypeBehindARealIntrospectReplyDoctype_isStillRefused()
PASS  0.001  selfReferentialEntityInASecondDoctype_isStillRefused()
PASS  0.000  secondDoctypeBehindACommentAndAProcessingInstruction_isStillRefused()
PASS  0.002  externalDoctypeOfARealIntrospectReply_stillParses()
PASS  0.002  entityDeclaredAfterTheRootElement_isNotHonouredByTheParser()
PASS  0.003  prologTheScanCannotRead_isRefusedRatherThanAssumedToDeclareNothing()
```

The positive controls are what make that worth something: they pass at the red commit too, so the suite discriminates the defect rather than the input shape. A fix that refused all doctypes, or refused documents with a byte order mark, would fail them.

The two earlier rounds are on the same pattern — `51825cd` (3 of 5 failing, including the 30 s watchdog abort and `StackOverflowError`) before the first fix, and `69ca3fc` (3 of 9 failing, byte order mark and unreadable prolog) before the second. Both are quoted in the review thread.

**The fixtures are deliberately bounded so they cannot take out the job meant to catch them.** The expanding one stops at four levels (10,000 characters, 2 ms) because the levels are a multiplier and the *shape* is what the assertion is about, not the size; and every parse runs on a daemon thread under a 5 s watchdog, so a regression fails the suite in bounded time instead of hanging it. That is what produced the `5.004` line above.

## Verification

Counted from fresh JUnit XML after `find . -type d -name test-results -prune -exec rm -rf {} +`, JDK 21, rebased on `75e0aa5`:

- `./gradlew :codegen:test` — **99 tests, 0 failures, 0 errors, 0 skipped** across 6 suite files (`CodegenHostileXmlTest` 13, `GeneratorTest` 69, `CodegenNamingAndTypeTest` 5, `CodegenParsingEdgeCaseTest` 4, `Xml2KotlinOptionsTest` 7, `CompilationIntegrationTest` 1). Whole `CodegenHostileXmlTest` suite in **0.146 s**, slowest case 0.066 s — nowhere near the watchdog.
- `./gradlew :compile_test:build` — BUILD SUCCESSFUL. It carries no test suites; it is the gate that compiles generated output.
- **No golden moved.** `GeneratorTest` is 69/69 and `git diff origin/main...HEAD -- codegen/src/test/resources` is empty. Valid XML generates exactly what it did before; the change only refuses inputs. The 23 checked-in fixtures are the regression corpus and all of them still parse.
- `./gradlew ktlintCheck apiCheck` — both pass. **No api file moved**: `git diff origin/main...HEAD -- codegen/api plugin/api api` is empty. `parseIntrospectionXml` is `internal`, `buildValidatedType` and the prolog scan are `private`, and the published `buildType(Map, String, String, String)` keeps its exact signature (it is now the validating wrapper). Nothing binary-visible changed on either published artifact.

No D-Bus bus is involved: `:codegen` and `:compile_test` are pure JVM.

## What is now rejected that previously "worked"

A document declaring its own XML entities, a document whose prolog cannot be read to its root element, and a type signature over 255 characters. All previously "worked" in the sense that one hung or exhausted the heap, one was already malformed, and one raised `StackOverflowError`; none is a usable outcome, and no conforming D-Bus service can produce any of them.

## Not in scope

Item 4 of #194 — a name containing a backtick, newline, space or `$` passes into KotlinPoet and yields output that will not compile — is untouched. It is a bounded, immediate, single-task failure with an unhelpful message rather than an availability problem, and fixing it properly means validating names against the D-Bus name grammar, which is a separate change with its own golden-fixture risk. Split out as #249, together with the two diagnostics notes in the issue's item 3 (an empty `name=""` still fails as `NoSuchElementException: Char sequence is empty`, and the plugin's in-process `clikt.main()` still exits the process on a `CliktError`); neither is attacker-triggered.

## Severity, stated honestly

Low-to-medium, availability only, and it needs a developer to point the generator at a hostile or compromised service and build. There is no code execution, file disclosure or arbitrary write here — I probed for the first two and could not reach them. What makes it worth fixing is that the failure mode is a *hang or an OOM in someone else's build*, which is not diagnosable from the outside, and that the entity case is amplification: a couple of hundred bytes of input against unbounded work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
