### PR TITLE
fix(jvm): honour Message.complete on isAtEnd/copyTo/rewind, and stop copying the header in copyTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,21 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   (`busctl`, d-feet, other language bindings), which previously described a fire-and-forget method
   as ordinary request/reply. The JVM backend still does not serve this annotation; that is part of
   #193. (#197)
+- **`Message.isAtEnd`, `Message.copyTo` and `Message.rewind` now honor their `complete` parameter on
+  the JVM backend, and `copyTo` no longer replaces the destination's header.** All three JVM actuals
+  ignored the flag, so they returned a silently wrong answer rather than an error: `isAtEnd(true)`
+  reported `true` with a variant still entered, `rewind(false)` inside a variant rewound to the start
+  of the body and dropped the container, and `copyTo` copied the whole payload from index 0 whatever
+  the flag said. `copyTo` additionally assigned the source's metadata onto the destination —
+  interface, member, path, sender, destination and sender credentials — making it a copy of identity
+  rather than of contents; native's `sd_bus_message_copy` moves body data only. The JVM behavior now
+  matches sd-bus: `copyTo` takes values from the read cursor and consumes them, one complete value
+  when `complete` is `false` and the rest of the open container when it is `true`, and `complete` is
+  honored against the variant stack (the only container the JVM payload model keeps open — arrays,
+  structs and dict entries are flat there). `MessageApiParityCommonTest` now pins all three on both
+  backends; native already satisfied every assertion unchanged. The `@param complete` KDoc on
+  `copyTo` was also wrong about *both* backends — it described `true` as copying "the whole message"
+  — and has been corrected. (#246)
 
 ## [1.0.1] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,18 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   structs and dict entries are flat there). `MessageApiParityCommonTest` now pins all three on both
   backends; native already satisfied every assertion unchanged. The `@param complete` KDoc on
   `copyTo` was also wrong about *both* backends — it described `true` as copying "the whole message"
-  — and has been corrected. (#246)
+  — and has been corrected. The consumer-visible consequence runs through public `Variant`: because
+  `Variant.deserializeFrom` is built on `copyTo`, a second `deserializeFrom` from the same source
+  message used to re-read the first value on JVM and never advanced the source; it now reads the
+  next value and consumes it, which is what native always did. (#246)
+- **A `Variant` is no longer left unusable by a `get` of the wrong type on the JVM backend.** Native
+  validates the contained signature in `sd_bus_message_enter_container`, so a mismatched extraction
+  never enters and leaves the variant untouched; the JVM backend enters first and only detects the
+  mismatch while decoding, so the failed `get` left the variant entered and every later `get`,
+  `peekValueType` and `containsValueOfType` on it failed — the last two being the inspection path
+  the `Variant` documentation recommends. `Variant.get` now unwinds the container when extraction
+  throws. This was previously masked on JVM by `rewind`'s ignored `complete` parameter, so it
+  surfaced only once that was fixed. (#246)
 
 ## [1.0.1] - 2026-07-15
 

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -163,7 +163,7 @@ expect sealed class Message {
      * one this property is named for, sharing the same field. So `if (!isValid) return` discards
      * locally built messages on JVM and keeps them on native. Which of the two definitions this
      * property should have is unsettled — see
-     * [issue #246](https://github.com/Monkopedia/sdbus-kotlin/issues/246) — so treat the value as
+     * [issue #256](https://github.com/Monkopedia/sdbus-kotlin/issues/256) — so treat the value as
      * unspecified for anything but native's `msg != null`.
      */
     val isValid: Boolean
@@ -174,9 +174,10 @@ expect sealed class Message {
     /**
      * Whether the read cursor has reached the end of the message body.
      *
-     * The JVM backend keeps only a variant on its container stack — arrays, structs and dict
-     * entries are flat in its payload model — so inside any other container it answers about the
-     * message body rather than about that container.
+     * **`complete = false` does not stop at the end of the current container on JVM**, inside a
+     * variant included: that backend answers whether the cursor has consumed the flat body, so
+     * with any body value left after the container it reports `false` where native reports `true`.
+     * `complete = true` agrees on both.
      *
      * @param complete When `true`, also requires that any open containers have been exited
      */
@@ -204,9 +205,10 @@ expect sealed class Message {
     /**
      * Resets the read cursor to the start of the message, or of the currently open container.
      *
-     * The JVM backend keeps only a variant on its container stack (see [isAtEnd]), and the cursor
-     * inside an entered variant always addresses that variant's single value, so a non-complete
-     * rewind there has nothing to move.
+     * A variant is the only container the JVM backend keeps on its container stack — arrays,
+     * structs and dict entries are flat in its payload model — and the cursor inside an entered
+     * variant always addresses that variant's single value, so a non-complete rewind there has
+     * nothing to move.
      *
      * @param complete When `true`, rewind past all containers to the very beginning; when `false`,
      *   rewind only the currently open container and leave it open. If no container is open the

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Message.kt
@@ -174,27 +174,27 @@ expect sealed class Message {
     /**
      * Whether the read cursor has reached the end of the message body.
      *
-     * **[complete] is honoured on native only.** The JVM backend ignores it and answers a third
-     * question instead — whether the cursor has consumed the flat payload — with no regard to
-     * container nesting, so `isAtEnd(true)` there can report `true` while containers are still
-     * open, and `isAtEnd(false)` does not stop at the end of the current container.
+     * The JVM backend keeps only a variant on its container stack — arrays, structs and dict
+     * entries are flat in its payload model — so inside any other container it answers about the
+     * message body rather than about that container.
      *
      * @param complete When `true`, also requires that any open containers have been exited
      */
     fun isAtEnd(complete: Boolean): Boolean
 
     /**
-     * Copies the contents of this message into [destination].
+     * Copies body values out of this message into [destination], starting at this message's read
+     * cursor and consuming what it copies.
      *
-     * **[complete] is honoured on native only**, and the JVM backend copies more than the
-     * contents. On JVM the flag is ignored — the whole payload is always copied from the start,
-     * never from the cursor — and the copy additionally overwrites [destination]'s metadata
-     * (interface, member, path, sender, destination, validity flag and sender credentials) with
-     * this message's. Native's `sd_bus_message_copy` moves body data only and leaves the
-     * destination's header alone.
+     * Only body data moves: [destination] keeps its own header — interface, member, path, sender,
+     * destination and sender credentials — so this copies contents, not identity.
      *
      * @param destination Message to copy into
-     * @param complete When `true`, copy the whole message; otherwise copy from the current cursor
+     * @param complete When `true`, copy every value remaining in the currently open container;
+     *   when `false`, copy exactly one complete value (a basic value, or a whole container).
+     *   (This corrects the parameter description published up to and including 1.0.1, which said
+     *   `true` copies "the whole message" and `false` copies "from the current cursor"; both
+     *   branches copy from the cursor, and neither backend ever rewound first.)
      */
     fun copyTo(destination: Message, complete: Boolean)
 
@@ -202,14 +202,15 @@ expect sealed class Message {
     fun seal()
 
     /**
-     * Resets the read cursor to the start of the message.
+     * Resets the read cursor to the start of the message, or of the currently open container.
      *
-     * **[complete] is honoured on native only.** The JVM backend ignores it and always rewinds to
-     * the very beginning of the body, so `rewind(false)` inside a container does not return the
-     * cursor to the start of that container — it returns it to the start of the message, and the
-     * next read yields a value from there rather than failing.
+     * The JVM backend keeps only a variant on its container stack (see [isAtEnd]), and the cursor
+     * inside an entered variant always addresses that variant's single value, so a non-complete
+     * rewind there has nothing to move.
      *
-     * @param complete When `true`, rewind past all containers to the very beginning
+     * @param complete When `true`, rewind past all containers to the very beginning; when `false`,
+     *   rewind only the currently open container and leave it open. If no container is open the
+     *   two are equivalent.
      */
     fun rewind(complete: Boolean)
 

--- a/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
+++ b/src/commonMain/kotlin/com/monkopedia/sdbus/Types.kt
@@ -120,8 +120,18 @@ class Variant constructor() {
         msg.rewind(false)
 
         msg.enterVariant(signature.value)
-        @Suppress("UNCHECKED_CAST")
-        val v: T = msg.deserialize(type, module)
+        val v: T = try {
+            msg.deserialize(type, module)
+        } catch (e: Throwable) {
+            // Leave the variant readable after a failed extraction. Native's enter validates the
+            // contained signature before entering, so a mismatched get never gets this far; the
+            // JVM backend has already consumed the value by the time decoding rejects it, and
+            // without this unwind the variant stays entered and every later get, peekValueType
+            // and containsValueOfType on it fails. The exit is best-effort because it can itself
+            // fail on a partially read container, and it must not replace the real error.
+            runCatching { msg.exitVariant() }
+            throw e
+        }
         msg.exitVariant()
         return v
     }

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/MessageApiParityCommonTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/MessageApiParityCommonTest.kt
@@ -2,6 +2,7 @@ package com.monkopedia.sdbus
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MessageApiParityCommonTest {
@@ -38,6 +39,87 @@ class MessageApiParityCommonTest {
         message.exitDictEntry()
         message.exitContainer()
         assertTrue(message.isAtEnd(false))
+    }
+
+    // The three tests below pin the meaning of the `complete` flag, which no test distinguished on
+    // either backend before #246. A variant is the container they use because it is the only
+    // container both backends track as open while it is entered.
+    @Test
+    fun copyTo_copiesOneValueWhenNotComplete_andTheRemainderWhenComplete() {
+        val source = createPlainMessage()
+        source.append(1)
+        source.append(2)
+        source.append(3)
+        source.seal()
+
+        val single = createPlainMessage()
+        source.copyTo(single, false)
+        single.seal()
+        assertEquals(1, single.readInt())
+        assertTrue(
+            single.isAtEnd(true),
+            "copyTo(complete = false) must copy exactly one value, not the whole body"
+        )
+
+        val remainder = createPlainMessage()
+        source.copyTo(remainder, true)
+        remainder.seal()
+        assertEquals(
+            2,
+            remainder.readInt(),
+            "copyTo must copy from the read cursor, so the value already copied is not repeated"
+        )
+        assertEquals(3, remainder.readInt())
+        assertTrue(remainder.isAtEnd(true))
+    }
+
+    @Test
+    fun isAtEnd_withCompleteTrue_isFalseWhileAContainerIsStillOpen() {
+        val message = createPlainMessage()
+        message.openVariant("i")
+        message.append(42)
+        message.closeVariant()
+        message.seal()
+
+        message.enterVariant("i")
+        assertEquals(42, message.deserialize<Int>())
+
+        assertTrue(
+            message.isAtEnd(false),
+            "the open variant has been read out, so isAtEnd(complete = false) is true"
+        )
+        assertFalse(
+            message.isAtEnd(true),
+            "isAtEnd(complete = true) must be false while a container is still open"
+        )
+
+        message.exitVariant()
+        assertTrue(message.isAtEnd(true))
+    }
+
+    @Test
+    fun rewind_withCompleteFalse_rewindsTheOpenContainerNotTheMessage() {
+        val message = createPlainMessage()
+        message.append(7)
+        message.openVariant("i")
+        message.append(42)
+        message.closeVariant()
+        message.seal()
+
+        assertEquals(7, message.readInt())
+        message.enterVariant("i")
+        assertEquals(42, message.deserialize<Int>())
+
+        message.rewind(false)
+        assertEquals(
+            42,
+            message.deserialize<Int>(),
+            "rewind(complete = false) must rewind the open container, not the whole message"
+        )
+
+        message.exitVariant()
+        message.rewind(true)
+        assertEquals(7, message.readInt())
     }
 
     @Test

--- a/src/commonTest/kotlin/com/monkopedia/sdbus/unit/TypesCommonTest.kt
+++ b/src/commonTest/kotlin/com/monkopedia/sdbus/unit/TypesCommonTest.kt
@@ -8,6 +8,7 @@ import com.monkopedia.sdbus.containsValueOfType
 import com.monkopedia.sdbus.createPlainMessage
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -90,6 +91,25 @@ class TypesCommonTest {
         )
         val variant = Variant(value)
         assertTrue(variant.containsValueOfType<TypeWithVariants>())
+    }
+
+    // A failed extraction must not consume the variant. Native gets this from
+    // sd_bus_message_enter_container, which validates the contained signature before it enters, so
+    // a mismatched get leaves the message untouched. The JVM backend enters first and only detects
+    // the mismatch while decoding, so it has to unwind (#246).
+    @Test
+    fun aVariant_RemainsReadableAfterAGetOfTheWrongType() {
+        val variant = Variant("a string")
+
+        assertFailsWith<SdbusException> { variant.get<Int>() }
+
+        assertEquals(
+            "a string",
+            variant.get<String>(),
+            "a failed extraction must leave the variant readable"
+        )
+        assertEquals("s", variant.peekValueType())
+        assertTrue(variant.containsValueOfType<String>())
     }
 
     @Test

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt
@@ -183,15 +183,33 @@ actual sealed class Message {
         get() = metadata.valid
     actual val isEmpty: Boolean
         get() = payload.isEmpty()
-    actual fun isAtEnd(complete: Boolean): Boolean = readIndex >= payload.size
+
+    // The only container this payload model keeps open is an entered variant: arrays, structs and
+    // dict entries are flattened, so their enter/exit calls are no-ops. `complete` is therefore
+    // honoured against the variant stack, which is the whole of "any open containers" here.
+    actual fun isAtEnd(complete: Boolean): Boolean =
+        readIndex >= payload.size && (!complete || enteredVariantValues.isEmpty())
     actual fun copyTo(destination: Message, complete: Boolean) {
-        destination.payload.addAll(payload)
-        destination.metadata = metadata
+        // sd_bus_message_copy semantics: copy from the read cursor, consuming what is copied --
+        // one complete value when `complete` is false, everything left when it is true -- and move
+        // body data only, never the destination's header.
+        if (readIndex >= payload.size) return
+        val end = if (complete) payload.size else readIndex + 1
+        val values = payload.subList(readIndex, end).toList()
+        readIndex = end
+        destination.payload.addAll(values)
     }
     actual fun seal(): Unit = Unit
     actual fun rewind(complete: Boolean): Unit = run {
-        readIndex = 0
-        enteredVariantValues.clear()
+        if (complete) {
+            readIndex = 0
+            enteredVariantValues.clear()
+        } else if (enteredVariantValues.isEmpty()) {
+            readIndex = 0
+        }
+        // Inside an entered variant the cursor always addresses that variant's single value, so
+        // rewinding the currently open container has nothing to move -- and must not disturb the
+        // outer cursor or pop the container, which is what sd_bus_message_rewind(m, false) does.
     }
     actual val credsPid: Int
         get() = requireJvmCredential(metadata.credsPid, "Message.credsPid")

--- a/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
+++ b/src/jvmTest/kotlin/com/monkopedia/sdbus/JvmMessageSupportTest.kt
@@ -138,6 +138,37 @@ class JvmMessageSupportTest {
         }
     }
 
+    // #246: copyTo moves body data only. The destination's header is its identity, and native's
+    // sd_bus_message_copy never touches it. Asserted here rather than in commonTest because the
+    // common surface offers no way to build a header-bearing message without a bus.
+    @Test
+    fun copyTo_leavesTheDestinationHeaderAlone() {
+        val source = createPlainMessage()
+        source.append(42)
+        source.seal()
+
+        val destination = MethodCall().also {
+            it.metadata = Message.Metadata(
+                interfaceName = "org.example.Copy",
+                memberName = "Target",
+                path = "/org/example/copy",
+                valid = true,
+                empty = true
+            )
+        }
+
+        source.copyTo(destination, true)
+
+        assertEquals(
+            InterfaceName("org.example.Copy"),
+            destination.interfaceName,
+            "copyTo must copy contents, not identity: the destination keeps its own header"
+        )
+        assertEquals(MemberName("Target"), destination.memberName)
+        assertEquals(ObjectPath("/org/example/copy"), destination.objectPath)
+        assertEquals(42, destination.readInt())
+    }
+
     @Test
     fun credentialAccessors_doNotUseUnsupportedOperationExceptions() {
         val message = createPlainMessage()


### PR DESCRIPTION
Three of #246's four items. The fourth (`isValid`) is split to #256 — reasoning below.

## What changed

`src/jvmMain/kotlin/com/monkopedia/sdbus/Message.jvm.kt` — three actuals, ~15 lines.

| | before | after |
|---|---|---|
| `isAtEnd(complete)` | `readIndex >= payload.size`, flag unread | `… && (!complete \|\| enteredVariantValues.isEmpty())` |
| `copyTo(dst, complete)` | whole payload from index 0, plus `dst.metadata = metadata` | from the read cursor, consuming it: one value when `complete` is `false`, the rest when `true`; header untouched |
| `rewind(complete)` | always `readIndex = 0` + clear the variant stack | `complete` does that; `!complete` rewinds the open container only, which inside an entered variant has nothing to move |

An entered variant is the whole of "any open containers" on JVM — the payload model flattens arrays, structs and dict entries, so their enter/exit actuals are already no-ops. That is stated in the code and in the KDoc rather than left for the next reader to rediscover.

## The `complete` semantics are sd-bus's, re-measured — and the old KDoc was wrong about native too

`sd_bus_message_copy(3)`: *"If `all` is false, a single complete type is copied (basic or container). If `all` is true, the contents are copied until the end of the currently open container or the end of source."* Both branches copy **from the cursor** and consume.

The `@param complete` on `copyTo` said `true` copies *"the whole message"* and `false` copies *"from the current cursor"* — i.e. it was wrong about **both** backends, and #248 corrected the surrounding prose without touching that line. Corrected here, with a note saying what it used to claim (the #221 style). `sd_bus_message_at_end(3)` and `sd_bus_message_rewind(3)` confirm the other two; those `@param`s were already right.

Corroboration from the repo itself: `MessageCommonTest.aMessage_CreatesDeepCopyWhenExplicitlyCopied` has to call `msg.rewind(true)` after `copyTo(…, true)` before it can read `msg` again — a test that only makes sense if the copy consumes.

## PR #248's KDoc

#248 (`8374897`) documented all four items as divergences in `commonMain`. Leaving those paragraphs in place while changing the behaviour would ship a newly-false doc — the exact defect #179/#178/#202 have been removing — so the `isAtEnd`, `copyTo` and `rewind` divergence notes are **deleted** and replaced with the now-true contract. **#248's `isValid` paragraph is deliberately left alone**: it still describes the code exactly, because that item is not fixed here.

Verified against the rendered output, not just the source: `grep -c "honoured on native only"` over `build/dokka/…/-message/{copy-to,rewind,is-at-end}.html` returns **0, 0, 0**, and the three replacement sentences return **1, 1, 1**. `:dokkaGeneratePublicationHtml` — BUILD SUCCESSFUL, 8 `Couldn't resolve link` warnings, all pre-existing in untouched `jvmMain` files (`DBusWireConnection.kt` ×4, `WireDbusBackend.kt` ×4), none naming `Message.kt`.

## Evidence — red first, on both backends

The three common cases assert one contract and run on both backends. **Native passed all three unmodified**, so they encode sd-bus's behaviour rather than the JVM's answer written down.

`MessageApiParityCommonTest` (commonTest), from the JUnit XML of a run with the fix reverted:

| case | JVM before | native before |
|---|---|---|
| `copyTo_copiesOneValueWhenNotComplete_andTheRemainderWhenComplete` | FAILED — `copyTo(complete = false) must copy exactly one value, not the whole body` | passed |
| `isAtEnd_withCompleteTrue_isFalseWhileAContainerIsStillOpen` | FAILED — `isAtEnd(complete = true) must be false while a container is still open` | passed |
| `rewind_withCompleteFalse_rewindsTheOpenContainerNotTheMessage` | FAILED — `rewind(complete = false) must rewind the open container, not the whole message expected:<42> but was:<7>` | passed |

`JvmMessageSupportTest.copyTo_leavesTheDestinationHeaderAlone` — FAILED: `copyTo must copy contents, not identity: the destination keeps its own header expected:<org.example.Copy> but was:<null>`. This one is JVM-only on purpose: the common surface has no way to build a header-bearing message without a bus, and native's `sd_bus_message_copy` is body-only by construction. Said plainly rather than dressed up as cross-backend.

Red run, counted from fresh XML: `:jvmTest` **340 tests, 4 failed**. Green run: `:jvmTest` **tests=340 failures=0 errors=0 skipped=0**, `:linuxX64Test` **tests=309 failures=0 errors=0 skipped=0** — same 340, so nothing was dropped to get there.

**No `TestBackendCapabilities` flag added or changed.** Both backends assert the identical contract and both are green, so there is nothing for a flag to encode; adding one would record a divergence that no longer exists. (#230's citation rule and #216's unflipped-flag rule therefore do not bite — no flag moved.)

## `isValid` split to #256

`isValid` is the one item that is a public behaviour change with **live** internal readers. Aligning it with native means making it unconditionally `true` on JVM and repointing the two guards that actually want the other concept — `Message.jvm.kt:447` and `WireDbusBackend.kt:487`, both `if (!result.reply.isValid) throw "invalid reply"`. Flip `isValid` without repointing them and both guards silently become no-ops, so `WireDbusBackend.invalidReply` stops being detectable: a live regression, not a latent one. `WireDbusBackend.kt` was under concurrent edit (#247) while this was in flight.

#256 also corrects a detail #246 got slightly wrong: `Message.jvm.kt:446` rethrows an error reply *before* the `isValid` check on the next line, so `createErrorReply`'s `valid = false` never reaches that guard — the real dependent is `invalidReply`, whose meaning is "no reply was produced", not "an error reply".

## Stale / out-of-scope items

- **Every `file:line` in #246 verified against `main`** — `Message.jvm.kt:186-195`, `:189`, `:182-183`, `:40`, `:447`, `:471-474`, `:533-535`, `Message.native.kt:586-587`, `:591-609`, `MessageApiParityCommonTest.kt:40`. **None stale.**
- #246's claim that `Message.append(Variant)` is dead on JVM is correct, but the wider claim that it is the only route into `copyTo` is **not**: `Variant.serializeTo` / `Variant.deserializeFrom` (`Types.kt:144,153`) are common code and live on JVM via `WireDbusBackend.variantToPayload`, `WireDbusBackend.wireVariant` and `JvmValueCodec.slotVariant`. Checked each: all three pass a throwaway `createPlainMessage()` holding exactly one value with default metadata, so the old "copy everything + copy the header" and the new "copy one value from the cursor" coincide there — which is why the whole `:jvmTest` suite is green.
- `PeekedType.type` returning `null` for non-end cases is in **#248's** table but is **not** one of #246's four items, so it is untouched. #248's KDoc for it remains accurate.

## Gates

`./gradlew ktlintCheck apiCheck` — BUILD SUCCESSFUL. **`api/*.api` does not move**: `git status --porcelain` after the run lists only the five edited files. No public signature changes — `isAtEnd`/`copyTo`/`rewind` keep their declarations, only their behaviour and KDoc change.

**Breaking-change assessment: not breaking, but observable.** No API or ABI change. The behaviour change replaces silently wrong answers with correct ones on paths where nothing can have been relying on the old result beneficially — `copyTo` now consumes and no longer clobbers the destination header, `rewind(false)` no longer escapes its container, `isAtEnd(true)` no longer reports the end with a variant open. The one shape a consumer could notice is `copyTo` advancing the source cursor; `Variant.serializeTo` (the only in-tree `complete = true` caller) rewinds before every copy, so it is unaffected. CHANGELOG entry added under `[Unreleased] → Fixed`.

Fixes #246
Refs #248, #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
