### PR TITLE
build(docs): fail the Dokka build on unresolved KDoc links, and fix the 8

### DIFF
--- a/.github/workflows/arm-build-test.yaml
+++ b/.github/workflows/arm-build-test.yaml
@@ -33,6 +33,14 @@ jobs:
       - name: ktlint + binary-compatibility check
         run: ./gradlew ktlintCheck apiCheck --stacktrace
 
+      # #254: the docs build is what publishes to github.io (pages.yaml), but it only ran there —
+      # after a release — so an unresolved KDoc link had no consumer on the PR that introduced it.
+      # Dokka is configured with failOnWarning (see build.gradle.kts), so this step goes red on any
+      # unresolved link; it lives in this job because it needs no D-Bus session bus and nothing
+      # beyond the headers installed above.
+      - name: KDoc link check (Dokka)
+        run: ./gradlew :dokkaGeneratePublicationHtml --stacktrace
+
   full-tests-x64:
     runs-on: ubuntu-24.04
     timeout-minutes: 90

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,6 +257,13 @@ val dokkaLogoStyleSheet = rootProject.file("dokka/styles/logo-styles.css")
 dokka {
     dokkaPublications.named("html") {
         outputDirectory.set(projectDir.resolve("build/dokka"))
+        // #254: Dokka only *prints* `Couldn't resolve link: [...]`, so the docs build used to exit
+        // BUILD SUCCESSFUL with dead KDoc links and pages.yaml published them anyway — the only
+        // thing between a broken link and github.io was somebody counting warnings by hand.
+        // failOnWarning makes the expected count zero rather than a baseline someone edits upward,
+        // and asserting it in the build (not in a workflow) means a local run of this task fails
+        // exactly the way CI does.
+        failOnWarning.set(true)
     }
     dokkaSourceSets.configureEach {
         includes.from(rootProject.file("dokka/moduledoc.md"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -263,6 +263,13 @@ dokka {
         // failOnWarning makes the expected count zero rather than a baseline someone edits upward,
         // and asserting it in the build (not in a workflow) means a local run of this task fails
         // exactly the way CI does.
+        //
+        // Deliberately broader than "unresolved links": it fails on ANY Dokka warning. Measured at
+        // 20dcae6 that is a distinction without a difference — every warning this task emitted was
+        // an unresolved link (8 of 8) — and the broad gate needs no log parsing, so unlike a grep
+        // for `Couldn't resolve link` it cannot be defeated by Dokka rewording that message. If a
+        // future Dokka emits some new warning category, fix it or suppress that category; turning
+        // this flag back off restores the #254 defect wholesale.
         failOnWarning.set(true)
     }
     dokkaSourceSets.configureEach {

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/DBusWireConnection.kt
@@ -708,13 +708,14 @@ internal class DBusWireConnection private constructor(
  * to [bound] after a nested-dispatch storm subsides.
  *
  * SCOPE of same-thread compensation: [beginNestedBlock] only covers a worker that blocks *on its own
- * thread* inside [call]/[callBlocking]. A serve handler that instead (a) offloads its nested
- * same-connection call to a DIFFERENT thread/dispatcher (e.g. `withContext(Dispatchers.IO) {
- * connection.call(...) }`) while keeping the worker parked, or (b) blocks the worker on a
- * non-same-connection dependency (a shared lock, or a result that only ANOTHER served call on this
- * connection can produce), runs off the marked worker thread, so [beginNestedBlock] returns false and
- * no fast-path compensation fires. Handlers SHOULD still do nested same-connection calls synchronously
- * on the worker thread; that remains the cheap, exact path.
+ * thread* inside [DBusWireConnection.call]/[DBusWireConnection.callBlocking]. A serve handler that
+ * instead (a) offloads its nested same-connection call to a DIFFERENT thread/dispatcher (e.g.
+ * `withContext(Dispatchers.IO) { connection.call(...) }`) while keeping the worker parked, or (b)
+ * blocks the worker on a non-same-connection dependency (a shared lock, or a result that only
+ * ANOTHER served call on this connection can produce), runs off the marked worker thread, so
+ * [beginNestedBlock] returns false and no fast-path compensation fires. Handlers SHOULD still do
+ * nested same-connection calls synchronously on the worker thread; that remains the cheap, exact
+ * path.
  *
  * WATCHDOG backstop for the cases same-thread compensation misses (issue #101 follow-up). A single
  * daemon thread periodically samples forward progress: if the queue is non-empty AND no task has

--- a/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
+++ b/src/jvmMain/kotlin/com/monkopedia/sdbus/internal/jvmdbus/WireDbusBackend.kt
@@ -47,9 +47,9 @@ import kotlin.time.Duration
  *   processes AND same-JVM connections alike;
  * - signal RECEPTION is correspondingly wire-only: every subscriber (whether listening to an
  *   external peer or to one of our own objects) registers `AddMatch` + a reader filter via
- *   [installSignalMatch] over its own socket, so each signal is delivered exactly once. The
- *   in-process [LocalJvmSignalBus]/[LocalJvmMatchBus] is NOT used on this backend -- it stays the
- *   dbus-java backend's same-process mechanism. Sender credentials of a signal from one of our own
+ *   [installSignalMatch] over its own socket, so each signal is delivered exactly once. There is no
+ *   in-process signal/match bus to fall back to: that was the dbus-java backend's same-process
+ *   mechanism, and dbus-java is retired. Sender credentials of a signal from one of our own
  *   connections are filled from the local process ([withLocalSenderCredentials]);
  * - what stays DEFERRED is incoming method-call SERVING over the wire (phase 4).
  */
@@ -743,8 +743,8 @@ private fun WireMessage.matches(spec: MatchSpec): Boolean {
 // reader delivers. Because the wire backend now emits signals over the wire too (see
 // [emitWireSignal]), this single path covers BOTH cross-process senders (e.g. a dbusmock peer) and
 // our OWN same-JVM served objects: each connection has its own socket + AddMatch, so the bus routes
-// every matching signal to it exactly once. The in-process [LocalJvmSignalBus]/[LocalJvmMatchBus]
-// is no longer used on this backend (it stays the dbus-java backend's same-process mechanism).
+// every matching signal to it exactly once. There is no in-process signal/match bus to fall back to
+// (that was the dbus-java backend's same-process mechanism, and dbus-java is retired).
 private fun installSignalMatch(
     wire: DBusWireConnection,
     rule: String,


### PR DESCRIPTION
Fixes #254

## The premise, re-measured

Confirmed on `origin/main` @ `20dcae6` before writing anything, since the issue records the
observation as a reviewer's rather than its author's:

```
$ ./gradlew :dokkaGeneratePublicationHtml
w: [:dokkaGeneratePublicationHtml] Couldn't resolve link: [call] in DBusWireConnection.kt/...ServeWorkerPool (:/jvmMain)
... (8 such lines)
BUILD SUCCESSFUL in 25s
GRADLE_EXIT=0
```

Eight unresolved links, exit code 0. Dokka detects the problem and nothing consumes the detection.

## What this does

**Fixes the 8 rather than baselining them.** They are 4 distinct links in 2 stale KDoc comments
(each failing comment is reported once per source-set pass, hence 8 lines for 4 links):

| link | why it was dead | fix |
| --- | --- | --- |
| `[call]`, `[callBlocking]` | referenced from `ServeWorkerPool`'s KDoc, but they are members of `DBusWireConnection` — out of scope there (the same links resolve fine from `DBusWireConnection`'s own KDoc, which is why only this one comment warned) | qualified to `[DBusWireConnection.call]` / `[DBusWireConnection.callBlocking]` |
| `[LocalJvmSignalBus]`, `[LocalJvmMatchBus]` | no such types exist anywhere in the tree; the sentence around them also still described dbus-java as a live same-process backend, which it stopped being in epic #93 phase 6 | sentence rewritten to state what is true: there is no in-process signal/match bus at all. Applied to both the class KDoc and the identical stale sentence in `installSignalMatch`'s comment |

Count goes **8 → 0**. No number is committed anywhere, so there is no baseline for a future agent to
edit upward.

**Asserts zero in the build, not in the workflow.** `failOnWarning.set(true)` on the html
publication. Two reasons for the build over the workflow: a plain local
`./gradlew :dokkaGeneratePublicationHtml` now fails exactly the way CI does, and it needs no log
parsing at all — so it sidesteps the `grep`-under-`pipefail` trap that PR #238's first attempt hit
(a `grep` matching nothing exits 1 and reddens the job with a misleading message).

**Gives the detector a consumer on PRs.** The docs build previously ran only in `pages.yaml`, which
triggers on a completed *Release build* — i.e. a broken link introduced by a PR would first fail
after it had already merged and shipped, if it failed at all. `:dokkaGeneratePublicationHtml` now
runs in the `static-checks` job, which needs no D-Bus session bus and nothing beyond the headers
that job already installs. Measured cost: that job currently runs ~3 min against a 30 min timeout.

## Both directions, demonstrated

Guard installed and links fixed — **green**:

```
########## A: guard installed, links fixed (expect GREEN)
EXIT_A=0
BUILD SUCCESSFUL in 16s
```

Deliberately break one link (`[Resource]` → `[ResourceThatDoesNotExist254]` in
`commonMain/.../Resource.kt`) — **red**, naming the link:

```
########## B: deliberately break [Resource] -> [ResourceThatDoesNotExist254]
 * or similar return a [ResourceThatDoesNotExist254]. Calling [release] will remove any registrations or
EXIT_B=1
w: [:dokkaGeneratePublicationHtml] Couldn't resolve link: [ResourceThatDoesNotExist254] in Resource.kt/com.monkopedia.sdbus.Resource (:/commonMain)
> Task :dokkaGeneratePublicationHtml FAILED

* What went wrong:
Execution failed for task ':dokkaGeneratePublicationHtml' ...
   > Failed with warningCount=1 and errorCount=0

BUILD FAILED in 11s
```

Note on the message: Gradle's own failure line is a count (`warningCount=1`); the line naming the
unresolved link is Dokka's, printed a few lines above it in the same step output. A reader of a red
job sees both.

Restore — **green**:

```
########## C: restore (expect GREEN)
EXIT_C=0
BUILD SUCCESSFUL in 11s
```

## Verification

Tasks run (all on JDK 21 locally; Dokka needs no D-Bus bus):

- `./gradlew :dokkaGeneratePublicationHtml` — baseline on main (8 warnings, exit 0), after the link
  fixes (0 warnings), after the guard (green), broken (red), restored (green)
- `./gradlew ktlintCheck apiCheck --stacktrace` — **BUILD SUCCESSFUL**; `api/*.api` unchanged
  (`git status` lists only the 4 files in this diff)

No production code changes — the two source files are touched in comments only, and `apiCheck`
agrees.

## Why `failOnWarning` rather than a link-specific assertion (stated, not implicit)

`failOnWarning` is **broader than the issue asked for** — it fails on *any* Dokka warning, not only
unresolved links. That is a deliberate trade, so here is the argument and the measurement:

- **Blast radius today is zero.** On a clean run at `20dcae6`, every warning the task emitted was an
  unresolved link — **8 of 8**, no other category present:
  ```
  $ awk 'index($0,"w: [:dokka")' dokka-baseline.log | wc -l   -> 8
  $ awk 'index($0,"w: [:dokka") && /resolve link/' ...| wc -l -> 8
  ```
- **It needs no log parsing.** A link-specific gate means grepping for the literal string
  `Couldn't resolve link`, which (a) is the `grep`-under-`pipefail` shape #254 explicitly warns
  against, and (b) silently stops matching if Dokka ever rewords that message — a detector that
  quietly becomes a no-op, which is the exact failure class this issue belongs to. `failOnWarning`
  reads Dokka's own warning counter and cannot drift that way.
- **Dokka version bumps.** If a future Dokka starts emitting a new warning category, the docs build
  will fail on something unrelated to KDoc correctness. The comment next to the flag names #254 and
  says what to do: fix it, or suppress *that category*, because turning the flag back off restores
  the original defect wholesale.
