### PR TITLE
test(cross): make the wire external suites fail, not skip, where CI guarantees busctl/dbus-monitor

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -53,6 +53,8 @@ jobs:
           # python3-dbusmock powers the independent-peer harness (the Dbusmock* suites). Because
           # this job installs it deliberately, the test step sets DBUSMOCK_REQUIRED so a missing
           # package fails loudly instead of turning the whole foreign-peer layer into no-ops.
+          # `dbus` likewise provides dbus-monitor (via dbus-bin); busctl ships with systemd on
+          # ubuntu-24.04. Both are guaranteed here, hence EXTERNAL_TOOLS_REQUIRED below.
           sudo apt-get install -y libcurl4-openssl-dev libsystemd-dev dbus python3-dbusmock
 
       - name: Run Full Test Suite on x64
@@ -64,6 +66,12 @@ jobs:
           # This job installs python3-dbusmock above, so the harness must fail — not skip — when
           # it cannot start a dbusmock peer.
           DBUSMOCK_REQUIRED: "1"
+          # busctl and dbus-monitor are guaranteed here (see the install step), and the two suites
+          # that drive them — WireServeExternalTest / WireSignalEmissionExternalTest — are the only
+          # proof a JVM-served object is reachable by, and a JVM-emitted signal observable from, a
+          # genuinely external process (#90, #93 phases 4/3b). Without this they would skip and the
+          # job would stay green if either binary vanished from the image (#229).
+          EXTERNAL_TOOLS_REQUIRED: "1"
         run: |
           set -euo pipefail
           X64_SYSTEMD_LIB="$(find "${GITHUB_WORKSPACE}/libs/x86_64" -maxdepth 2 -type d -name lib | head -n 1 || true)"

--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -57,6 +57,14 @@ val reverseInteropEnabled = providers
 // actually configures it — mirroring the gcSoak gate in the root build.
 tasks.named<Test>("jvmTest") {
     filter.excludeTestsMatching("com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest")
+    // EXTERNAL_TOOLS_REQUIRED is read from the test JVM's environment by `requireExternalTool`
+    // (ExternalToolGate.kt), which Gradle's up-to-date check knows nothing about — so without this,
+    // newly setting it would replay the previous, ungated result and the guard would appear to have
+    // been honoured when it never ran (#188, found on DBUSMOCK_REQUIRED, which still has that bug).
+    inputs.property(
+        "EXTERNAL_TOOLS_REQUIRED",
+        providers.environmentVariable("EXTERNAL_TOOLS_REQUIRED")
+    ).optional(true)
 }
 
 // Kotlin/Native's test runner has no runtime-skip primitive, so `DbusmockHarness.skipTest`'s native

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/ExternalToolGate.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/ExternalToolGate.kt
@@ -1,0 +1,59 @@
+/**
+ *
+ * (C) 2024 - 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Project: sdbus-kotlin
+ * Description: High-level D-Bus IPC kotlin library based on sd-bus
+ *
+ * This file is part of sdbus-kotlin.
+ *
+ * sdbus-kotlin is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * sdbus-kotlin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * sdbus-kotlin. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.monkopedia.sdbus.integration
+
+import java.io.File
+import org.junit.AssumptionViolatedException
+
+/**
+ * Environment variable that turns a "the external tool is not on PATH" skip into a hard failure.
+ * Set by the CI job that installs those tools on purpose.
+ *
+ * Same shape, and the same reasoning, as `DBUSMOCK_REQUIRED` in `DbusmockHarness` (#182): the skip
+ * is right on a contributor's box, where `busctl` / `dbus-monitor` may legitimately be absent, and
+ * wrong in a job that guarantees them — there a vanished binary would silently convert the only
+ * out-of-process coverage the repo has into a green `skipped="1"` (#229).
+ */
+internal const val EXTERNAL_TOOLS_REQUIRED_ENV = "EXTERNAL_TOOLS_REQUIRED"
+
+/**
+ * Returns the executable [name] found on `PATH`, or aborts the calling test.
+ *
+ * [capability] completes the sentence "<name> is not on PATH, so …" and should name the coverage
+ * that is lost without the tool.
+ *
+ * @throws AssumptionViolatedException when the tool is absent — JUnit records that as a real
+ *   `<skipped/>`, unlike an early return (#227).
+ * @throws IllegalStateException instead, when [EXTERNAL_TOOLS_REQUIRED_ENV] is set.
+ */
+internal fun requireExternalTool(name: String, capability: String): File {
+    val path = System.getenv("PATH").orEmpty()
+    path.split(File.pathSeparator)
+        .map { File(it, name) }
+        .firstOrNull { it.canExecute() }
+        ?.let { return it }
+
+    val reason = "$name is not on PATH, so $capability."
+    check(System.getenv(EXTERNAL_TOOLS_REQUIRED_ENV) == null) {
+        "$EXTERNAL_TOOLS_REQUIRED_ENV is set but $reason"
+    }
+    throw AssumptionViolatedException(reason)
+}

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireServeExternalTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireServeExternalTest.kt
@@ -30,14 +30,12 @@ import com.monkopedia.sdbus.createBusConnection
 import com.monkopedia.sdbus.createObject
 import com.monkopedia.sdbus.method
 import com.monkopedia.sdbus.prop
-import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
-import org.junit.Assume.assumeTrue
 
 /**
  * Proves an object exported by a JVM sdbus-kotlin service on the OWNED wire backend is reachable by
@@ -52,9 +50,11 @@ import org.junit.Assume.assumeTrue
  *    busctl gets correct results.
  *
  * The owned wire connection is now the only JVM backend (epic #93 phase 6 retired dbus-java), so
- * this always runs. `busctl` is genuinely optional, so its absence is a real skip; a missing
- * session bus is not — every job that runs this wraps the build in `dbus-run-session` — so that
- * FAILS. Neither is an early return, which JUnit records as a pass (issue #227).
+ * this always runs. `busctl` is genuinely optional, so its absence is a real skip — unless
+ * [EXTERNAL_TOOLS_REQUIRED_ENV] is set, as the CI job that guarantees busctl does, because there a
+ * skip would silently delete this coverage (issue #229). A missing session bus is never optional —
+ * every job that runs this wraps the build in `dbus-run-session` — so that FAILS. Neither is an
+ * early return, which JUnit records as a pass (issue #227).
  */
 class WireServeExternalTest {
 
@@ -65,14 +65,10 @@ class WireServeExternalTest {
                 "and hands its address to busctl. Run the suite under " +
                 "`dbus-run-session -- ./gradlew …`."
         }
-        val busctl = findExecutable("busctl")
-        if (busctl == null) {
-            assumeTrue(
-                "busctl is not on PATH, so no external peer can call the served object.",
-                false
-            )
-            return@runBlocking
-        }
+        val busctl = requireExternalTool(
+            "busctl",
+            "no external peer can call the served object"
+        )
 
         val id = Random.nextInt(100_000, 999_999)
         val service = ServiceName("com.monkopedia.sdbus.serve$id")
@@ -221,12 +217,5 @@ class WireServeExternalTest {
             connection.stopEventLoop()
             connection.release()
         }
-    }
-
-    private fun findExecutable(name: String): File? {
-        val path = System.getenv("PATH") ?: return null
-        return path.split(File.pathSeparator)
-            .map { File(it, name) }
-            .firstOrNull { it.canExecute() }
     }
 }

--- a/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireSignalEmissionExternalTest.kt
+++ b/cross_test/src/jvmTest/kotlin/com/monkopedia/sdbus/integration/WireSignalEmissionExternalTest.kt
@@ -35,7 +35,6 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
-import org.junit.Assume.assumeTrue
 
 /**
  * Proves that a signal our object emits actually traverses the BUS and reaches an INDEPENDENT
@@ -49,9 +48,11 @@ import org.junit.Assume.assumeTrue
  *
  * JVM-only (cross_test `jvmTest`) because the owned-connection backend is JVM-only and toggle-gated;
  * the native backend's over-the-wire emission is already covered elsewhere. `dbus-monitor` is
- * genuinely optional, so its absence is a real skip; a missing session bus is not — every job that
- * runs this wraps the build in `dbus-run-session` — so that FAILS. Neither is an early return,
- * which JUnit records as a pass (issue #227).
+ * genuinely optional, so its absence is a real skip — unless [EXTERNAL_TOOLS_REQUIRED_ENV] is set,
+ * as the CI job that guarantees dbus-monitor does, because there a skip would silently delete this
+ * coverage (issue #229). A missing session bus is never optional — every job that runs this wraps
+ * the build in `dbus-run-session` — so that FAILS. Neither is an early return, which JUnit records
+ * as a pass (issue #227).
  */
 class WireSignalEmissionExternalTest {
 
@@ -62,14 +63,10 @@ class WireSignalEmissionExternalTest {
                 "and watches for it with dbus-monitor --session. Run the suite under " +
                 "`dbus-run-session -- ./gradlew …`."
         }
-        val dbusMonitor = findExecutable("dbus-monitor")
-        if (dbusMonitor == null) {
-            assumeTrue(
-                "dbus-monitor is not on PATH, so no external observer can see the signal.",
-                false
-            )
-            return@runBlocking
-        }
+        val dbusMonitor = requireExternalTool(
+            "dbus-monitor",
+            "no external observer can see the signal"
+        )
 
         val id = Random.nextInt(100_000, 999_999)
         val service = ServiceName("com.monkopedia.sdbus.wireemit$id")
@@ -126,12 +123,5 @@ class WireSignalEmissionExternalTest {
             monitor.destroy()
             if (!monitor.waitFor(5, TimeUnit.SECONDS)) monitor.destroyForcibly()
         }
-    }
-
-    private fun findExecutable(name: String): File? {
-        val path = System.getenv("PATH") ?: return null
-        return path.split(File.pathSeparator)
-            .map { File(it, name) }
-            .firstOrNull { it.canExecute() }
     }
 }


### PR DESCRIPTION
Fixes #229.

`#228` converted `WireServeExternalTest` / `WireSignalEmissionExternalTest` from an early return
into an honest `<skipped/>` when `busctl` / `dbus-monitor` is off `PATH`. That is half of what
c5f874c (#182) established. The other half — a `*_REQUIRED` flag set by the CI job that installs
the dependency **on purpose**, so the skip cannot silently delete coverage where the dependency is
guaranteed — was missing. These two suites are the repo's only proof that a JVM-served object is
reachable by a genuinely external process (#90, epic #93 phase 4) and that emission reaches an
out-of-process observer (phase 3b), so a vanished binary would have taken all of it out behind a
green `tests="1" skipped="1"`.

This mirrors c5f874c rather than adding a second mechanism.

## The change (~6 lines of behaviour + a de-duplication)

- **`ExternalToolGate.kt`** — `requireExternalTool(name, capability)`. It also absorbs the
  `findExecutable` helper both suites had copy-pasted, so each call site shrinks from a
  nine-line `if (x == null) { assumeTrue(...); return@runBlocking }` to a three-line call and
  the return type is non-null (no `?:` at the call sites).
  - `EXTERNAL_TOOLS_REQUIRED` unset → `AssumptionViolatedException` — byte-for-byte the same skip
    message #228 shipped.
  - set → `IllegalStateException` naming the missing binary.
- **`full-tests-x64`** sets `EXTERNAL_TOOLS_REQUIRED: "1"` next to the existing
  `DBUSMOCK_REQUIRED: "1"`, with the reason in a comment.
- **`:cross_test:jvmTest` declares the variable as a task input** — see the #188 section.

## Are the binaries actually on the runner?

This is the one thing the issue says cannot be checked locally, so it is answered by measurement,
not assumption: **`ubuntu-24.04` provides both.** `dbus-monitor` comes from `dbus-bin`, pulled in by
the `dbus` package this job already installs; `busctl` ships with systemd. The proof is this PR's own
`full-tests-x64` run: with the flag set an absent binary is a hard failure, so a green run *is* the
statement that both were present and both suites really exercised an external peer — which is also
the observability gap #229 complained about (the job only uploads test-results on failure, so
"present and ran" and "absent and skipped" used to look identical from outside).

## Evidence — all three directions

Whole `:cross_test:jvmTest`, fresh JUnit XML each time, run under `dbus-run-session`. "absent" =
`PATH` pointed at a mirror of `/usr/bin` with `busctl` and `dbus-monitor` removed.

**1. Flag set + binaries absent → FAILS.** (`BUILD FAILED`)

```
<testsuite name="WireServeExternalTest[jvm]"          tests="1" skipped="0" failures="1" errors="0" time="0.002"
  <failure message="java.lang.IllegalStateException: EXTERNAL_TOOLS_REQUIRED is set but busctl is not on PATH, so no external peer can call the served object."
<testsuite name="WireSignalEmissionExternalTest[jvm]" tests="1" skipped="0" failures="1" errors="0" time="0.001"
  <failure message="java.lang.IllegalStateException: EXTERNAL_TOOLS_REQUIRED is set but dbus-monitor is not on PATH, so no external observer can see the signal."
```

**2. Flag unset + binaries absent → still an honest `<skipped/>`.** (`BUILD SUCCESSFUL`)

```
<testsuite name="WireServeExternalTest[jvm]"          tests="1" skipped="1" failures="0" errors="0" time="0.001"
  <skipped message="org.junit.AssumptionViolatedException: busctl is not on PATH, so no external peer can call the served object."
<testsuite name="WireSignalEmissionExternalTest[jvm]" tests="1" skipped="1" failures="0" errors="0" time="0.001"
  <skipped message="org.junit.AssumptionViolatedException: dbus-monitor is not on PATH, so no external observer can see the signal."
```

**3. Flag set + binaries present → green, and really ran.** (`BUILD SUCCESSFUL`)

```
<testsuite name="WireServeExternalTest[jvm]"          tests="1" skipped="0" failures="0" errors="0" time="0.045"
  <testcase name="externalBusctl_reachesServedObject[jvm]" time="0.045"/>
<testsuite name="WireSignalEmissionExternalTest[jvm]" tests="1" skipped="0" failures="0" errors="0" time="0.26"
  <testcase name="emittedSignal_reachesExternalDbusMonitor[jvm]" time="0.26"/>
```

`ktlintCheck apiCheck`: `BUILD SUCCESSFUL`. **`api/*.api` does not move** — the change is entirely
inside `cross_test`'s test source set and the workflow.

## #188: the flag is a declared Gradle input, and the bug is shown red-first

#188 records that `DBUSMOCK_REQUIRED` is read at runtime but **not** declared as a task input, so
toggling it can replay a stale `UP-TO-DATE` result. `EXTERNAL_TOOLS_REQUIRED` would have inherited
that exactly, so it is declared:

```kotlin
inputs.property(
    "EXTERNAL_TOOLS_REQUIRED",
    providers.environmentVariable("EXTERNAL_TOOLS_REQUIRED")
).optional(true)
```

Measured, as two pairs of runs differing **only** in the environment variable, with nothing deleted
in between:

| | undeclared (`DBUSMOCK_REQUIRED`'s shape today) | declared (this PR) |
|---|---|---|
| run 1, flag unset | `> Task :cross_test:jvmTest` → `skipped="1"` | `> Task :cross_test:jvmTest` → `skipped="1"` |
| run 2, flag set | `> Task :cross_test:jvmTest UP-TO-DATE`, **BUILD SUCCESSFUL**, XML byte-identical (same mtime, same `timestamp=`) | `> Task :cross_test:jvmTest FAILED`, **BUILD FAILED**, fresh XML `failures="1"` |

So without the declaration the guard silently does nothing on a warm build; with it, it fires. This
PR fixes the instance it introduces and does **not** close #188 — `DBUSMOCK_REQUIRED`,
`DBUSMOCK_PYTHON` and `kdbus.crossRuntimeInterop.reverse.enabled` are still undeclared and #188 asks
for them to be handled together.

## Scope notes

- **Nothing native.** Both suites are `jvmTest`-only (the owned wire connection is the JVM backend),
  so this does not touch the "native cannot emit `<skipped/>`" problem #240/#242 established — there
  is no native half here to be inconsistent with.
- **Shared workflow file touched:** `.github/workflows/arm-build-test.yaml`, two comment blocks and
  one `env:` entry in `full-tests-x64`. Rebased on `75e0aa5`, after #223 and #238.
- Contributor laptops without the variable behave exactly as they do on `main` today.
