### PR TITLE
docs: scope Proxy.callMethod's connection-stall claim to the native backend

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Proxy.kt
@@ -91,15 +91,23 @@ interface Proxy : Resource {
      * The call blocks otherwise, waiting for the remote peer to send back a reply or an error,
      * or until the call times out.
      *
-     * While blocking, other concurrent operations (in other threads) on the underlying bus
-     * connection are stalled until the call returns. This is not an issue in vast majority of
-     * (simple, single-threaded) applications. In asynchronous, multi-threaded designs involving
+     * **On the native backend**, other concurrent operations (in other threads) on the underlying
+     * bus connection are stalled while this call blocks. This is not an issue in the vast majority
+     * of (simple, single-threaded) applications. In asynchronous, multi-threaded designs involving
      * shared bus connections, this may be an issue. It is advised to instead use an asynchronous
      * callMethod() function overload, which does not block the bus connection, or do the synchronous
      * call from another Proxy instance created just before the call and then destroyed (which is
      * anyway quite a typical approach in D-Bus implementations). Such proxy instance must have
      * its own bus connection. So-called light-weight proxies (ones created with
      * `runEventLoopThread = false`) are designed for exactly that purpose.
+     *
+     * **On the JVM backend the connection is not stalled:** only the calling thread parks, and the
+     * reader thread keeps dispatching throughout — it must, since it is what completes the pending
+     * reply. The write lock is held for the duration of the codec write and released before the
+     * wait begins. The mitigations above are therefore unnecessary on JVM, though harmless.
+     *
+     * This paragraph was stated unconditionally until #202. It was inherited from sdbus-c++ and
+     * describes that implementation's threading model, not the JVM backend's.
      *
      * The default D-Bus method call timeout is used. See [Connection.methodCallTimeout].
      *
@@ -122,15 +130,23 @@ interface Proxy : Resource {
      * The call blocks otherwise, waiting for the remote peer to send back a reply or an error,
      * or until the call times out.
      *
-     * While blocking, other concurrent operations (in other threads) on the underlying bus
-     * connection are stalled until the call returns. This is not an issue in vast majority of
-     * (simple, single-threaded) applications. In asynchronous, multi-threaded designs involving
+     * **On the native backend**, other concurrent operations (in other threads) on the underlying
+     * bus connection are stalled while this call blocks. This is not an issue in the vast majority
+     * of (simple, single-threaded) applications. In asynchronous, multi-threaded designs involving
      * shared bus connections, this may be an issue. It is advised to instead use an asynchronous
      * callMethod() function overload, which does not block the bus connection, or do the synchronous
      * call from another Proxy instance created just before the call and then destroyed (which is
      * anyway quite a typical approach in D-Bus implementations). Such proxy instance must have
      * its own bus connection. So-called light-weight proxies (ones created with
      * `runEventLoopThread = false`) are designed for exactly that purpose.
+     *
+     * **On the JVM backend the connection is not stalled:** only the calling thread parks, and the
+     * reader thread keeps dispatching throughout — it must, since it is what completes the pending
+     * reply. The write lock is held for the duration of the codec write and released before the
+     * wait begins. The mitigations above are therefore unnecessary on JVM, though harmless.
+     *
+     * This paragraph was stated unconditionally until #202. It was inherited from sdbus-c++ and
+     * describes that implementation's threading model, not the JVM backend's.
      *
      * If timeout is [Duration.ZERO], the default D-Bus method call timeout is used.
      * See [Connection.methodCallTimeout].


### PR DESCRIPTION
Closes the last open item of #202. The other two were handled in #244 (one fixed, one found already fixed by #222 and left alone).

`Proxy.callMethod`'s KDoc asserted **unconditionally** that a blocking call stalls other concurrent operations on the underlying bus connection, and then advised a set of mitigations built on that premise. True on native; **false on JVM**.

The JVM trace, verified during #244's investigation:

- `callBlocking` parks only the **calling** thread.
- The sole `synchronized(writeLock)` is scoped to the codec write and released **before** `future.get()`.
- The reader thread keeps dispatching throughout — it has to, since it is what completes the pending reply.

So the advice to use an async overload, or a throwaway light-weight proxy with its own connection, is unnecessary on JVM. Harmless, but it tells a reader to engineer around a stall that does not happen on their backend.

## Provenance

Inherited from sdbus-c++, where it accurately describes that implementation's threading model, and never re-examined when the JVM backend was written for 0.5.0. **Same provenance as the `MethodInvoker.timeout` KDoc behind #179** — which was the root cause of #178, a busy-spin burning a full core on every native call. This one is the benign direction of that failure: the doc is over-conservative, so the cost is a consumer over-engineering rather than a hang.

## One correction to the issue

#202 cites a single location. **The paragraph appears twice** — both `callMethod` overloads, at `Proxy.kt:94` and `Proxy.kt:125`. Verified with `/usr/bin/grep -n` (2 hits, and 2 for the sibling `The call blocks otherwise` line as a control; 0 remaining after the fix). Both corrected; fixing only the cited one would have left the same false claim on the other overload.

## Verification

`ktlintCheck apiCheck` — BUILD SUCCESSFUL, and `git status --porcelain -- api/` empty afterwards, so no `api/*.api` moved. Note `:klibApiCheck` executes inside that graph, so the native klib ABI is covered too.

**Not run:** any test suite. This is a comment-only change; `git diff --stat` is one file, +22/−6, entirely inside a KDoc block.