### PR TITLE
docs: delete the duplicated UnixFd class KDoc from the native actual so it cannot drift again (follow-up to #248)

### DIFF
--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -162,8 +162,9 @@ expect sealed class Message {
      * `false` deliberately to mean "this reply carries an error" — a different concept from the
      * one this property is named for, sharing the same field. So `if (!isValid) return` discards
      * locally built messages on JVM and keeps them on native. Which of the two definitions this
-     * property should have is unsettled; treat the value as unspecified for anything but native
-     * `msg != null`.
+     * property should have is unsettled — see
+     * [issue #246](https://github.com/Monkopedia/sdbus-kotlin/issues/246) — so treat the value as
+     * unspecified for anything but native's `msg != null`.
      */
     val isValid: Boolean
 

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
@@ -335,8 +335,9 @@ value class Signature(
  * an explicitly provided fd by either duplicating ([UnixFd] primary constructor)
  * or adopting that fd as-is ([UnixFd.adopt]).
  *
- * **Duplicating and closing are backend-dependent on JVM.** The native backend always `dup(2)`s
- * in the primary constructor — throwing if the syscall fails — and always `close(2)`s on release.
+ * **Duplicating and closing are backend-dependent on JVM.** For any valid (non-negative) fd, the
+ * native backend `dup(2)`s in the primary constructor — throwing if the syscall fails — and
+ * `close(2)`s on release; a negative fd is passed through and never closed on either backend.
  * The JVM backend reaches the descriptor through junixsocket's *optional* native support; when
  * that support is absent (no native binary for the platform, or a consumer where the reflective
  * access it needs is denied, e.g. a JPMS-modular application) the primary constructor returns the

--- a/src/nativeMain/kotlin/com/monkopedia/sdbus/UnixFd.kt
+++ b/src/nativeMain/kotlin/com/monkopedia/sdbus/UnixFd.kt
@@ -36,15 +36,11 @@ import platform.posix.close
 import platform.posix.dup
 import platform.posix.errno
 
-/**
- * A representation of the file descriptor D-Bus type that owns
- * the underlying fd, provides access to it, and closes the fd when
- * the UnixFd is released.
- *
- * UnixFd can be default constructed (owning invalid fd), or constructed from
- * an explicitly provided fd by either duplicating ([UnixFd] primary constructor)
- * or adopting that fd as-is ([UnixFd.adopt]).
- */
+// Intentionally carries no class KDoc: with none here, Dokka renders the `expect`
+// declaration's documentation on this actual too (as it already does for the JVM actual, which
+// likewise has none). A second copy of that prose is what drifted in #208 -- the sentence was
+// corrected here and left wrong on the `expect`, which is the declaration published to
+// consumers. One source, so it cannot happen again in either direction.
 @OptIn(ExperimentalNativeApi::class)
 @Serializable(UnixFd.Companion::class)
 actual class UnixFd internal actual constructor(


### PR DESCRIPTION
Follow-up to #248 (merged, `8374897`), closing the three actionable non-blocking notes from its review. **Comment-only**, no executable line changed.

## 1. The native `actual`'s duplicate class KDoc — deleted, not re-synced

#208's defect was *"the correction landed on the `actual` and never reached the `expect`"*. #248 fixed the `expect` — and in doing so made the native `actual`'s copy the stale one, because Dokka renders three platform blocks on the `UnixFd` page and the native `actual` had its own KDoc (`src/nativeMain/.../UnixFd.kt:39-47`), while `common` and `jvm` both show the `expect`'s. So a reader filtering to native got neither the GC-backstop paragraph nor the fd-exhaustion warning. Same drift, roles swapped.

Re-syncing the copy would have set up the next round of it, so the copy is **deleted** instead. With no KDoc on the `actual`, Dokka renders the `expect`'s documentation on the native block — exactly as it already did for the JVM `actual`, which has never had one (`src/jvmMain/.../Types.jvm.kt:19-20`). A short `//` comment in its place says why, so nobody helpfully re-adds it.

**Verified in the rendered output, not assumed:** `build/dokka/sdbus-kotlin/com.monkopedia.sdbus/-unix-fd/index.html` now contains "Nothing closes the fd at scope exit" **3 times** — common, jvm and native — where before it appeared in two blocks and native carried the older sentence alone.

## 2. `isValid`'s open question now has a link

The creds paragraph links #199 so a reader can follow the undecided question; `isValid`'s *"which of the two definitions this property should have is unsettled"* stopped at the word. It now links **#246**, which tracks exactly that.

## 3. "always `dup(2)`s … always `close(2)`s" was overstated

Caught by the reviewer. Native passes a negative fd through unchanged (`UnixFd.kt:99-102`) and only closes for `fd >= 0` (`:56-60`) — same as JVM (`Types.jvm.kt:87,93`). Reworded to scope the claim to valid descriptors and to state the negative-fd behaviour explicitly, since an overstated divergence is as wrong as an understated one.

## Not changed: #248's PR-body framing

The review's other note — that "BUILD SUCCESSFUL … the guard that matters" undersells the measurement, because `:dokkaGeneratePublicationHtml` exits green *with* a broken link, so the **warning list** is the instrument and not the exit code — is a correction to prose in a merged PR body, with nothing in the repo to change. Recording it here so the next person who repeats that check does not read the exit code as link verification. (The reviewer proved the point by breaking `[Resource]` on purpose and watching the build still succeed.)

## Verification

- `./gradlew ktlintCheck apiCheck :dokkaGeneratePublicationHtml` (JDK 21) — **BUILD SUCCESSFUL**; `git status --porcelain` afterwards lists only the three edited sources, so `api/*.api` did not move.
- Dokka emits **8** `Couldn't resolve link` warnings, unchanged from #248 and from `main`: all pre-existing in untouched `jvmMain` (`DBusWireConnection.kt` ×4, `WireDbusBackend.kt` ×4), none naming `Message.kt`, `Types.kt` or `UnixFd.kt`. The new `[issue #246]` link is a plain URL, so it cannot be an unresolved KDoc reference — the count staying at 8 is the check that nothing else broke.
- **Did not run** the test suites. A comment deletion cannot change behaviour; CI covers them.

Refs #208, #246, #248
