### PR TITLE
build(cross): declare DBUSMOCK_REQUIRED / DBUSMOCK_PYTHON as test-task inputs so toggling a guard re-runs it

### DIFF
--- a/cross_test/build.gradle.kts
+++ b/cross_test/build.gradle.kts
@@ -51,20 +51,23 @@ val reverseInteropEnabled = providers
     .systemProperty("kdbus.crossRuntimeInterop.reverse.enabled")
     .orElse(providers.gradleProperty("kdbus.crossRuntimeInterop.reverse.enabled"))
 
+// A test task's system properties are an `@Input` to Gradle, but its *environment* is `@Internal`
+// — so a variable the test process reads at runtime is invisible to up-to-date checking, and newly
+// setting one replays the previous result: the guard reports as honoured having never run (#188).
+// Declaring it here is what makes toggling it re-run the tests it gates.
+fun Task.declareEnvironmentInputs(vararg names: String) = names.forEach { name ->
+    inputs.property(name, providers.environmentVariable(name)).optional(true)
+}
+
 // CrossRuntimeInteropSmokeTest only does anything under `jvmInteropTest` below, which is the task
 // that selects it and hands it a linked native test binary. Keep it out of the plain `jvmTest`
 // task (which `allTests` runs on every CI job) so it is reported exactly once, by the task that
 // actually configures it — mirroring the gcSoak gate in the root build.
 tasks.named<Test>("jvmTest") {
     filter.excludeTestsMatching("com.monkopedia.sdbus.integration.CrossRuntimeInteropSmokeTest")
-    // EXTERNAL_TOOLS_REQUIRED is read from the test JVM's environment by `requireExternalTool`
-    // (ExternalToolGate.kt), which Gradle's up-to-date check knows nothing about — so without this,
-    // newly setting it would replay the previous, ungated result and the guard would appear to have
-    // been honoured when it never ran (#188, found on DBUSMOCK_REQUIRED, which still has that bug).
-    inputs.property(
-        "EXTERNAL_TOOLS_REQUIRED",
-        providers.environmentVariable("EXTERNAL_TOOLS_REQUIRED")
-    ).optional(true)
+    // EXTERNAL_TOOLS_REQUIRED gates `requireExternalTool` (ExternalToolGate.kt); DBUSMOCK_REQUIRED
+    // and DBUSMOCK_PYTHON gate `launchDbusmock` (DbusmockHarness.jvm.kt).
+    declareEnvironmentInputs("EXTERNAL_TOOLS_REQUIRED", "DBUSMOCK_REQUIRED", "DBUSMOCK_PYTHON")
 }
 
 // Kotlin/Native's test runner has no runtime-skip primitive, so `DbusmockHarness.skipTest`'s native
@@ -89,6 +92,13 @@ tasks.named<Test>("jvmTest") {
 //    reports passes that asserted nothing.
 //  * If the class names below drift, the exclusions silently stop matching. Gradle's filter API
 //    offers no "this exclusion matched nothing" signal to guard that with.
+//
+// These two are read twice over: here at configuration time, and again by the test binary itself at
+// runtime. The configuration-time read needs nothing extra — its only effect is `filter`, which is a
+// task input, so a flip in `dbusmockCanRun()` invalidates `linuxX64Test` on its own. The runtime read
+// is what `declareEnvironmentInputs` below covers: a change that leaves the filter alone (a
+// different interpreter, or the required flag flipping while dbusmock is installed either way) would
+// otherwise replay the previous result (#188).
 val dbusmockRequired = providers.environmentVariable("DBUSMOCK_REQUIRED").isPresent
 val dbusmockPython = providers.environmentVariable("DBUSMOCK_PYTHON").getOrElse("python3")
 val sessionBusPresent = providers.environmentVariable("DBUS_SESSION_BUS_ADDRESS").isPresent
@@ -113,6 +123,7 @@ tasks.named<AbstractTestTask>("linuxX64Test") {
     // that as a pass. They are covered where they are actually driven: `jvmInteropTest`, which now
     // fails unless the spawned peer really ran its case and reported it passing (#183).
     filter.excludeTestsMatching("com.monkopedia.sdbus.integration.NativeInteropPeerTest")
+    declareEnvironmentInputs("DBUSMOCK_REQUIRED", "DBUSMOCK_PYTHON")
     if (!dbusmockCanRun()) {
         logger.lifecycle(
             "cross_test: excluding the Dbusmock* suites from linuxX64Test — '$dbusmockPython -m " +


### PR DESCRIPTION
Fixes #188.

#255 declared the one variable it introduced (`EXTERNAL_TOOLS_REQUIRED`) and said so plainly —
*"Reproduced, and worked around (**not fixed**)"* — but GitHub's `closingIssuesReferences` resolved
to #188 as well and closed this on merge. It has been reopened. This PR finishes the other three
items, and answers the configuration-time wrinkle #255's author flagged.

## Why this keeps `Fixes` — the four items, each with the run that settles it

#188 was auto-closed once already on a partial fix, so the closing keyword is deliberate and
itemised rather than assumed. Each row names the runs below that establish it.

| #188 item | state | evidence |
|---|---|---|
| `EXTERNAL_TOOLS_REQUIRED` | declared in #255; re-expressed through the shared helper here, no behaviour change | #255's own A/B |
| `DBUSMOCK_REQUIRED` | **fixed here** — declared on `:cross_test:jvmTest` *and* `:cross_test:linuxX64Test` | § 1, § 3 |
| `DBUSMOCK_PYTHON` | **fixed here** — same two tasks | § 2, § 3 |
| `kdbus.crossRuntimeInterop.reverse.enabled` | **already correct in both modules — no change needed, and none made** | § "reverse-interop" |
| the configuration-time read in `dbusmockCanRun()` | **already correct; measured, not assumed** — and the half it genuinely cannot cover is what § 3 fixes | § "configuration-time" |

Two points worth stating outright, because both look like gaps from the diff alone:

- **`stress_test/build.gradle.kts` is byte-identical to `origin/main` in this PR, and that is the
  finding, not an omission.** The reverse-interop property is wired in *both* modules
  (`cross_test/build.gradle.kts:51`, `stress_test/build.gradle.kts:45`) and this PR changes it in
  **neither**, because `:cross_test:jvmInteropTest` and `:stress_test:jvmInteropStressTest` were
  *each* measured on pristine `1f289ca` and *each* already re-run when the property changes. Adding
  `inputs.property` for it would be a second, redundant declaration of a value Gradle already hashes.
  Both modules are covered in the reverse-interop section below; neither is half-handled.
- **The configuration-time read has exactly one consumer, and it is already a task input.** Verified
  rather than argued: `dbusmockRequired` and `sessionBusPresent` are read only inside
  `dbusmockCanRun()`; `dbusmockPython` is read there and in the text of the `logger.lifecycle` line;
  and `dbusmockCanRun()` has a single call site, whose only effect is
  `filter.excludeTestsMatching(…)` on `linuxX64Test`. The section below shows that flip invalidating
  the task **on unmodified `main`, with no declaration present**.

Nothing from #188 is deferred to a follow-up. What this PR deliberately does *not* do is listed at
the bottom, and none of it is a #188 item.

## The change

```kotlin
fun Task.declareEnvironmentInputs(vararg names: String) = names.forEach { name ->
    inputs.property(name, providers.environmentVariable(name)).optional(true)
}
```

- `:cross_test:jvmTest` — `EXTERNAL_TOOLS_REQUIRED` (already there, now via the helper),
  `DBUSMOCK_REQUIRED`, `DBUSMOCK_PYTHON`.
- `:cross_test:linuxX64Test` — `DBUSMOCK_REQUIRED`, `DBUSMOCK_PYTHON`. The native binary reads both
  from its environment exactly as the JVM one does, and that task had the bug too.

Why an environment variable needs this and a system property does not, from the Gradle 9.6.1
distribution rather than from memory: `JavaForkOptions.getSystemProperties()` carries
`@org.gradle.api.tasks.Input`, while `Test.getEnvironment()` carries `@org.gradle.api.tasks.Internal`.

## Evidence

Every number below is from a fresh JUnit XML written by the run it is quoted under. Each pair is two
consecutive invocations differing **only** in the variable, with **nothing deleted in between**
(deleting `build/test-results` invalidates the output dir and hides the effect); the first of a pair
carries `--rerun` purely to force it to execute, the second never does. All runs are
`--no-daemon`, under `dbus-run-session`, JDK 21, on `1f289ca` (baseline) and on this branch (fixed),
holding the fleet build slot. `DBUSMOCK_PYTHON` is pointed either at a
`venv --system-site-packages` with `python-dbusmock` 0.38.1 installed, or at `/usr/bin/python3`,
which has no `dbusmock` module.

### 1. `DBUSMOCK_REQUIRED` on `:cross_test:jvmTest`

`--tests com.monkopedia.sdbus.integration.DbusmockSmokeTest`, interpreter fixed at `/usr/bin/python3`
(no dbusmock), so run 2 *must* fail: the flag's whole job is to turn "no peer" into a hard failure.

| | baseline (`1f289ca`) | this branch |
|---|---|---|
| run 1, flag unset | `> Task :cross_test:jvmTest` | `> Task :cross_test:jvmTest` |
| | `skipped="1" failures="0" timestamp="2026-08-10T04:38:23.062Z"` md5 `bf01bde22b5e2717ad183a88fce7159d` | `skipped="1" failures="0" timestamp="2026-08-10T04:46:19.801Z"` md5 `bf05d317eb35726b946b0c016026d087` |
| run 2, `DBUSMOCK_REQUIRED=1` | `> Task :cross_test:jvmTest UP-TO-DATE`, **BUILD SUCCESSFUL** | `> Task :cross_test:jvmTest FAILED`, **BUILD FAILED** |
| | XML byte-identical — md5 `bf01bde2…`, same `timestamp="…T04:38:23.062Z"`, same mtime | fresh XML: `skipped="0" failures="1" timestamp="2026-08-10T04:46:26.529Z"` md5 `9aa608a56f5619a70658d1f8d8b0bb86` |

### 2. `DBUSMOCK_PYTHON` on `:cross_test:jvmTest`

`DBUSMOCK_REQUIRED=1` in both runs; only the interpreter moves, venv (has dbusmock) → `/usr/bin/python3`
(does not). Run 2 must fail.

| | baseline | this branch |
|---|---|---|
| run 1, venv interpreter | `> Task :cross_test:jvmTest`, real pass: `skipped="0" failures="0" time="0.685"` md5 `f2be011abc891f9775f9c9bc3f0319d9` | `> Task :cross_test:jvmTest`, `skipped="0" failures="0" time="0.641"` md5 `6ea581fbcae3c3de4518f69f18499d5f` |
| run 2, `/usr/bin/python3` | `> Task :cross_test:jvmTest UP-TO-DATE`, **BUILD SUCCESSFUL**, md5 `f2be011a…` unchanged, same `timestamp="…T04:38:36.872Z"` | `> Task :cross_test:jvmTest FAILED`, **BUILD FAILED**, `failures="1" timestamp="2026-08-10T04:46:40.417Z"` md5 `b74c1cdca387b6b3a84f612a3b850499` |

### 3. Both variables on `:cross_test:linuxX64Test`

Same defect, same fix. `--tests …EventLoopStartIdempotencyTest --tests …DbusmockSmokeTest`
(a suite that always runs, plus the gated one).

`DBUSMOCK_PYTHON`, `DBUSMOCK_REQUIRED=1` throughout — the case the configuration-time filter cannot see
(§ below), because `dbusmockCanRun()` returns `true` either way and the filter is identical:

| | baseline | this branch |
|---|---|---|
| run 1, venv interpreter | `> Task :cross_test:linuxX64Test`, `skipped="0" failures="0"` md5 `4504654fc47c91ff441209282eb5a644` `timestamp="2026-08-10T04:41:08.818Z"` | `> Task :cross_test:linuxX64Test`, `failures="0"` md5 `47d9c2f86c1e133c2cdb6adb5a813f88` |
| run 2, `/usr/bin/python3` | `> Task :cross_test:linuxX64Test UP-TO-DATE`, **BUILD SUCCESSFUL**, md5 `4504654f…` and `timestamp="…T04:41:08.818Z"` unchanged | `> Task :cross_test:linuxX64Test FAILED`, **BUILD FAILED**, `failures="1" timestamp="2026-08-10T04:47:07.127Z"` md5 `2d106f01ed0af54f94a8b477cf2f55eb` |

## The configuration-time read — what it affects, and why it needs nothing further

`DBUSMOCK_REQUIRED` / `DBUSMOCK_PYTHON` are also read at configuration time by `dbusmockCanRun()`.
Its **only** effect is whether `filter.excludeTestsMatching("…Dbusmock*")` is added to
`linuxX64Test` — there is no other consumer (the other use of `dbusmockPython` is the text of the
`logger.lifecycle` line). And `AbstractTestTask.getFilter()` is `@Nested`, with
`DefaultTestFilter.getExcludePatterns()` `@Input`, so a flip in `dbusmockCanRun()` invalidates the
task **by itself**.

Measured on **unmodified `1f289ca`**, `DBUSMOCK_PYTHON=/usr/bin/python3` in both runs:

- run 1, flag unset → `cross_test: excluding the Dbusmock* suites from linuxX64Test …`,
  `> Task :cross_test:linuxX64Test`, **BUILD SUCCESSFUL**, only
  `EventLoopStartIdempotencyTest` in the results (`timestamp="2026-08-10T04:40:55.087Z"`).
- run 2, `DBUSMOCK_REQUIRED=1` → the exclusion is gone, the task **re-runs with no input declaration
  present**: `DbusmockSmokeTest.callsMethodAndReadsPropertyOnDbusmockPeer[linuxX64] FAILED`,
  `> Task :cross_test:linuxX64Test FAILED`, **BUILD FAILED**,
  `tests="1" skipped="0" failures="1" timestamp="2026-08-10T04:41:01.644Z"`.

So the configuration-time half was never the stale one; what it cannot see is any change that leaves
the filter alone — which is exactly case 3 above, and exactly what the new declarations close. Both
halves are now covered, and the comment above `dbusmockCanRun()` says which is which so the next
reader does not add a redundant second mechanism. (No configuration cache is enabled in this repo —
`gradle.properties` does not set it — so the configuration-time read is re-evaluated every
invocation; that is the regime measured here.)

## The reverse-interop system property was already declared — measured, not assumed

`kdbus.crossRuntimeInterop.reverse.enabled` reaches the test JVM through
`systemProperty(…)` on `:cross_test:jvmInteropTest` **and** `:stress_test:jvmInteropStressTest`, and a
`Test` task's system properties **are** an `@Input`. **Both** tasks were checked — this is the one
variable that lives in two modules, so neither module is taken on the other's word. The third run of
each rules out the alternative explanation "this task simply never goes up to date":

`:cross_test:jvmInteropTest`

| run | command | result |
|---|---|---|
| 1 | (no `-D`) `--rerun` | executed — `tests="14" skipped="7"` md5 `bbf54b17f00d07275eaad1868c85af25` `timestamp="2026-08-10T04:43:21.134Z"` |
| 2 | `-Dkdbus.crossRuntimeInterop.reverse.enabled=true` | **executed** (not `UP-TO-DATE`) — `tests="14" skipped="1"` md5 `0e62130d22fb1d28441b68a6041f7f4f` `timestamp="2026-08-10T04:43:29.574Z"` |
| 3 | identical to run 2 | `UP-TO-DATE` — XML unchanged, md5 `0e62130d…`, same `timestamp` |

`:stress_test:jvmInteropStressTest` (`-Dkdbus.stress.repeat=1` held constant; its reverse cases
early-`return` rather than skip, so the count stays at 10 and the duration is what moves)

| run | command | result |
|---|---|---|
| 1 | `--rerun` | executed — `tests="10" time="6.865"` md5 `1a8ace37f9edaaa71e9054e9ca54c223` `timestamp="2026-08-10T04:47:41.519Z"` |
| 2 | `+ -D…reverse.enabled=true` | **executed** — `tests="10" time="12.705"` md5 `8f55a887e5a8b4c123e6de3f22c26986` `timestamp="2026-08-10T04:47:55.149Z"` |
| 3 | identical to run 2 | `UP-TO-DATE` — md5 `8f55a887…` and `timestamp` unchanged |

Provenance, since this PR is about stale results and the stress rows deserve it spelled out: the
`:stress_test:jvmInteropStressTest` **task lines** (`executed` / `executed` / `UP-TO-DATE`) were
first observed on **pristine `1f289ca`** with a clean tree, in a run whose XML capture was broken by
a bug in my harness; the **md5 / timestamp** figures above come from a repeat on this branch, where
`stress_test/build.gradle.kts` and `:stress_test:jvmInteropStressTest`'s inputs are byte-identical to
`origin/main`. Both runs agree on the conclusion, and the conclusion does not depend on the branch.

So there is nothing to fix there, and `stress_test/build.gradle.kts` is untouched by this PR. Adding
an `inputs.property` for it would be a second, redundant declaration of a value Gradle already
hashes.

## A declaration that never invalidates is the same bug — and so is one that always does

Same environment twice, on this branch, nothing deleted:

- `:cross_test:jvmTest` — run 1 executed (md5 `c8e4aea70d2a8115fbbd2046f7fb771f`,
  `timestamp="2026-08-10T04:47:13.966Z"`), run 2 `UP-TO-DATE` with that XML untouched.
- `:cross_test:linuxX64Test` — run 1 executed (md5 `544babe308b89b8f937dd06f91a39929`,
  `timestamp="2026-08-10T04:47:28.635Z"`), run 2 `UP-TO-DATE`, unchanged.

`.optional(true)` is what keeps the unset case a legitimate input value rather than a configuration
failure, so a contributor who sets none of these still gets normal up-to-date behaviour.

## Gates

`./gradlew ktlintCheck apiCheck` — `BUILD SUCCESSFUL`. **`api/*.api` does not move**; the diff is one
build script.

## Not addressed, deliberately

- `ExternalToolGate` resolves `busctl` / `dbus-monitor` against `PATH`, which is likewise untracked.
  Declaring `PATH` as a task input would invalidate these tasks on almost any environment change, so
  it would trade a rare false green for constant churn. Out of scope for #188, which is about the
  guard flags.
- CI is unaffected either way: `full-tests-x64` runs on a fresh checkout with no prior task outputs,
  so there was never anything stale for it to replay. This closes the local-development hole and the
  latent one that a shared or persistent Gradle cache would open.
