### PR TITLE
fix(codegen): hold introspection XML to a maximum element nesting depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   three report what they refused. Generated output for valid XML is unchanged. (#194)
 - **Deeply nested introspection XML no longer overflows the stack.** `<node>` elements nest without
   limit and the decoder recurses once per level, so 60KB of `<node>` — no entity declaration, so
-  nothing the limits above cover — aborted the parse with `StackOverflowError` (measured from 385
-  levels on a 256KB stack). Elements are now held to a maximum nesting depth of 64, counted with
+  nothing the limits above cover — aborted the parse with `StackOverflowError` (from 68 levels on a
+  cold 256KB stack). Elements are now held to a maximum nesting depth of 64, counted with
   the parser's own reader before decoding and reported like the other refusals. A real
   `Introspect` reply is `node > interface > method > arg` and the deepest checked-in fixture is 6
   elements, so the limit is an order of magnitude above anything legitimate. (#259)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   255-character maximum, which bounds the recursion by construction. A document whose prolog cannot
   be read as far as its root element is refused too, rather than assumed to declare nothing. All
   three report what they refused. Generated output for valid XML is unchanged. (#194)
+- **Deeply nested introspection XML no longer overflows the stack.** `<node>` elements nest without
+  limit and the decoder recurses once per level, so 60KB of `<node>` — no entity declaration, so
+  nothing the limits above cover — aborted the parse with `StackOverflowError` (measured from 385
+  levels on a 256KB stack). Elements are now held to a maximum nesting depth of 64, counted with
+  the parser's own reader before decoding and reported like the other refusals. A real
+  `Introspect` reply is `node > interface > method > arg` and the deepest checked-in fixture is 6
+  elements, so the limit is an order of magnitude above anything legitimate. (#259)
 
 ### Changed — codegen
 

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -25,6 +25,7 @@ package com.monkopedia.sdbus
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
+import nl.adaptivity.xmlutil.EventType
 import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
 import nl.adaptivity.xmlutil.QName
 import nl.adaptivity.xmlutil.XmlReader
@@ -36,6 +37,7 @@ import nl.adaptivity.xmlutil.serialization.XmlElement
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
 import nl.adaptivity.xmlutil.serialization.XmlValue
 import nl.adaptivity.xmlutil.serialization.structure.XmlDescriptor
+import nl.adaptivity.xmlutil.xmlStreaming
 
 /**
  * The serialization format the [Xml2Kotlin] CLI and the tests share, so the golden fixtures assert
@@ -72,9 +74,18 @@ internal val introspectionXml: XML = XML.compat {
  * availability rather than anything at runtime.
  */
 internal fun parseIntrospectionXml(xml: String): XmlRootNode {
-    prologRefusal(xml)?.let { throw IllegalArgumentException(it) }
+    refusal(xml)?.let { throw IllegalArgumentException(it) }
     return introspectionXml.decodeFromString(xml)
 }
+
+/**
+ * Why [xml] must not be handed to the decoder, or null to go ahead. Both checks read the document
+ * before it is decoded and answer the same way, so what is bounded is one list rather than two
+ * mechanisms: the prolog may not declare entities, and the elements may not nest past
+ * [MAX_NESTING_DEPTH]. The prolog goes first — the nesting scan parses, and parsing is what an
+ * entity declaration makes unbounded.
+ */
+private fun refusal(xml: String): String? = prologRefusal(xml) ?: nestingRefusal(xml)
 
 /**
  * Why [xml]'s prolog must not be handed to the parser, or null to go ahead.
@@ -151,6 +162,32 @@ private fun endOfDoctypeBody(xml: String, start: Int): Int? {
 private fun String.endOf(token: String, from: Int): Int? =
     indexOf(token, from).takeIf { it >= 0 }?.plus(token.length)
 
+/**
+ * Why [xml] nests too deeply to decode, or null to go ahead.
+ *
+ * [XmlRootNode] holds `nodes: List<XmlRootNode>` and the serialization decoder descends a stack
+ * frame or more per level, so element nesting is the one thing that bounds that recursion \u2014 no
+ * other property of the document does. Measured against xmlutil 1.0.1 on JDK 21,
+ * `"<node>".repeat(n)` aborted the decode with `StackOverflowError` from n = 385 on a 256KB stack
+ * and from n = 409 on the default one: 60,000 bytes, no entity declaration anywhere in them, so
+ * nothing [prologRefusal] covers is engaged.
+ *
+ * The depth is counted with the parser's own reader rather than a second hand-rolled reading of the
+ * markup. That is exact, and it does not itself recurse \u2014 the reader keeps an explicit element
+ * stack, so 50,000 levels cost it time and no stack at all. It stops at the first element over the
+ * limit rather than reading to the end, so a document built to be deep is refused in milliseconds.
+ * A document the reader cannot read at all throws here rather than at the decoder, with the
+ * parser's own message; either way it does not reach the decoder.
+ */
+private fun nestingRefusal(xml: String): String? = xmlStreaming.newReader(xml).use { reader ->
+    while (reader.hasNext()) {
+        if (reader.next() == EventType.START_ELEMENT && reader.depth > MAX_NESTING_DEPTH) {
+            return TOO_DEEPLY_NESTED
+        }
+    }
+    null
+}
+
 private const val BYTE_ORDER_MARK = '\uFEFF'
 
 private const val DOCTYPE = "<!DOCTYPE"
@@ -159,6 +196,23 @@ private const val INTERNAL_SUBSET =
     "Introspection XML declares a DTD internal subset (<!DOCTYPE ... [ ... ]>). Introspection " +
         "XML has no use for one, and the entities it can declare are expanded without any limit, " +
         "so the declaration is refused rather than parsed."
+
+/**
+ * How deeply introspection XML may nest its elements. This project's number rather than the
+ * specification's — D-Bus bounds names and signatures but says nothing about introspection nesting
+ * — so it is set where nothing legitimate can reach it: a real `Introspect` reply is
+ * `node > interface > method > arg`, the deepest of the 23 checked-in fixtures is 6 elements, and
+ * a document that assembled a whole BlueZ object tree with its documentation would still be under
+ * 20. That is an order of magnitude of headroom, and the limit is still a factor of six below the
+ * shallowest depth measured to overflow the decoder.
+ */
+private const val MAX_NESTING_DEPTH = 64
+
+private const val TOO_DEEPLY_NESTED =
+    "Introspection XML nests elements deeper than the maximum nesting depth of " +
+        "$MAX_NESTING_DEPTH. The parser recurses once per level and runs out of stack in the low " +
+        "hundreds, while a real introspection reply nests a handful of elements, so the document " +
+        "is refused rather than decoded."
 
 private const val UNREADABLE_PROLOG =
     "The XML prolog of the introspection XML could not be read as far as the root element, so " +

--- a/codegen/src/main/kotlin/XmlFormat.kt
+++ b/codegen/src/main/kotlin/XmlFormat.kt
@@ -166,18 +166,26 @@ private fun String.endOf(token: String, from: Int): Int? =
  * Why [xml] nests too deeply to decode, or null to go ahead.
  *
  * [XmlRootNode] holds `nodes: List<XmlRootNode>` and the serialization decoder descends a stack
- * frame or more per level, so element nesting is the one thing that bounds that recursion \u2014 no
- * other property of the document does. Measured against xmlutil 1.0.1 on JDK 21,
- * `"<node>".repeat(n)` aborted the decode with `StackOverflowError` from n = 385 on a 256KB stack
- * and from n = 409 on the default one: 60,000 bytes, no entity declaration anywhere in them, so
- * nothing [prologRefusal] covers is engaged.
+ * frame or more per level, so element nesting is the one thing that bounds that recursion — no
+ * other property of the document does. `"<node>".repeat(n)` aborts the decode with
+ * `StackOverflowError` at 60,000 bytes with no entity declaration anywhere in it, so nothing
+ * [prologRefusal] covers is engaged.
+ *
+ * The n it does that at is not a fixed depth, and reporting one would be misleading. Measured
+ * against xmlutil 1.0.1 on JDK 21 with a 256KB stack, one thread per attempt: a cold decode
+ * overflowed from 68 levels, a warm one (after 3,000 decodes) only from 545. The cliff tracks how
+ * much of the decoder has been compiled rather than anything about the document, which is why
+ * [MAX_NESTING_DEPTH] is argued from what introspection XML legitimately needs instead.
  *
  * The depth is counted with the parser's own reader rather than a second hand-rolled reading of the
- * markup. That is exact, and it does not itself recurse \u2014 the reader keeps an explicit element
- * stack, so 50,000 levels cost it time and no stack at all. It stops at the first element over the
- * limit rather than reading to the end, so a document built to be deep is refused in milliseconds.
- * A document the reader cannot read at all throws here rather than at the decoder, with the
- * parser's own message; either way it does not reach the decoder.
+ * markup. `introspectionXml` leaves `defaultToGenericParser` false, so this is the same
+ * `xmlStreaming.newReader` call `decodeFromString` goes on to make: the scan is not a model of the
+ * parse, it is the parse — and it has to stay that same call for that to keep holding. It does not
+ * itself recurse, since the reader keeps an explicit element stack, so 50,000 levels cost it time
+ * and no stack at all. It stops at the first element over the limit rather than reading to the end,
+ * so a document built to be deep is refused in milliseconds. A document the reader cannot read at
+ * all throws here rather than at the decoder, with the parser's own message; either way it does not
+ * reach the decoder.
  */
 private fun nestingRefusal(xml: String): String? = xmlStreaming.newReader(xml).use { reader ->
     while (reader.hasNext()) {
@@ -200,11 +208,16 @@ private const val INTERNAL_SUBSET =
 /**
  * How deeply introspection XML may nest its elements. This project's number rather than the
  * specification's — D-Bus bounds names and signatures but says nothing about introspection nesting
- * — so it is set where nothing legitimate can reach it: a real `Introspect` reply is
- * `node > interface > method > arg`, the deepest of the 23 checked-in fixtures is 6 elements, and
- * a document that assembled a whole BlueZ object tree with its documentation would still be under
- * 20. That is an order of magnitude of headroom, and the limit is still a factor of six below the
- * shallowest depth measured to overflow the decoder.
+ * — and it is argued from the legitimate side, because the other side does not hold still: the
+ * depth the decoder overflows at moves with JIT state, from 68 levels to 545 on the same stack
+ * (see [nestingRefusal]), so no constant can be called a safe fraction of it.
+ *
+ * Where legitimate documents sit can be said exactly. A real `Introspect` reply is
+ * `node > interface > method > arg`, the deepest of the 23 checked-in fixtures is 6 elements, and a
+ * document that assembled a whole BlueZ object tree with its documentation would still be under 20.
+ * 64 is an order of magnitude above that, and it decodes reliably — at 64 and at 65, on cold 256KB
+ * threads, zero overflows in five attempts each. Raising it is not free: 128, or 255 for symmetry
+ * with the signature limit, is back inside the range that overflowed cold.
  */
 private const val MAX_NESTING_DEPTH = 64
 

--- a/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
+++ b/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
@@ -216,9 +216,9 @@ class CodegenHostileXmlTest {
     }
 
     /**
-     * One level over, to pin where the limit actually falls. Measured on JDK 21, the decoder
-     * overflowed from 385 levels on a 256KB stack and from 409 on the default one, so the refusal
-     * here is a clean message rather than an `Error` either way.
+     * One level over, to pin where the limit actually falls. The depth the decoder overflows at is
+     * not a fixed one — measured on JDK 21 at a 256KB stack, 68 levels cold and 545 warm — so what
+     * is pinned here is the limit, and the refusal at it is a clean message rather than an `Error`.
      */
     @Test
     fun nestingOneLevelOverTheLimit_isRefused() {

--- a/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
+++ b/codegen/src/test/kotlin/CodegenHostileXmlTest.kt
@@ -204,6 +204,58 @@ class CodegenHostileXmlTest {
         assertEquals(null, namingManagerFailureFor("a".repeat(254) + "s"))
     }
 
+    /**
+     * The shape #259 measured: `<node>` nests without limit and the decoder recurses per level, so
+     * 60,000 bytes with no entity declaration in them aborted the parse with `StackOverflowError`.
+     * The document is bounded because the refusal has to arrive before the decoder is ever handed
+     * it — the scan stops at the first element over the limit rather than reading to the end.
+     */
+    @Test
+    fun nestingDeeperThanTheLimit_isRefusedRatherThanOverflowingTheStack() {
+        assertRefusedAsTooDeeplyNested(nestedNodes(5_000))
+    }
+
+    /**
+     * One level over, to pin where the limit actually falls. Measured on JDK 21, the decoder
+     * overflowed from 385 levels on a 256KB stack and from 409 on the default one, so the refusal
+     * here is a clean message rather than an `Error` either way.
+     */
+    @Test
+    fun nestingOneLevelOverTheLimit_isRefused() {
+        assertRefusedAsTooDeeplyNested(nestedNodes(MAX_NESTING_DEPTH + 1))
+    }
+
+    /**
+     * The control that keeps the two cases above from being satisfied by refusing nesting
+     * generally: a document nested to exactly the limit still parses, all the way down. A real
+     * `Introspect` reply is `node > interface > method > arg` and the deepest of the 23 checked-in
+     * fixtures is 6 elements, so the limit sits an order of magnitude above anything legitimate.
+     */
+    @Test
+    fun nestingAtTheLimit_stillParses() {
+        val xml = nestedNodes(MAX_NESTING_DEPTH)
+
+        assertEquals(null, parseWithin(xml))
+        var node = TestXmlSupport.parse(xml)
+        repeat(MAX_NESTING_DEPTH - 2) { node = node.nodes.single() }
+        assertEquals("org.example.Deep", node.interfaces.single().name)
+    }
+
+    /** A document whose deepest element — the interface at the bottom — sits at [depth]. */
+    private fun nestedNodes(depth: Int): String = "<node>".repeat(depth - 1) +
+        """<interface name="org.example.Deep"/>""" +
+        "</node>".repeat(depth - 1)
+
+    private fun assertRefusedAsTooDeeplyNested(xml: String) {
+        val failure = parseWithin(xml)
+            ?: fail("expected the nesting to be refused, but the document parsed")
+        assertTrue(
+            failure.message.orEmpty().contains("maximum nesting depth of $MAX_NESTING_DEPTH"),
+            "expected the failure to name the limit it hit, got: " +
+                "${failure::class.simpleName}: ${failure.message}"
+        )
+    }
+
     private fun assertRefusedAsInternalSubset(xml: String) {
         val failure = parseWithin(xml)
             ?: fail("expected the entity declaration to be refused, but the document parsed")
@@ -245,6 +297,12 @@ class CodegenHostileXmlTest {
     }
 
     companion object {
+        /**
+         * The parser's limit, spelled out here rather than shared with it: the boundary pair below
+         * is what says where it falls, so moving it has to mean changing this too.
+         */
+        private const val MAX_NESTING_DEPTH = 64
+
         /** Two orders of magnitude over the green path, which answers in under a hundredth. */
         private const val PARSE_TIMEOUT_MS = 5_000L
 


### PR DESCRIPTION
Fixes #259

#250 bounded what hostile introspection XML can make `:codegen` do — entity expansion, prolog abuse, signature recursion — and said plainly in its own "not covered" list that nesting depth was still uncapped. Its reviewer then measured that residual and filed #259: element nesting is unbounded, the serialization decoder recurses once per level, and `XmlRootNode` holds `nodes: List<XmlRootNode>`, so a document of a few thousand nested `<node>` elements — tens of kilobytes, **no entity declaration anywhere in it**, so nothing #250 guards is engaged — aborted the parse with `StackOverflowError`.

This closes it in the same place and the same shape as the existing limits rather than beside them.

## Where the limit actually falls

#259 reported "5,000 overflows, 500 does not". My first bisection put the cliff at 385 levels on a 256KB stack and 409 on the default one — **and that number was wrong**, in the permissive direction. Review re-measured it with a *fresh thread per attempt* rather than reusing a warmed one, on the same machine and JDK:

| 256KB stack | shallowest depth that overflows |
|---|---|
| cold — the decode is the first thing the JVM does | **68** |
| warm — after 3,000 decodes of a 20-deep document | **545** |

So there is no single threshold to be a safe fraction of: **the cliff tracks how much of the decoder has been JIT-compiled, not the document.** 68 → 545 on the same stack, and it is not even monotone in depth (one sweep decoded 400 while 385 and 500 overflowed). My original table was a warm measurement reported as *the* measurement, and the KDoc has been corrected to say the range and why it is a range. Credit to the review for catching it.

That does not change the constant — 64 was measured to decode reliably at 64 and 65 on cold 256KB threads, zero overflows in five attempts each — but it removes the sentence a future maintainer would have read as licence to raise it. 128, or 255 for symmetry with #250's signature limit, is back inside the range that overflowed cold.

## The limit chosen: 64, and its headroom

`MAX_NESTING_DEPTH = 64`, counted as element depth with the root at 1.

- A real `Introspect` reply is `node > interface > method > arg` — 4. With freedesktop `<doc:doc>` markup on an argument it is `node > interface > method > arg > doc > description > para` — 7.
- **The deepest of the 23 checked-in fixtures in `codegen/src/test/resources` is 6.** (Measured across all of them; the distribution is 3–6.)
- The worst legitimate case I can construct is a document assembling a whole BlueZ object tree — `/org/bluez/hci0/dev_XX/serviceNNNN/charNNNN/descNNNN` is 7 path segments, so 7 nested `<node>` plus the 6 element levels of a documented argument — **under 20**.

64 is therefore an order of magnitude above anything legitimate, and that — not any ratio against the overflow depth — is the argument for it. Unlike #250's 255, this is not a specification number: D-Bus bounds names and signatures but says nothing about introspection nesting, so the KDoc on the constant states it as this project's choice, argues it from the side that holds still, and says outright that raising it is not free.

## The mechanism, extended rather than duplicated

`parseIntrospectionXml` already asked one question before decoding — "why must this not be handed to the parser?" — and threw `IllegalArgumentException` with the answer. It now asks the same question of both limits through one `refusal(xml)`, which is `prologRefusal(xml) ?: nestingRefusal(xml)`. One entry point, one throw site, one list of what is bounded. The prolog check stays first because the nesting scan parses, and parsing is exactly what an entity declaration makes unbounded.

`nestingRefusal` counts depth with **the parser's own reader** rather than a second hand-rolled reading of the markup:

- It is exact, and it does not add a second thing that has to understand comments, CDATA and quoted attribute values (the prolog scan's two review rounds are the argument against writing another one). Review established this is stronger than I claimed: `XML.compat` leaves `defaultToGenericParser` false, so `decodeFromString` makes the *identical* `xmlStreaming.newReader(CharSequence, relaxed = false)` call — the scan is not a model of the parse, it **is** the parse, which structurally rules out the whole "the pre-scan reads the markup differently" family. The KDoc now records that the guard has to stay that same call for this to keep holding.
- The reader keeps an explicit element stack — it is iterative, not recursive — so it does not have the defect it is checking for. Measured: it walks 50,000 levels in 651ms without touching the stack.
- **It stops at the first element over the limit**, so a deep document is refused in about a millisecond rather than being read to its end. That is what makes the fixtures below bounded.
- Fail-closed: a document the reader cannot read at all throws at the scan instead of at the decoder, with the parser's own message. Either way it does not reach the decoder.

Cost on legitimate input is one extra streaming pass over a document the size of an `Introspect` reply — the whole 102-test suite runs in the same fractions of a second it did before.

## Red first

Tests-only at `cad14a8`, `./gradlew :codegen:test --tests "com.monkopedia.sdbus.CodegenHostileXmlTest"`, verbatim from that commit's JUnit XML: **16 tests, 2 failed**, suite 0.175s:

```
FAIL  0.010  nestingDeeperThanTheLimit_isRefusedRatherThanOverflowingTheStack()
               expected the failure to name the limit it hit, got: StackOverflowError: null
FAIL  0.011  nestingOneLevelOverTheLimit_isRefused()
               expected the nesting to be refused, but the document parsed
PASS  0.007  nestingAtTheLimit_stillParses()
   … 13 more passing, all of #250's cases
```

The two failures are the two halves of the defect: past the cliff it is an `Error`, and below the cliff there is no limit at all. Note the first one — `StackOverflowError` is an `Error`, so the assertion is on the message naming the limit, which an overflow cannot satisfy; the test cannot pass by catching the crash it is about.

After `1fa5bec`, all 16 pass and the deep case is refused in **0.001s**:

```
PASS  0.001  nestingDeeperThanTheLimit_isRefusedRatherThanOverflowingTheStack()
PASS  0.001  nestingOneLevelOverTheLimit_isRefused()
PASS  0.007  nestingAtTheLimit_stillParses()
```

`nestingAtTheLimit_stillParses` passes at the red commit too, which is what makes the pair worth something — it nests to exactly 64, walks all the way down and asserts the innermost interface decoded, so a "fix" that refused deep nesting generally, or that was off by one, fails it. The fixtures are deliberately bounded: the refusal arrives before the decoder is handed anything, every parse runs on a daemon thread under the suite's existing 5s watchdog, and the deepest document in the suite is 5,000 levels, which is refused without being read past level 65.

## Verification

Counted from fresh JUnit XML after `find . -type d -name test-results -prune -exec rm -rf {} +`, JDK 21, on `1f289ca`:

- `./gradlew :codegen:test` — **102 tests, 0 failures, 0 errors, 0 skipped** across 6 suites (`CodegenHostileXmlTest` 16, `GeneratorTest` 69, `CodegenNamingAndTypeTest` 5, `CodegenParsingEdgeCaseTest` 4, `Xml2KotlinOptionsTest` 7, `CompilationIntegrationTest` 1). 99 → 102 is the three new cases; nothing else moved.
- `./gradlew :compile_test:build` — BUILD SUCCESSFUL. It emits no JUnit XML (it carries no test suites); it is the gate that compiles generated output.
- **No golden moved.** `GeneratorTest` is 69/69 and `git diff origin/main...HEAD -- codegen/src/test/resources` is empty. The 23 fixtures are the regression corpus and every one still parses — none is deeper than 6. Regeneration is left to the `RegenerateGoldens` split from #239 and is untouched.
- `./gradlew ktlintCheck apiCheck` — both pass, and **no api file moved**: `git diff origin/main...HEAD -- codegen/api plugin/api api` is empty. Everything added is `private`; `parseIntrospectionXml` keeps its signature and stays `internal`.

Pure JVM — no D-Bus bus involved.

## What the guard now covers, and what it does not

**Covered:** any document whose elements nest past 64, whatever the element names — the depth is counted over all elements, not just `<node>`, so nesting through unknown or vendor elements is refused on the same terms. The refusal arrives before the decoder, in milliseconds, naming the limit.

**Not covered — stated plainly, in the same spirit as #250's list, which is why this issue existed to fix:**

- **Nothing bounds document size, element count, attribute count or text length.** Breadth is linear — #259 measured 20,000 sibling interfaces decoding in 119ms — so there is no amplification there, but a large document is still a large parse, and it is now scanned twice.
- **The limit is on element nesting, not on "recursion" in general.** Signature recursion is bounded separately by the 255-character check from #250. If a future model field introduces another recursive descent that is not driven by element depth, this does not cover it.
- **This is not a hardening of xmlutil.** It bounds one measured path; the parser is otherwise unaudited.
- **Legitimate documents deeper than 64 would now be refused.** I could not construct one — the deepest real shape I know of is under 20 — but the number is a judgement call, not a specification, and it is a single constant with the reasoning next to it.
- **The limit is not a proof that an accepted document decodes.** The overflow depth moves with JIT state, so no constant can be shown to clear it structurally the way #250's 255 bounds signature recursion. What is claimed is that hostile depth is refused promptly and legibly, and that 64 decodes reliably at the worst state measured — not that the decoder has been made non-recursive.
- Item 4 of #194 (hostile names producing uncompilable output) is untouched and remains tracked in #249.

## Severity, stated honestly

Low, availability only, and it needs a developer to point the generator at a hostile or compromised service and build. The pre-fix failure was already bounded and immediate — one aborted task in milliseconds, no hang, no heap exhaustion, the Gradle daemon survives. What is worth fixing is that `StackOverflowError` is an unhelpful, undiagnosable way for someone else's build to fail, and that leaving the sibling of an already-fixed recursion path open is the kind of gap that gets rediscovered rather than remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRxpvcbYLsgYeaNsSd5SqQ
